### PR TITLE
fix(app-platform): translate flat image string to DO AppSpec nested image object

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -35,7 +35,10 @@ func NewAppPlatformDriverWithClient(c AppPlatformClient, region string) *AppPlat
 }
 
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
-	image, _ := spec.Config["image"].(string)
+	imgSpec, err := imageSpecFromConfig(spec.Config)
+	if err != nil {
+		return nil, fmt.Errorf("app platform image config: %w", err)
+	}
 	region, _ := spec.Config["region"].(string)
 	if region == "" {
 		region = d.region
@@ -53,11 +56,7 @@ func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.Resource
 					InstanceCount: int64(instanceCount),
 					HTTPPort:      int64(httpPort),
 					Envs:          envVarsFromConfig(spec.Config),
-					Image: &godo.ImageSourceSpec{
-						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
-						Repository:   imageRepo(image),
-						Tag:          imageTag(image),
-					},
+					Image:         imgSpec,
 				},
 			},
 		},
@@ -79,7 +78,10 @@ func (d *AppPlatformDriver) Read(ctx context.Context, ref interfaces.ResourceRef
 }
 
 func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
-	image, _ := spec.Config["image"].(string)
+	imgSpec, err := imageSpecFromConfig(spec.Config)
+	if err != nil {
+		return nil, fmt.Errorf("app platform image config: %w", err)
+	}
 	region, _ := spec.Config["region"].(string)
 	if region == "" {
 		region = d.region
@@ -97,11 +99,7 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 					InstanceCount: int64(instanceCount),
 					HTTPPort:      int64(httpPort),
 					Envs:          envVarsFromConfig(spec.Config),
-					Image: &godo.ImageSourceSpec{
-						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
-						Repository:   imageRepo(image),
-						Tag:          imageTag(image),
-					},
+					Image:         imgSpec,
 				},
 			},
 		},
@@ -181,17 +179,116 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 	return out
 }
 
-func imageRepo(image string) string {
-	parts := strings.SplitN(image, ":", 2)
-	return parts[0]
+// ParseImageRef parses a flat image reference string into a DO App Platform
+// ImageSourceSpec. Supports:
+//
+//   - registry.digitalocean.com/<registry>/<repo>:<tag>  → DOCR (Registry left empty per DO API requirement)
+//   - ghcr.io/<org>/<repo>:<tag>                         → GHCR
+//   - docker.io/<org>/<repo>:<tag>                       → DOCKER_HUB
+//   - <org>/<repo>:<tag>                                 → DOCKER_HUB (bare form)
+//
+// A missing tag defaults to "latest".
+func ParseImageRef(imageStr string) (*godo.ImageSourceSpec, error) {
+	if imageStr == "" {
+		return nil, fmt.Errorf("image ref is empty")
+	}
+
+	// Separate tag from the path reference.
+	ref, tag, _ := strings.Cut(imageStr, ":")
+	if tag == "" {
+		tag = "latest"
+	}
+
+	parts := strings.Split(ref, "/")
+
+	switch {
+	case strings.HasPrefix(ref, "registry.digitalocean.com/"):
+		// registry.digitalocean.com/<registry>/<repo>
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid DOCR image ref %q: expected registry.digitalocean.com/<registry>/<repo>", imageStr)
+		}
+		return &godo.ImageSourceSpec{
+			RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+			// Registry must be left empty for DOCR per DO API.
+			Repository: parts[len(parts)-1],
+			Tag:        tag,
+		}, nil
+
+	case strings.HasPrefix(ref, "ghcr.io/"):
+		// ghcr.io/<org>/<repo>
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid GHCR image ref %q: expected ghcr.io/<org>/<repo>", imageStr)
+		}
+		return &godo.ImageSourceSpec{
+			RegistryType: godo.ImageSourceSpecRegistryType_Ghcr,
+			Registry:     parts[1],
+			Repository:   parts[len(parts)-1],
+			Tag:          tag,
+		}, nil
+
+	case strings.HasPrefix(ref, "docker.io/"):
+		// docker.io/<org>/<repo>
+		if len(parts) < 3 {
+			return nil, fmt.Errorf("invalid Docker Hub image ref %q: expected docker.io/<org>/<repo>", imageStr)
+		}
+		return &godo.ImageSourceSpec{
+			RegistryType: godo.ImageSourceSpecRegistryType_DockerHub,
+			Registry:     parts[1],
+			Repository:   parts[len(parts)-1],
+			Tag:          tag,
+		}, nil
+
+	default:
+		// Bare <org>/<repo> format treated as Docker Hub.
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("unsupported image ref %q: expected <org>/<repo>[:tag] or a registry-prefixed form (registry.digitalocean.com, ghcr.io, docker.io)", imageStr)
+		}
+		return &godo.ImageSourceSpec{
+			RegistryType: godo.ImageSourceSpecRegistryType_DockerHub,
+			Registry:     parts[0],
+			Repository:   parts[len(parts)-1],
+			Tag:          tag,
+		}, nil
+	}
 }
 
-func imageTag(image string) string {
-	parts := strings.SplitN(image, ":", 2)
-	if len(parts) == 2 {
-		return parts[1]
+// imageSpecFromConfig extracts an ImageSourceSpec from spec.Config["image"].
+// Accepts either a flat string (parsed by ParseImageRef) or an already-nested
+// map[string]any with keys registry_type, repository, tag, registry.
+func imageSpecFromConfig(cfg map[string]any) (*godo.ImageSourceSpec, error) {
+	switch v := cfg["image"].(type) {
+	case string:
+		if v == "" {
+			return nil, fmt.Errorf("image config is empty")
+		}
+		return ParseImageRef(v)
+	case map[string]any:
+		return imageSpecFromMap(v)
+	default:
+		return nil, fmt.Errorf("image config must be a string or map[string]any, got %T", cfg["image"])
 	}
-	return "latest"
+}
+
+func imageSpecFromMap(m map[string]any) (*godo.ImageSourceSpec, error) {
+	repo, _ := m["repository"].(string)
+	if repo == "" {
+		return nil, fmt.Errorf("image map config missing required field 'repository'")
+	}
+	regType, _ := m["registry_type"].(string)
+	if regType == "" {
+		regType = string(godo.ImageSourceSpecRegistryType_DOCR)
+	}
+	tag, _ := m["tag"].(string)
+	if tag == "" {
+		tag = "latest"
+	}
+	registry, _ := m["registry"].(string)
+	return &godo.ImageSourceSpec{
+		RegistryType: godo.ImageSourceSpecRegistryType(regType),
+		Registry:     registry,
+		Repository:   repo,
+		Tag:          tag,
+	}, nil
 }
 
 // envVarsFromConfig converts the "env_vars" map in spec config to App Platform

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -327,3 +327,211 @@ func TestAppPlatformDriver_HealthCheck_Unhealthy(t *testing.T) {
 		t.Errorf("expected unhealthy when no active deployment")
 	}
 }
+
+// ── ParseImageRef unit tests ──────────────────────────────────────────────────
+
+func TestParseImageRef_DOCR(t *testing.T) {
+	spec, err := drivers.ParseImageRef("registry.digitalocean.com/foo/bar:v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
+		t.Errorf("RegistryType = %q, want DOCR", spec.RegistryType)
+	}
+	if spec.Registry != "" {
+		t.Errorf("Registry = %q, want empty (must be empty for DOCR)", spec.Registry)
+	}
+	if spec.Repository != "bar" {
+		t.Errorf("Repository = %q, want %q", spec.Repository, "bar")
+	}
+	if spec.Tag != "v1" {
+		t.Errorf("Tag = %q, want %q", spec.Tag, "v1")
+	}
+}
+
+func TestParseImageRef_GHCR(t *testing.T) {
+	spec, err := drivers.ParseImageRef("ghcr.io/org/app:sha256abc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.RegistryType != godo.ImageSourceSpecRegistryType_Ghcr {
+		t.Errorf("RegistryType = %q, want GHCR", spec.RegistryType)
+	}
+	if spec.Registry != "org" {
+		t.Errorf("Registry = %q, want %q", spec.Registry, "org")
+	}
+	if spec.Repository != "app" {
+		t.Errorf("Repository = %q, want %q", spec.Repository, "app")
+	}
+	if spec.Tag != "sha256abc" {
+		t.Errorf("Tag = %q, want %q", spec.Tag, "sha256abc")
+	}
+}
+
+func TestParseImageRef_DockerHub_Explicit(t *testing.T) {
+	spec, err := drivers.ParseImageRef("docker.io/org/app:tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.RegistryType != godo.ImageSourceSpecRegistryType_DockerHub {
+		t.Errorf("RegistryType = %q, want DOCKER_HUB", spec.RegistryType)
+	}
+	if spec.Registry != "org" {
+		t.Errorf("Registry = %q, want %q", spec.Registry, "org")
+	}
+	if spec.Repository != "app" {
+		t.Errorf("Repository = %q, want %q", spec.Repository, "app")
+	}
+	if spec.Tag != "tag" {
+		t.Errorf("Tag = %q, want %q", spec.Tag, "tag")
+	}
+}
+
+func TestParseImageRef_DockerHub_Bare(t *testing.T) {
+	spec, err := drivers.ParseImageRef("org/app:tag")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.RegistryType != godo.ImageSourceSpecRegistryType_DockerHub {
+		t.Errorf("RegistryType = %q, want DOCKER_HUB", spec.RegistryType)
+	}
+	if spec.Registry != "org" {
+		t.Errorf("Registry = %q, want %q", spec.Registry, "org")
+	}
+	if spec.Repository != "app" {
+		t.Errorf("Repository = %q, want %q", spec.Repository, "app")
+	}
+}
+
+func TestParseImageRef_NoTag(t *testing.T) {
+	// Missing tag defaults to "latest".
+	spec, err := drivers.ParseImageRef("registry.digitalocean.com/myregistry/myapp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spec.Tag != "latest" {
+		t.Errorf("Tag = %q, want %q (default)", spec.Tag, "latest")
+	}
+}
+
+func TestParseImageRef_Malformed(t *testing.T) {
+	cases := []string{
+		"",                                     // empty
+		"justarepo",                            // no org/registry prefix
+		"registry.digitalocean.com/onlyone",    // DOCR with only one path segment
+		"ghcr.io/onlyone",                      // GHCR with only org, no repo
+		"docker.io/onlyone",                    // docker.io with only one path segment
+	}
+	for _, tc := range cases {
+		_, err := drivers.ParseImageRef(tc)
+		if err == nil {
+			t.Errorf("ParseImageRef(%q): expected error, got nil", tc)
+		}
+	}
+}
+
+// ── Create with nested image spec ────────────────────────────────────────────
+
+func TestAppPlatformDriver_Create_BuildsNestedImageSpec(t *testing.T) {
+	mock := &mockAppClient{app: testApp()}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/bmw-registry/buymywishlist:abc123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if mock.lastCreateReq == nil {
+		t.Fatal("no create request captured")
+	}
+	svc := mock.lastCreateReq.Spec.Services[0]
+	img := svc.Image
+	if img == nil {
+		t.Fatal("service Image is nil")
+	}
+	if img.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
+		t.Errorf("RegistryType = %q, want DOCR", img.RegistryType)
+	}
+	if img.Registry != "" {
+		t.Errorf("Registry = %q, want empty (must be empty for DOCR)", img.Registry)
+	}
+	if img.Repository != "buymywishlist" {
+		t.Errorf("Repository = %q, want %q", img.Repository, "buymywishlist")
+	}
+	if img.Tag != "abc123" {
+		t.Errorf("Tag = %q, want %q", img.Tag, "abc123")
+	}
+}
+
+func TestAppPlatformDriver_Update_BuildsNestedImageSpec(t *testing.T) {
+	mock := &mockAppClient{app: testApp()}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "bmw-app", ProviderID: "app-123",
+	}, interfaces.ResourceSpec{
+		Name: "bmw-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/bmw-registry/buymywishlist:def456",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if mock.lastUpdateReq == nil {
+		t.Fatal("no update request captured")
+	}
+	svc := mock.lastUpdateReq.Spec.Services[0]
+	img := svc.Image
+	if img == nil {
+		t.Fatal("service Image is nil")
+	}
+	if img.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
+		t.Errorf("RegistryType = %q, want DOCR", img.RegistryType)
+	}
+	if img.Repository != "buymywishlist" {
+		t.Errorf("Repository = %q, want %q", img.Repository, "buymywishlist")
+	}
+	if img.Tag != "def456" {
+		t.Errorf("Tag = %q, want %q", img.Tag, "def456")
+	}
+}
+
+func TestAppPlatformDriver_Create_NestedMapImageSpec(t *testing.T) {
+	mock := &mockAppClient{app: testApp()}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-app",
+		Config: map[string]any{
+			"image": map[string]any{
+				"registry_type": "DOCR",
+				"repository":    "buymywishlist",
+				"tag":           "v2",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create with nested map: %v", err)
+	}
+	svc := mock.lastCreateReq.Spec.Services[0]
+	img := svc.Image
+	if img == nil {
+		t.Fatal("service Image is nil")
+	}
+	if img.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
+		t.Errorf("RegistryType = %q, want DOCR", img.RegistryType)
+	}
+	if img.Repository != "buymywishlist" {
+		t.Errorf("Repository = %q, want %q", img.Repository, "buymywishlist")
+	}
+	if img.Tag != "v2" {
+		t.Errorf("Tag = %q, want %q", img.Tag, "v2")
+	}
+}

--- a/internal/drivers/util.go
+++ b/internal/drivers/util.go
@@ -1,5 +1,7 @@
 package drivers
 
+import "strings"
+
 // intFromConfig extracts an integer value from a config map, returning a default if absent.
 func intFromConfig(config map[string]any, key string, defaultVal int) (int, bool) {
 	v, ok := config[key]
@@ -23,4 +25,32 @@ func strFromConfig(config map[string]any, key, defaultVal string) string {
 		return v
 	}
 	return defaultVal
+}
+
+// imageRepo returns the repository portion of a flat "<repo>:<tag>" image reference.
+func imageRepo(image string) string {
+	parts := splitImageRef(image)
+	return parts[0]
+}
+
+// imageTag returns the tag portion of a flat "<repo>:<tag>" image reference, defaulting to "latest".
+func imageTag(image string) string {
+	parts := splitImageRef(image)
+	if len(parts) == 2 {
+		return parts[1]
+	}
+	return "latest"
+}
+
+// splitImageRef splits an image reference on the last colon that follows a slash
+// (i.e. the tag delimiter), returning [ref] or [ref, tag].
+func splitImageRef(image string) []string {
+	// Find the last slash to anchor the colon search to the tag portion only.
+	lastSlash := strings.LastIndex(image, "/")
+	tagIdx := strings.Index(image[lastSlash+1:], ":")
+	if tagIdx < 0 {
+		return []string{image}
+	}
+	split := lastSlash + 1 + tagIdx
+	return []string{image[:split], image[split+1:]}
 }


### PR DESCRIPTION
## Problem

BMW's deploy-staging failed with:
```
error validating app spec field "services.image.repository": services.image.repository is required
```

BMW's `infra.yaml` passes `image: "registry.digitalocean.com/bmw-registry/buymywishlist:\${IMAGE_SHA}"` as a flat string. DO App Platform's API requires a nested `ImageSourceSpec` object with `registry_type`, `repository`, and `tag` fields — the old driver was passing the full path as `repository`, which is invalid.

## Changes

- **`ParseImageRef(imageStr)`** — exported helper that parses flat image refs into `godo.ImageSourceSpec`:
  - `registry.digitalocean.com/<registry>/<repo>:<tag>` → `DOCR` (Registry left empty per DO API requirement)
  - `ghcr.io/<org>/<repo>:<tag>` → `GHCR`
  - `docker.io/<org>/<repo>:<tag>` → `DOCKER_HUB`
  - `<org>/<repo>:<tag>` (bare) → `DOCKER_HUB`
  - Missing tag defaults to `"latest"`; malformed refs return clear errors
- **`imageSpecFromConfig`** — accepts either a flat string (parsed via above) or an already-nested `map[string]any` (passthrough for advanced configs)
- **`Create` / `Update`** now use `imageSpecFromConfig` instead of the old hard-coded DOCR-only construction
- Moved shared `imageRepo`/`imageTag` helpers to `util.go` (still used by deploy driver)

## Tests

9 new tests covering:
- `TestParseImageRef_DOCR` / `_GHCR` / `_DockerHub_Explicit` / `_DockerHub_Bare` / `_NoTag` / `_Malformed`
- `TestAppPlatformDriver_Create_BuildsNestedImageSpec` — asserts `RegistryType=DOCR`, `Registry=""`, `Repository="buymywishlist"`, `Tag="abc123"`
- `TestAppPlatformDriver_Update_BuildsNestedImageSpec`
- `TestAppPlatformDriver_Create_NestedMapImageSpec`

`GOWORK=off go test ./... -race` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)