### PR TITLE
feat(bootstrap): DOProvider.BootstrapStateBackend for DO Spaces (v0.7.4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.18.2
+	github.com/GoCodeAlone/workflow v0.18.6
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.18.2 h1:Vbm+NvhWMcHHl1zE6aQzNh3MSJzQhmunFO6DA3x9qh8=
-github.com/GoCodeAlone/workflow v0.18.2/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
+github.com/GoCodeAlone/workflow v0.18.6 h1:SmwU9cscZ/lMzNrdDXS+k7ivvWSRp0GYNR8Ljs8ney4=
+github.com/GoCodeAlone/workflow v0.18.6/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/bootstrap.go
+++ b/internal/bootstrap.go
@@ -1,0 +1,141 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// Sentinel errors for config-validation failures in BootstrapStateBackend.
+var (
+	errMissingBucket      = errors.New("missing required config key 'bucket'")
+	errMissingCredentials = errors.New("missing required config keys 'access_key' and/or 'secret_key'")
+)
+
+// spacesBucketClient abstracts the S3 operations needed for state bucket
+// bootstrapping. It is satisfied by *s3.Client and can be faked in tests.
+type spacesBucketClient interface {
+	HeadBucket(ctx context.Context, input *s3.HeadBucketInput, opts ...func(*s3.Options)) (*s3.HeadBucketOutput, error)
+	CreateBucket(ctx context.Context, input *s3.CreateBucketInput, opts ...func(*s3.Options)) (*s3.CreateBucketOutput, error)
+}
+
+// newSpacesS3Client builds an S3 client pointed at the DO Spaces endpoint for
+// the given region. Construction mirrors drivers/spaces.go s3SpacesClient.s3Client.
+func newSpacesS3Client(accessKey, secretKey, region string) spacesBucketClient {
+	endpoint := fmt.Sprintf("https://%s.digitaloceanspaces.com", region)
+	return s3.New(s3.Options{
+		Region:       region,
+		BaseEndpoint: aws.String(endpoint),
+		Credentials:  aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+	})
+}
+
+// BootstrapStateBackend ensures the DO Spaces state bucket exists. It is
+// idempotent: if the bucket already exists it returns the metadata without
+// error. Providers that do not manage a state backend should return (nil, nil).
+//
+// Required cfg keys: "bucket", and credentials supplied as either camelCase
+// ("accessKey"/"secretKey", e.g. BMW infra.yaml) or snake_case
+// ("access_key"/"secret_key"); camelCase is checked first.
+// Optional cfg keys: "region" (falls back to the provider's configured region,
+// then "nyc3" as the ultimate default).
+//
+// Returns a BootstrapResult with:
+//   - Bucket, Region, Endpoint fields populated
+//   - EnvVars: WFCTL_STATE_BUCKET and SPACES_BUCKET set to the bucket name
+func (p *DOProvider) BootstrapStateBackend(ctx context.Context, cfg map[string]any) (*interfaces.BootstrapResult, error) {
+	return p.bootstrapStateBackendWithFactory(ctx, cfg, newSpacesS3Client)
+}
+
+// bootstrapStateBackendWithFactory is the testable core of BootstrapStateBackend.
+// clientFactory receives the resolved credentials and region and returns the
+// client used for HeadBucket/CreateBucket, allowing tests to inject a
+// fakeBucketClient without any network I/O.
+func (p *DOProvider) bootstrapStateBackendWithFactory(
+	ctx context.Context,
+	cfg map[string]any,
+	clientFactory func(accessKey, secretKey, region string) spacesBucketClient,
+) (*interfaces.BootstrapResult, error) {
+	bucket, _ := cfg["bucket"].(string)
+	if bucket == "" {
+		return nil, fmt.Errorf("digitalocean bootstrap: %w", errMissingBucket)
+	}
+
+	region, _ := cfg["region"].(string)
+	if region == "" {
+		region = p.region // provider-level default (set during Initialize)
+	}
+	if region == "" {
+		region = "nyc3"
+	}
+
+	accessKey, _ := cfg["accessKey"].(string) // camelCase (BMW infra.yaml)
+	if accessKey == "" {
+		accessKey, _ = cfg["access_key"].(string) // snake_case fallback
+	}
+	secretKey, _ := cfg["secretKey"].(string)
+	if secretKey == "" {
+		secretKey, _ = cfg["secret_key"].(string)
+	}
+	if accessKey == "" || secretKey == "" {
+		return nil, fmt.Errorf("digitalocean bootstrap: %w", errMissingCredentials)
+	}
+
+	endpoint := fmt.Sprintf("https://%s.digitaloceanspaces.com", region)
+	client := clientFactory(accessKey, secretKey, region)
+
+	if err := bootstrapSpacesBucketWithClient(ctx, bucket, region, client); err != nil {
+		return nil, fmt.Errorf("digitalocean bootstrap: %w", err)
+	}
+
+	return &interfaces.BootstrapResult{
+		Bucket:   bucket,
+		Region:   region,
+		Endpoint: endpoint,
+		EnvVars: map[string]string{
+			"WFCTL_STATE_BUCKET": bucket,
+			"SPACES_BUCKET":      bucket,
+		},
+	}, nil
+}
+
+// bootstrapSpacesBucketWithClient is the testable core of the S3 round-trip.
+// It uses HeadBucket to check existence and CreateBucket to create if absent.
+func bootstrapSpacesBucketWithClient(ctx context.Context, bucket, region string, client spacesBucketClient) error {
+	_, headErr := client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: aws.String(bucket)})
+	if headErr == nil {
+		fmt.Printf("  state backend: bucket %q already exists — skipped\n", bucket)
+		return nil
+	}
+
+	// HeadBucket returns types.NotFound (HTTP 404) when the bucket does not exist.
+	// Any other error (e.g. 403 Forbidden — owned by another account) is fatal.
+	var notFound *s3types.NotFound
+	if !errors.As(headErr, &notFound) {
+		return fmt.Errorf("check bucket %q: %w", bucket, headErr)
+	}
+
+	_, createErr := client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+			LocationConstraint: s3types.BucketLocationConstraint(region),
+		},
+	})
+	if createErr != nil {
+		// BucketAlreadyOwnedByYou: a concurrent create won the race — still OK.
+		var alreadyOwned *s3types.BucketAlreadyOwnedByYou
+		if errors.As(createErr, &alreadyOwned) {
+			fmt.Printf("  state backend: bucket %q already owned — skipped\n", bucket)
+			return nil
+		}
+		return fmt.Errorf("create bucket %q: %w", bucket, createErr)
+	}
+	fmt.Printf("  state backend: created spaces state bucket %q in %s\n", bucket, region)
+	return nil
+}

--- a/internal/bootstrap_test.go
+++ b/internal/bootstrap_test.go
@@ -1,0 +1,224 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// fakeBucketClient implements spacesBucketClient for unit tests.
+type fakeBucketClient struct {
+	headErr      error
+	createErr    error
+	headCalled   bool
+	createCalled bool
+	lastBucket   string
+	lastRegion   string
+}
+
+func (f *fakeBucketClient) HeadBucket(_ context.Context, input *s3.HeadBucketInput, _ ...func(*s3.Options)) (*s3.HeadBucketOutput, error) {
+	f.headCalled = true
+	if input.Bucket != nil {
+		f.lastBucket = *input.Bucket
+	}
+	if f.headErr != nil {
+		return nil, f.headErr
+	}
+	return &s3.HeadBucketOutput{}, nil
+}
+
+func (f *fakeBucketClient) CreateBucket(_ context.Context, input *s3.CreateBucketInput, _ ...func(*s3.Options)) (*s3.CreateBucketOutput, error) {
+	f.createCalled = true
+	if input.Bucket != nil {
+		f.lastBucket = *input.Bucket
+	}
+	if input.CreateBucketConfiguration != nil {
+		f.lastRegion = string(input.CreateBucketConfiguration.LocationConstraint)
+	}
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &s3.CreateBucketOutput{}, nil
+}
+
+// fakeFactory wraps a fakeBucketClient in a clientFactory-compatible func.
+func fakeFactory(c *fakeBucketClient) func(string, string, string) spacesBucketClient {
+	return func(_, _, _ string) spacesBucketClient { return c }
+}
+
+// ── bootstrapSpacesBucketWithClient unit tests ────────────────────────────────
+
+func TestBootstrapSpacesBucket_AlreadyExists(t *testing.T) {
+	client := &fakeBucketClient{headErr: nil} // nil → bucket exists (200 OK)
+	if err := bootstrapSpacesBucketWithClient(t.Context(), "my-bucket", "nyc3", client); err != nil {
+		t.Fatalf("expected no error when bucket already exists, got: %v", err)
+	}
+	if !client.headCalled {
+		t.Error("expected HeadBucket to be called")
+	}
+	if client.createCalled {
+		t.Error("expected CreateBucket NOT to be called when bucket already exists")
+	}
+}
+
+func TestBootstrapSpacesBucket_CreatesNew(t *testing.T) {
+	client := &fakeBucketClient{
+		headErr: &s3types.NotFound{}, // 404 → bucket does not exist
+	}
+	if err := bootstrapSpacesBucketWithClient(t.Context(), "new-bucket", "nyc3", client); err != nil {
+		t.Fatalf("expected no error creating new bucket, got: %v", err)
+	}
+	if !client.createCalled {
+		t.Error("expected CreateBucket to be called when bucket does not exist")
+	}
+	if client.lastBucket != "new-bucket" {
+		t.Errorf("CreateBucket bucket: want %q, got %q", "new-bucket", client.lastBucket)
+	}
+	if client.lastRegion != "nyc3" {
+		t.Errorf("CreateBucket region: want %q, got %q", "nyc3", client.lastRegion)
+	}
+}
+
+func TestBootstrapSpacesBucket_CreateErrorSurfaced(t *testing.T) {
+	createErr := errors.New("spaces quota exceeded")
+	client := &fakeBucketClient{
+		headErr:   &s3types.NotFound{},
+		createErr: createErr,
+	}
+	err := bootstrapSpacesBucketWithClient(t.Context(), "my-bucket", "nyc3", client)
+	if err == nil {
+		t.Fatal("expected error when CreateBucket fails, got nil")
+	}
+	if !errors.Is(err, createErr) {
+		t.Errorf("error chain should contain createErr, got: %v", err)
+	}
+}
+
+func TestBootstrapSpacesBucket_HeadFatalError(t *testing.T) {
+	// A non-404 HeadBucket error (e.g. 403 Forbidden) must be surfaced as-is.
+	headErr := errors.New("403 Forbidden")
+	client := &fakeBucketClient{headErr: headErr}
+	err := bootstrapSpacesBucketWithClient(t.Context(), "my-bucket", "nyc3", client)
+	if err == nil {
+		t.Fatal("expected error for non-404 HeadBucket failure, got nil")
+	}
+	if !errors.Is(err, headErr) {
+		t.Errorf("error chain should contain headErr, got: %v", err)
+	}
+	if client.createCalled {
+		t.Error("CreateBucket must NOT be called on non-404 HeadBucket error")
+	}
+}
+
+func TestBootstrapSpacesBucket_AlreadyOwnedByYou(t *testing.T) {
+	// BucketAlreadyOwnedByYou on Create is treated as idempotent success.
+	client := &fakeBucketClient{
+		headErr:   &s3types.NotFound{},
+		createErr: &s3types.BucketAlreadyOwnedByYou{},
+	}
+	if err := bootstrapSpacesBucketWithClient(t.Context(), "my-bucket", "nyc3", client); err != nil {
+		t.Fatalf("expected no error for BucketAlreadyOwnedByYou, got: %v", err)
+	}
+}
+
+// ── DOProvider.bootstrapStateBackendWithFactory tests ────────────────────────
+// All tests below inject a fakeBucketClient via fakeFactory — no network I/O.
+
+func TestDOProvider_BootstrapStateBackend_CamelCaseKeys(t *testing.T) {
+	// BMW infra.yaml uses accessKey/secretKey (camelCase). Verify they are resolved.
+	client := &fakeBucketClient{headErr: nil}
+	p := NewDOProvider()
+	_, err := p.bootstrapStateBackendWithFactory(t.Context(), map[string]any{
+		"bucket":    "bmw-state",
+		"region":    "nyc3",
+		"accessKey": "k",
+		"secretKey": "s",
+	}, fakeFactory(client))
+	if err != nil {
+		t.Fatalf("camelCase keys should succeed, got: %v", err)
+	}
+	if !client.headCalled {
+		t.Error("expected HeadBucket to be called")
+	}
+}
+
+func TestDOProvider_BootstrapStateBackend_SnakeCaseKeys(t *testing.T) {
+	// Verify snake_case access_key/secret_key fallback also resolves correctly.
+	client := &fakeBucketClient{headErr: nil}
+	p := NewDOProvider()
+	_, err := p.bootstrapStateBackendWithFactory(t.Context(), map[string]any{
+		"bucket":     "bmw-state",
+		"region":     "nyc3",
+		"access_key": "k",
+		"secret_key": "s",
+	}, fakeFactory(client))
+	if err != nil {
+		t.Fatalf("snake_case keys should succeed, got: %v", err)
+	}
+	if !client.headCalled {
+		t.Error("expected HeadBucket to be called")
+	}
+}
+
+func TestDOProvider_BootstrapStateBackend_MissingBucket(t *testing.T) {
+	p := NewDOProvider()
+	_, err := p.bootstrapStateBackendWithFactory(t.Context(), map[string]any{
+		"region":    "nyc3",
+		"accessKey": "k",
+		"secretKey": "s",
+	}, fakeFactory(&fakeBucketClient{}))
+	if !errors.Is(err, errMissingBucket) {
+		t.Fatalf("expected errMissingBucket, got: %v", err)
+	}
+}
+
+func TestDOProvider_BootstrapStateBackend_MissingCredentials(t *testing.T) {
+	p := NewDOProvider()
+	_, err := p.bootstrapStateBackendWithFactory(t.Context(), map[string]any{
+		"bucket": "bmw-state",
+		"region": "nyc3",
+		// no credentials at all
+	}, fakeFactory(&fakeBucketClient{}))
+	if !errors.Is(err, errMissingCredentials) {
+		t.Fatalf("expected errMissingCredentials, got: %v", err)
+	}
+}
+
+func TestDOProvider_BootstrapStateBackend_DefaultsRegion(t *testing.T) {
+	// When cfg["region"] is absent and the provider has no configured region,
+	// BootstrapStateBackend must pass "nyc3" as the region.
+	var gotRegion string
+	client := &fakeBucketClient{headErr: nil}
+	factory := func(_, _, region string) spacesBucketClient {
+		gotRegion = region
+		return client
+	}
+	p := NewDOProvider() // p.region == "" (not yet initialized)
+	_, err := p.bootstrapStateBackendWithFactory(t.Context(), map[string]any{
+		"bucket":    "bmw-state",
+		"accessKey": "k",
+		"secretKey": "s",
+		// no "region"
+	}, factory)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotRegion != "nyc3" {
+		t.Errorf("default region = %q, want %q", gotRegion, "nyc3")
+	}
+}
+
+func TestDOProvider_BootstrapStateBackend_IdempotentOnExists(t *testing.T) {
+	// HeadBucket success → CreateBucket must NOT be called.
+	client := &fakeBucketClient{headErr: nil}
+	err := bootstrapSpacesBucketWithClient(t.Context(), "existing-bucket", "sfo3", client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.createCalled {
+		t.Error("CreateBucket must NOT be called when bucket already exists")
+	}
+}

--- a/internal/module_instance_test.go
+++ b/internal/module_instance_test.go
@@ -256,10 +256,10 @@ func TestDoModuleInstance_InvokeMethod_Read_DispatchesToDriver(t *testing.T) {
 	mi := &doModuleInstance{provider: provider}
 
 	result, err := mi.InvokeMethod("ResourceDriver.Read", map[string]any{
-		"resource_type":    "infra.database",
-		"ref_name":         "my-db",
-		"ref_type":         "infra.database",
-		"ref_provider_id":  "do-456",
+		"resource_type":   "infra.database",
+		"ref_name":        "my-db",
+		"ref_type":        "infra.database",
+		"ref_provider_id": "do-456",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
@@ -309,15 +309,15 @@ func TestDoModuleInstance_InvokeMethod_Diff_DispatchesToDriver(t *testing.T) {
 	mi := &doModuleInstance{provider: provider}
 
 	result, err := mi.InvokeMethod("ResourceDriver.Diff", map[string]any{
-		"resource_type":    "infra.container_service",
-		"spec_name":        "my-app",
-		"spec_type":        "infra.container_service",
-		"spec_config":      map[string]any{"image": "nginx:2.0"},
+		"resource_type":       "infra.container_service",
+		"spec_name":           "my-app",
+		"spec_type":           "infra.container_service",
+		"spec_config":         map[string]any{"image": "nginx:2.0"},
 		"current_provider_id": "do-abc",
-		"current_name":     "my-app",
-		"current_type":     "infra.container_service",
-		"current_status":   "running",
-		"current_outputs":  map[string]any{"url": "https://app.example.com"},
+		"current_name":        "my-app",
+		"current_type":        "infra.container_service",
+		"current_status":      "running",
+		"current_outputs":     map[string]any{"url": "https://app.example.com"},
 	})
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
@@ -757,8 +757,8 @@ type fakeIaCProvider struct {
 	sizingResult  *interfaces.ProviderSizing
 }
 
-func (f *fakeIaCProvider) Name() string                                          { return "fake" }
-func (f *fakeIaCProvider) Version() string                                       { return "0.0.0" }
+func (f *fakeIaCProvider) Name() string                                         { return "fake" }
+func (f *fakeIaCProvider) Version() string                                      { return "0.0.0" }
 func (f *fakeIaCProvider) Initialize(_ context.Context, _ map[string]any) error { return nil }
 func (f *fakeIaCProvider) Capabilities() []interfaces.IaCCapabilityDeclaration  { return nil }
 func (f *fakeIaCProvider) ResourceDriver(_ string) (interfaces.ResourceDriver, error) {
@@ -796,3 +796,6 @@ func (f *fakeIaCProvider) ResolveSizing(_ string, _ interfaces.Size, hints *inte
 	return f.sizingResult, nil
 }
 func (f *fakeIaCProvider) SupportedCanonicalKeys() []string { return interfaces.CanonicalKeys() }
+func (f *fakeIaCProvider) BootstrapStateBackend(_ context.Context, _ map[string]any) (*interfaces.BootstrapResult, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

- Implements `BootstrapStateBackend(ctx, cfg)` on `DOProvider`, relocating DO Spaces bucket bootstrap logic from wfctl core into the plugin
- Accepts both `accessKey`/`secretKey` (camelCase, BMW infra.yaml) and `access_key`/`secret_key` (snake_case) credential keys with fallback chain
- Returns `*interfaces.BootstrapResult{Bucket, Region, Endpoint, EnvVars}` with `WFCTL_STATE_BUCKET` and `SPACES_BUCKET` set
- Testable core (`bootstrapSpacesBucketWithClient`) handles: HeadBucket→exists (skip), NotFound→CreateBucket, BucketAlreadyOwnedByYou (idempotent), other errors (fatal)
- Bumps workflow dep to v0.18.6 which adds the `BootstrapStateBackend` interface method

## Test plan

- [ ] `GOWORK=off go test -race -short -count=1 ./internal/...` — all pass
- [ ] `go vet ./...` — clean
- [ ] `TestBootstrapSpacesBucket_AlreadyExists` — HeadBucket nil → skip CreateBucket
- [ ] `TestBootstrapSpacesBucket_CreatesNew` — NotFound → CreateBucket with correct bucket/region
- [ ] `TestBootstrapSpacesBucket_CreateErrorSurfaced` — create error wrapped and returned
- [ ] `TestBootstrapSpacesBucket_HeadFatalError` — non-404 head error surfaced, no create
- [ ] `TestBootstrapSpacesBucket_AlreadyOwnedByYou` — idempotent success
- [ ] `TestDOProvider_BootstrapStateBackend_MissingBucket` / `_MissingCredentials` — config validation
- [ ] `TestDOProvider_BootstrapStateBackend_CamelCaseKeys` — accessKey/secretKey resolved (BMW format)
- [ ] `TestDOProvider_BootstrapStateBackend_SnakeCaseKeys` — access_key/secret_key also resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)