### PR TITLE
fix(provider): upsert on ErrResourceAlreadyExists in Apply

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -184,13 +184,16 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 				// Resource exists in the provider but is not tracked in local
 				// state (e.g. manually created, or state was wiped). Upsert:
 				// discover the provider ID by reading by name, then update.
+				createErr := err
 				ref := interfaces.ResourceRef{
 					Name: action.Resource.Name,
 					Type: action.Resource.Type,
 				}
 				existing, readErr := d.Read(ctx, ref)
 				if readErr != nil {
-					err = fmt.Errorf("upsert: read after AlreadyExists: %w", readErr)
+					// Preserve createErr so ErrResourceAlreadyExists remains
+					// in the error chain for callers using errors.Is.
+					err = fmt.Errorf("upsert: read after conflict: %w", errors.Join(createErr, readErr))
 					break
 				}
 				ref.ProviderID = existing.ProviderID

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -179,6 +180,22 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 		switch action.Action {
 		case "create":
 			out, err = d.Create(ctx, action.Resource)
+			if errors.Is(err, interfaces.ErrResourceAlreadyExists) {
+				// Resource exists in the provider but is not tracked in local
+				// state (e.g. manually created, or state was wiped). Upsert:
+				// discover the provider ID by reading by name, then update.
+				ref := interfaces.ResourceRef{
+					Name: action.Resource.Name,
+					Type: action.Resource.Type,
+				}
+				existing, readErr := d.Read(ctx, ref)
+				if readErr != nil {
+					err = fmt.Errorf("upsert: read after AlreadyExists: %w", readErr)
+					break
+				}
+				ref.ProviderID = existing.ProviderID
+				out, err = d.Update(ctx, ref, action.Resource)
+			}
 		case "update":
 			ref := interfaces.ResourceRef{
 				Name:       action.Resource.Name,

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -143,5 +145,107 @@ func TestConfigHash_Empty(t *testing.T) {
 	h := configHash(nil)
 	if h != "" {
 		t.Errorf("expected empty hash for nil config, got %q", h)
+	}
+}
+
+// ── fake driver for Apply upsert test ─────────────────────────────────────────
+
+// upsertFakeDriver is a minimal ResourceDriver that:
+//   - returns ErrResourceAlreadyExists on the first Create call
+//   - returns a fixed ResourceOutput on Read (simulating discovery by name)
+//   - records Update calls so the test can assert the upsert path was taken
+type upsertFakeDriver struct {
+	createCalls int
+	updateCalls int
+	readCalls   int
+	updatedRef  interfaces.ResourceRef
+}
+
+func (f *upsertFakeDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.createCalls++
+	return nil, fmt.Errorf("create conflict: %w", interfaces.ErrResourceAlreadyExists)
+}
+
+func (f *upsertFakeDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	f.readCalls++
+	return &interfaces.ResourceOutput{
+		Name:       ref.Name,
+		Type:       ref.Type,
+		ProviderID: "discovered-provider-id",
+	}, nil
+}
+
+func (f *upsertFakeDriver) Update(_ context.Context, ref interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.updateCalls++
+	f.updatedRef = ref
+	return &interfaces.ResourceOutput{
+		Name:       ref.Name,
+		Type:       ref.Type,
+		ProviderID: ref.ProviderID,
+	}, nil
+}
+
+func (f *upsertFakeDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
+func (f *upsertFakeDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return nil, nil
+}
+func (f *upsertFakeDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+func (f *upsertFakeDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *upsertFakeDriver) SensitiveKeys() []string { return nil }
+
+// TestDOProvider_Apply_UpsertOnAlreadyExists verifies that when a create action
+// hits ErrResourceAlreadyExists, Apply:
+//  1. Calls Read (by name, empty ProviderID) to discover the existing ProviderID.
+//  2. Calls Update with the discovered ProviderID.
+//  3. Returns the resource in ApplyResult.Resources (no errors).
+func TestDOProvider_Apply_UpsertOnAlreadyExists(t *testing.T) {
+	fake := &upsertFakeDriver{}
+	p := &DOProvider{
+		drivers: map[string]interfaces.ResourceDriver{
+			"infra.container_service": fake,
+		},
+	}
+
+	spec := interfaces.ResourceSpec{
+		Name:   "bmw-app",
+		Type:   "infra.container_service",
+		Config: map[string]any{"image": "registry/bmw:latest"},
+	}
+	plan := &interfaces.IaCPlan{
+		ID:      "plan-test",
+		Actions: []interfaces.PlanAction{{Action: "create", Resource: spec}},
+	}
+
+	result, err := p.Apply(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply returned errors: %v", result.Errors)
+	}
+
+	// Create was attempted once.
+	if fake.createCalls != 1 {
+		t.Errorf("createCalls = %d, want 1", fake.createCalls)
+	}
+	// Read was called to discover the ProviderID.
+	if fake.readCalls != 1 {
+		t.Errorf("readCalls = %d, want 1", fake.readCalls)
+	}
+	// Update was called with the discovered ProviderID.
+	if fake.updateCalls != 1 {
+		t.Errorf("updateCalls = %d, want 1", fake.updateCalls)
+	}
+	if fake.updatedRef.ProviderID != "discovered-provider-id" {
+		t.Errorf("updatedRef.ProviderID = %q, want %q", fake.updatedRef.ProviderID, "discovered-provider-id")
+	}
+
+	// Resource appears in result.
+	if len(result.Resources) != 1 || result.Resources[0].Name != "bmw-app" {
+		t.Errorf("result.Resources = %v, want [{bmw-app ...}]", result.Resources)
 	}
 }

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -151,13 +151,15 @@ func TestConfigHash_Empty(t *testing.T) {
 // ── fake driver for Apply upsert test ─────────────────────────────────────────
 
 // upsertFakeDriver is a minimal ResourceDriver that:
-//   - returns ErrResourceAlreadyExists on the first Create call
+//   - always returns ErrResourceAlreadyExists on Create
 //   - returns a fixed ResourceOutput on Read (simulating discovery by name)
-//   - records Update calls so the test can assert the upsert path was taken
+//   - records the ref passed to Read and Update so the test can assert the
+//     upsert path was taken with the correct arguments
 type upsertFakeDriver struct {
 	createCalls int
 	updateCalls int
 	readCalls   int
+	lastReadRef interfaces.ResourceRef
 	updatedRef  interfaces.ResourceRef
 }
 
@@ -168,6 +170,7 @@ func (f *upsertFakeDriver) Create(_ context.Context, _ interfaces.ResourceSpec) 
 
 func (f *upsertFakeDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
 	f.readCalls++
+	f.lastReadRef = ref
 	return &interfaces.ResourceOutput{
 		Name:       ref.Name,
 		Type:       ref.Type,
@@ -220,7 +223,7 @@ func TestDOProvider_Apply_UpsertOnAlreadyExists(t *testing.T) {
 		Actions: []interfaces.PlanAction{{Action: "create", Resource: spec}},
 	}
 
-	result, err := p.Apply(context.Background(), plan)
+	result, err := p.Apply(t.Context(), plan)
 	if err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -232,9 +235,15 @@ func TestDOProvider_Apply_UpsertOnAlreadyExists(t *testing.T) {
 	if fake.createCalls != 1 {
 		t.Errorf("createCalls = %d, want 1", fake.createCalls)
 	}
-	// Read was called to discover the ProviderID.
+	// Read was called with empty ProviderID (triggers name-based lookup in drivers).
 	if fake.readCalls != 1 {
 		t.Errorf("readCalls = %d, want 1", fake.readCalls)
+	}
+	if fake.lastReadRef.ProviderID != "" {
+		t.Errorf("Read called with non-empty ProviderID %q; want empty for name-based lookup", fake.lastReadRef.ProviderID)
+	}
+	if fake.lastReadRef.Name != spec.Name || fake.lastReadRef.Type != spec.Type {
+		t.Errorf("Read ref = {%q, %q}, want {%q, %q}", fake.lastReadRef.Name, fake.lastReadRef.Type, spec.Name, spec.Type)
 	}
 	// Update was called with the discovered ProviderID.
 	if fake.updateCalls != 1 {


### PR DESCRIPTION
## Summary

- `DOProvider.Apply()` now upserts when a `create` action returns `ErrResourceAlreadyExists` (HTTP 409): calls `d.Read` with empty `ProviderID` to discover the existing resource by name, then calls `d.Update` with the populated ref
- Handles the common case where a resource exists in DigitalOcean but is absent from local state (manually created, state wiped, first apply after `wfctl infra import`)
- `break` on Read failure wraps the read error and falls through to the normal error-accumulation path — no silent swallowing

## Test plan

- [ ] `TestDOProvider_Apply_UpsertOnAlreadyExists`: `upsertFakeDriver` returns `ErrResourceAlreadyExists` on Create → verifies Read called with empty ProviderID → Update called with discovered ProviderID → result has resource, no errors
- [ ] `GOWORK=off go test -race -short -count=1 ./internal/...` passes clean
- [ ] `go build ./...`, `go vet ./...`, `gofmt` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)