### PR TITLE
feat(drivers): name-based Read + SupportsUpsert for VPC, Firewall, Database (v0.7.3)

### DIFF
--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -12,6 +12,7 @@ import (
 type DatabaseClient interface {
 	Create(ctx context.Context, req *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error)
 	Get(ctx context.Context, databaseID string) (*godo.Database, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]godo.Database, *godo.Response, error)
 	Resize(ctx context.Context, databaseID string, req *godo.DatabaseResizeRequest) (*godo.Response, error)
 	Delete(ctx context.Context, databaseID string) (*godo.Response, error)
 	UpdateFirewallRules(ctx context.Context, databaseID string, req *godo.DatabaseUpdateFirewallRulesRequest) (*godo.Response, error)
@@ -58,12 +59,41 @@ func (d *DatabaseDriver) Create(ctx context.Context, spec interfaces.ResourceSpe
 	return dbOutput(db), nil
 }
 
+// SupportsUpsert reports that DatabaseDriver can locate a resource by name alone
+// (empty ProviderID), enabling the ErrResourceAlreadyExists → upsert path.
+func (d *DatabaseDriver) SupportsUpsert() bool { return true }
+
 func (d *DatabaseDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	if ref.ProviderID == "" {
+		return d.findDatabaseByName(ctx, ref.Name)
+	}
 	db, _, err := d.client.Get(ctx, ref.ProviderID)
 	if err != nil {
 		return nil, fmt.Errorf("database read %q: %w", ref.Name, WrapGodoError(err))
 	}
 	return dbOutput(db), nil
+}
+
+// findDatabaseByName iterates the paginated database list and returns the first
+// database whose Name matches. Returns ErrResourceNotFound if no match is found.
+func (d *DatabaseDriver) findDatabaseByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		dbs, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("database list: %w", WrapGodoError(err))
+		}
+		for i := range dbs {
+			if dbs[i].Name == name {
+				return dbOutput(&dbs[i]), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("database %q: %w", name, ErrResourceNotFound)
 }
 
 func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -25,6 +25,15 @@ func (m *mockDatabaseClient) Create(_ context.Context, req *godo.DatabaseCreateR
 func (m *mockDatabaseClient) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
 	return m.db, nil, m.err
 }
+func (m *mockDatabaseClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	if m.db == nil {
+		return nil, nil, nil
+	}
+	return []godo.Database{*m.db}, nil, nil
+}
 func (m *mockDatabaseClient) Resize(_ context.Context, _ string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
 	return nil, m.err
 }
@@ -342,5 +351,41 @@ func TestDatabaseDriver_HealthCheck_Unhealthy(t *testing.T) {
 	}
 	if result.Healthy {
 		t.Errorf("expected unhealthy for migrating db")
+	}
+}
+
+func TestDatabaseDriver_SupportsUpsert(t *testing.T) {
+	d := drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3")
+	if !d.SupportsUpsert() {
+		t.Error("DatabaseDriver.SupportsUpsert() should return true")
+	}
+}
+
+func TestDatabaseDriver_Read_NameBased(t *testing.T) {
+	mock := &mockDatabaseClient{db: testDatabase()}
+	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
+
+	// Read with empty ProviderID triggers name-based lookup.
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "my-db",
+	})
+	if err != nil {
+		t.Fatalf("Read by name: %v", err)
+	}
+	if out.ProviderID != "db-123" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "db-123")
+	}
+	if out.Name != "my-db" {
+		t.Errorf("Name = %q, want %q", out.Name, "my-db")
+	}
+}
+
+func TestDatabaseDriver_Read_NameBased_NotFound(t *testing.T) {
+	mock := &mockDatabaseClient{db: nil}
+	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
+
+	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-db"})
+	if err == nil {
+		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
 	}
 }

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -2,6 +2,7 @@ package drivers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -385,7 +386,7 @@ func TestDatabaseDriver_Read_NameBased_NotFound(t *testing.T) {
 	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
 
 	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-db"})
-	if err == nil {
-		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
+	if !errors.Is(err, drivers.ErrResourceNotFound) {
+		t.Fatalf("expected ErrResourceNotFound, got: %v", err)
 	}
 }

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -12,6 +12,7 @@ import (
 type FirewallClient interface {
 	Create(ctx context.Context, req *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
 	Get(ctx context.Context, fwID string) (*godo.Firewall, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]godo.Firewall, *godo.Response, error)
 	Update(ctx context.Context, fwID string, req *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error)
 	Delete(ctx context.Context, fwID string) (*godo.Response, error)
 }
@@ -40,12 +41,44 @@ func (d *FirewallDriver) Create(ctx context.Context, spec interfaces.ResourceSpe
 	return fwOutput(fw), nil
 }
 
+// SupportsUpsert reports that FirewallDriver can locate a resource by name alone
+// (empty ProviderID), enabling the ErrResourceAlreadyExists → upsert path.
+func (d *FirewallDriver) SupportsUpsert() bool { return true }
+
 func (d *FirewallDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	if ref.ProviderID == "" {
+		return d.findFirewallByName(ctx, ref.Name)
+	}
 	fw, _, err := d.client.Get(ctx, ref.ProviderID)
 	if err != nil {
 		return nil, fmt.Errorf("firewall read %q: %w", ref.Name, WrapGodoError(err))
 	}
+	if fw == nil {
+		return nil, fmt.Errorf("firewall read %q: provider returned nil resource", ref.Name)
+	}
 	return fwOutput(fw), nil
+}
+
+// findFirewallByName iterates the paginated firewall list and returns the first
+// firewall whose Name matches. Returns ErrResourceNotFound if no match is found.
+func (d *FirewallDriver) findFirewallByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		fws, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("firewall list: %w", WrapGodoError(err))
+		}
+		for i := range fws {
+			if fws[i].Name == name {
+				return fwOutput(&fws[i]), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("firewall %q: %w", name, ErrResourceNotFound)
 }
 
 func (d *FirewallDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -110,6 +110,9 @@ func (d *FirewallDriver) HealthCheck(ctx context.Context, ref interfaces.Resourc
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
+	if fw == nil {
+		return &interfaces.HealthResult{Healthy: false, Message: "provider returned nil firewall"}, nil
+	}
 	healthy := fw.Status == "succeeded"
 	return &interfaces.HealthResult{Healthy: healthy, Message: fw.Status}, nil
 }
@@ -120,8 +123,9 @@ func (d *FirewallDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ in
 
 // firewallRequest builds a godo FirewallRequest from a ResourceSpec.
 // Config keys:
-//   inbound_rules  []map[string]any  — each: {protocol, ports, sources}
-//   outbound_rules []map[string]any  — each: {protocol, ports, destinations}
+//
+//	inbound_rules  []map[string]any  — each: {protocol, ports, sources}
+//	outbound_rules []map[string]any  — each: {protocol, ports, destinations}
 func firewallRequest(spec interfaces.ResourceSpec) *godo.FirewallRequest {
 	req := &godo.FirewallRequest{Name: spec.Name}
 

--- a/internal/drivers/firewall_test.go
+++ b/internal/drivers/firewall_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 type mockFirewallClient struct {
-	fw  *godo.Firewall
-	err error
+	fw      *godo.Firewall
+	err     error
+	listErr error
 }
 
 func (m *mockFirewallClient) Create(_ context.Context, _ *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
@@ -20,6 +21,15 @@ func (m *mockFirewallClient) Create(_ context.Context, _ *godo.FirewallRequest) 
 }
 func (m *mockFirewallClient) Get(_ context.Context, _ string) (*godo.Firewall, *godo.Response, error) {
 	return m.fw, nil, m.err
+}
+func (m *mockFirewallClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+	if m.listErr != nil {
+		return nil, nil, m.listErr
+	}
+	if m.fw == nil {
+		return nil, nil, nil
+	}
+	return []godo.Firewall{*m.fw}, nil, nil
 }
 func (m *mockFirewallClient) Update(_ context.Context, _ string, _ *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
 	return m.fw, nil, m.err
@@ -201,5 +211,57 @@ func TestFirewallDriver_HealthCheck_Unhealthy(t *testing.T) {
 	}
 	if result.Healthy {
 		t.Errorf("expected unhealthy for firewall with status 'waiting'")
+	}
+}
+
+func TestFirewallDriver_SupportsUpsert(t *testing.T) {
+	d := drivers.NewFirewallDriverWithClient(&mockFirewallClient{})
+	if !d.SupportsUpsert() {
+		t.Error("FirewallDriver.SupportsUpsert() should return true")
+	}
+}
+
+func TestFirewallDriver_Read_NameBased(t *testing.T) {
+	mock := &mockFirewallClient{fw: testFirewall()}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	// Read with empty ProviderID triggers name-based lookup.
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "my-fw",
+	})
+	if err != nil {
+		t.Fatalf("Read by name: %v", err)
+	}
+	if out.ProviderID != "fw-123" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "fw-123")
+	}
+	if out.Name != "my-fw" {
+		t.Errorf("Name = %q, want %q", out.Name, "my-fw")
+	}
+}
+
+func TestFirewallDriver_Read_NameBased_NotFound(t *testing.T) {
+	mock := &mockFirewallClient{fw: nil}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-fw"})
+	if err == nil {
+		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
+	}
+}
+
+// TestFirewallDriver_Read_NilClientReturn_NoPanic is a regression test for the
+// nil-pointer dereference in fwOutput that would occur if the godo client
+// returns (nil, nil, nil) for a Get call. The nil guard added to Read ensures
+// a descriptive error is returned instead of a panic.
+func TestFirewallDriver_Read_NilClientReturn_NoPanic(t *testing.T) {
+	mock := &mockFirewallClient{fw: nil, err: nil} // client returns nil, nil, nil
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	_, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "my-fw", ProviderID: "fw-123",
+	})
+	if err == nil {
+		t.Fatal("expected error for nil firewall returned by client, got nil")
 	}
 }

--- a/internal/drivers/firewall_test.go
+++ b/internal/drivers/firewall_test.go
@@ -2,6 +2,7 @@ package drivers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -245,8 +246,8 @@ func TestFirewallDriver_Read_NameBased_NotFound(t *testing.T) {
 	d := drivers.NewFirewallDriverWithClient(mock)
 
 	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-fw"})
-	if err == nil {
-		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
+	if !errors.Is(err, drivers.ErrResourceNotFound) {
+		t.Fatalf("expected ErrResourceNotFound, got: %v", err)
 	}
 }
 
@@ -263,5 +264,26 @@ func TestFirewallDriver_Read_NilClientReturn_NoPanic(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for nil firewall returned by client, got nil")
+	}
+}
+
+// TestFirewallDriver_HealthCheck_NilClientReturn verifies that HealthCheck does
+// not panic when the godo client returns (nil, nil, nil). The nil guard ensures
+// a non-healthy result with a descriptive message is returned instead.
+func TestFirewallDriver_HealthCheck_NilClientReturn(t *testing.T) {
+	mock := &mockFirewallClient{fw: nil, err: nil}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name: "my-fw", ProviderID: "fw-123",
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck: unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false for nil firewall")
+	}
+	if result.Message == "" {
+		t.Error("expected non-empty Message for nil firewall")
 	}
 }

--- a/internal/drivers/vpc.go
+++ b/internal/drivers/vpc.go
@@ -12,6 +12,7 @@ import (
 type VPCClient interface {
 	Create(ctx context.Context, req *godo.VPCCreateRequest) (*godo.VPC, *godo.Response, error)
 	Get(ctx context.Context, vpcID string) (*godo.VPC, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]*godo.VPC, *godo.Response, error)
 	Update(ctx context.Context, vpcID string, req *godo.VPCUpdateRequest) (*godo.VPC, *godo.Response, error)
 	Delete(ctx context.Context, vpcID string) (*godo.Response, error)
 }
@@ -49,12 +50,41 @@ func (d *VPCDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 	return vpcOutput(vpc), nil
 }
 
+// SupportsUpsert reports that VPCDriver can locate a resource by name alone
+// (empty ProviderID), enabling the ErrResourceAlreadyExists → upsert path.
+func (d *VPCDriver) SupportsUpsert() bool { return true }
+
 func (d *VPCDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	if ref.ProviderID == "" {
+		return d.findVPCByName(ctx, ref.Name)
+	}
 	vpc, _, err := d.client.Get(ctx, ref.ProviderID)
 	if err != nil {
 		return nil, fmt.Errorf("vpc read %q: %w", ref.Name, WrapGodoError(err))
 	}
 	return vpcOutput(vpc), nil
+}
+
+// findVPCByName iterates the paginated VPC list and returns the first VPC whose
+// Name matches. Returns ErrResourceNotFound if no match is found.
+func (d *VPCDriver) findVPCByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		vpcs, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("vpc list: %w", WrapGodoError(err))
+		}
+		for _, vpc := range vpcs {
+			if vpc.Name == name {
+				return vpcOutput(vpc), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("vpc %q: %w", name, ErrResourceNotFound)
 }
 
 func (d *VPCDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/vpc_test.go
+++ b/internal/drivers/vpc_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 type mockVPCClient struct {
-	vpc *godo.VPC
-	err error
+	vpc     *godo.VPC
+	err     error
+	listErr error
 }
 
 func (m *mockVPCClient) Create(_ context.Context, _ *godo.VPCCreateRequest) (*godo.VPC, *godo.Response, error) {
@@ -20,6 +21,15 @@ func (m *mockVPCClient) Create(_ context.Context, _ *godo.VPCCreateRequest) (*go
 }
 func (m *mockVPCClient) Get(_ context.Context, _ string) (*godo.VPC, *godo.Response, error) {
 	return m.vpc, nil, m.err
+}
+func (m *mockVPCClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.VPC, *godo.Response, error) {
+	if m.listErr != nil {
+		return nil, nil, m.listErr
+	}
+	if m.vpc == nil {
+		return nil, nil, nil
+	}
+	return []*godo.VPC{m.vpc}, nil, nil
 }
 func (m *mockVPCClient) Update(_ context.Context, _ string, _ *godo.VPCUpdateRequest) (*godo.VPC, *godo.Response, error) {
 	return m.vpc, nil, m.err
@@ -198,5 +208,41 @@ func TestVPCDriver_Diff_IPRangeChange(t *testing.T) {
 	}
 	if !result.NeedsReplace {
 		t.Error("expected NeedsReplace for ip_range change")
+	}
+}
+
+func TestVPCDriver_SupportsUpsert(t *testing.T) {
+	d := drivers.NewVPCDriverWithClient(&mockVPCClient{}, "nyc3")
+	if !d.SupportsUpsert() {
+		t.Error("VPCDriver.SupportsUpsert() should return true")
+	}
+}
+
+func TestVPCDriver_Read_NameBased(t *testing.T) {
+	mock := &mockVPCClient{vpc: testVPC()}
+	d := drivers.NewVPCDriverWithClient(mock, "nyc3")
+
+	// Read with empty ProviderID triggers name-based lookup.
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "my-vpc",
+	})
+	if err != nil {
+		t.Fatalf("Read by name: %v", err)
+	}
+	if out.ProviderID != "vpc-123" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "vpc-123")
+	}
+	if out.Name != "my-vpc" {
+		t.Errorf("Name = %q, want %q", out.Name, "my-vpc")
+	}
+}
+
+func TestVPCDriver_Read_NameBased_NotFound(t *testing.T) {
+	mock := &mockVPCClient{vpc: nil}
+	d := drivers.NewVPCDriverWithClient(mock, "nyc3")
+
+	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-vpc"})
+	if err == nil {
+		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
 	}
 }

--- a/internal/drivers/vpc_test.go
+++ b/internal/drivers/vpc_test.go
@@ -2,6 +2,7 @@ package drivers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -242,7 +243,7 @@ func TestVPCDriver_Read_NameBased_NotFound(t *testing.T) {
 	d := drivers.NewVPCDriverWithClient(mock, "nyc3")
 
 	_, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "missing-vpc"})
-	if err == nil {
-		t.Fatal("expected ErrResourceNotFound for unknown name, got nil")
+	if !errors.Is(err, drivers.ErrResourceNotFound) {
+		t.Fatalf("expected ErrResourceNotFound, got: %v", err)
 	}
 }

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -345,7 +345,7 @@ func TestDOProvider_Apply_NoUpsertForUnsupportedDriver(t *testing.T) {
 	}
 }
 
-// ── integration: upsert across all three new drivers ─────────────────────────
+// ── integration: upsert across all four driver types ─────────────────────────
 
 // multiUpsertFakeDriver is a per-resource-type fake that always returns
 // ErrResourceAlreadyExists on Create, implements SupportsUpsert, and records

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -349,12 +349,14 @@ func TestDOProvider_Apply_NoUpsertForUnsupportedDriver(t *testing.T) {
 
 // multiUpsertFakeDriver is a per-resource-type fake that always returns
 // ErrResourceAlreadyExists on Create, implements SupportsUpsert, and records
-// all call counts so assertions can verify the full upsert path.
+// all call counts and the ProviderID passed to Update so assertions can verify
+// the full upsert path.
 type multiUpsertFakeDriver struct {
-	providerID  string
-	createCalls int
-	readCalls   int
-	updateCalls int
+	providerID        string
+	createCalls       int
+	readCalls         int
+	updateCalls       int
+	updatedProviderID string
 }
 
 func (f *multiUpsertFakeDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -367,6 +369,7 @@ func (f *multiUpsertFakeDriver) Read(_ context.Context, ref interfaces.ResourceR
 }
 func (f *multiUpsertFakeDriver) Update(_ context.Context, ref interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	f.updateCalls++
+	f.updatedProviderID = ref.ProviderID
 	return &interfaces.ResourceOutput{Name: ref.Name, Type: ref.Type, ProviderID: ref.ProviderID}, nil
 }
 func (f *multiUpsertFakeDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
@@ -442,6 +445,10 @@ func TestDOProvider_Apply_UpsertAllDrivers(t *testing.T) {
 		}
 		if f.updateCalls != 1 {
 			t.Errorf("%s: updateCalls = %d, want 1", r.rtype, f.updateCalls)
+		}
+		// Verify the discovered ProviderID from Read was propagated into Update.
+		if f.updatedProviderID != r.providerID {
+			t.Errorf("%s: Update called with ProviderID %q, want %q", r.rtype, f.updatedProviderID, r.providerID)
 		}
 	}
 }

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -344,3 +344,104 @@ func TestDOProvider_Apply_NoUpsertForUnsupportedDriver(t *testing.T) {
 		t.Errorf("updateCalls = %d, want 0", fake.updateCalls)
 	}
 }
+
+// ── integration: upsert across all three new drivers ─────────────────────────
+
+// multiUpsertFakeDriver is a per-resource-type fake that always returns
+// ErrResourceAlreadyExists on Create, implements SupportsUpsert, and records
+// all call counts so assertions can verify the full upsert path.
+type multiUpsertFakeDriver struct {
+	providerID  string
+	createCalls int
+	readCalls   int
+	updateCalls int
+}
+
+func (f *multiUpsertFakeDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.createCalls++
+	return nil, fmt.Errorf("already exists: %w", interfaces.ErrResourceAlreadyExists)
+}
+func (f *multiUpsertFakeDriver) Read(_ context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	f.readCalls++
+	return &interfaces.ResourceOutput{Name: ref.Name, Type: ref.Type, ProviderID: f.providerID}, nil
+}
+func (f *multiUpsertFakeDriver) Update(_ context.Context, ref interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.updateCalls++
+	return &interfaces.ResourceOutput{Name: ref.Name, Type: ref.Type, ProviderID: ref.ProviderID}, nil
+}
+func (f *multiUpsertFakeDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
+func (f *multiUpsertFakeDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return nil, nil
+}
+func (f *multiUpsertFakeDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+func (f *multiUpsertFakeDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *multiUpsertFakeDriver) SensitiveKeys() []string { return nil }
+func (f *multiUpsertFakeDriver) SupportsUpsert() bool    { return true }
+
+// TestDOProvider_Apply_UpsertAllDrivers verifies that when VPC, Firewall,
+// Database, and container_service resources all pre-exist (Create returns
+// ErrResourceAlreadyExists), Apply upserts every one of them: Read is called
+// with empty ProviderID, then Update is called with the discovered ProviderID.
+func TestDOProvider_Apply_UpsertAllDrivers(t *testing.T) {
+	resources := []struct {
+		rtype      string
+		name       string
+		providerID string
+	}{
+		{"infra.vpc", "bmw-vpc", "vpc-aaa"},
+		{"infra.firewall", "bmw-fw", "fw-bbb"},
+		{"infra.database", "bmw-db", "db-ccc"},
+		{"infra.container_service", "bmw-app", "app-ddd"},
+	}
+
+	fakes := make(map[string]*multiUpsertFakeDriver, len(resources))
+	driverMap := make(map[string]interfaces.ResourceDriver, len(resources))
+	for _, r := range resources {
+		f := &multiUpsertFakeDriver{providerID: r.providerID}
+		fakes[r.rtype] = f
+		driverMap[r.rtype] = f
+	}
+
+	p := &DOProvider{drivers: driverMap}
+
+	actions := make([]interfaces.PlanAction, 0, len(resources))
+	for _, r := range resources {
+		actions = append(actions, interfaces.PlanAction{
+			Action: "create",
+			Resource: interfaces.ResourceSpec{
+				Name:   r.name,
+				Type:   r.rtype,
+				Config: map[string]any{},
+			},
+		})
+	}
+	plan := &interfaces.IaCPlan{ID: "plan-multi", Actions: actions}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply returned errors: %v", result.Errors)
+	}
+	if len(result.Resources) != len(resources) {
+		t.Errorf("result.Resources len = %d, want %d", len(result.Resources), len(resources))
+	}
+
+	for _, r := range resources {
+		f := fakes[r.rtype]
+		if f.createCalls != 1 {
+			t.Errorf("%s: createCalls = %d, want 1", r.rtype, f.createCalls)
+		}
+		if f.readCalls != 1 {
+			t.Errorf("%s: readCalls = %d, want 1", r.rtype, f.readCalls)
+		}
+		if f.updateCalls != 1 {
+			t.Errorf("%s: updateCalls = %d, want 1", r.rtype, f.updateCalls)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **VPCDriver**, **FirewallDriver**, **DatabaseDriver** all gain name-based `Read` (list-and-match when `ProviderID == ""`), matching the existing `AppPlatformDriver` pattern
- Each driver adds `SupportsUpsert() bool { return true }` to opt into the `DOProvider.Apply` upsert path introduced in v0.7.2
- `FirewallDriver.Read` adds a nil guard before `fwOutput` to return a descriptive error instead of panicking on unexpected nil client returns
- Integration test `TestDOProvider_Apply_UpsertAllDrivers` verifies all four driver types (VPC + Firewall + Database + container_service) complete the full Create→Read→Update upsert path

## Changes by driver

| Driver | Interface change | New behaviour | New tests |
|--------|-----------------|---------------|-----------|
| VPC | Added `List` to `VPCClient` | `Read` falls back to paginated `findVPCByName` | `SupportsUpsert`, `Read_NameBased`, `Read_NameBased_NotFound` |
| Firewall | Added `List` to `FirewallClient` | `Read` falls back to paginated `findFirewallByName`; nil guard added | `SupportsUpsert`, `Read_NameBased`, `Read_NameBased_NotFound`, `Read_NilClientReturn_NoPanic` |
| Database | Added `List` to `DatabaseClient` | `Read` falls back to paginated `findDatabaseByName` | `SupportsUpsert`, `Read_NameBased`, `Read_NameBased_NotFound` |

## Test plan

- [x] `GOWORK=off go test -race -short -count=1 ./internal/...` — all pass (2.1s + 2.2s)
- [x] `go vet ./...` clean
- [x] `gofmt` clean on all changed files
- [x] Integration test `TestDOProvider_Apply_UpsertAllDrivers` covers 4-driver upsert in one Apply call

🤖 Generated with [Claude Code](https://claude.com/claude-code)