### PR TITLE
fix(dispatch): args IS cfg in BootstrapStateBackend — unwrap removal (v0.7.6)

### DIFF
--- a/internal/bootstrap.go
+++ b/internal/bootstrap.go
@@ -50,7 +50,11 @@ func newSpacesS3Client(accessKey, secretKey, region string) spacesBucketClient {
 //   - Bucket, Region, Endpoint fields populated
 //   - EnvVars: WFCTL_STATE_BUCKET and SPACES_BUCKET set to the bucket name
 func (p *DOProvider) BootstrapStateBackend(ctx context.Context, cfg map[string]any) (*interfaces.BootstrapResult, error) {
-	return p.bootstrapStateBackendWithFactory(ctx, cfg, newSpacesS3Client)
+	factory := p.bootstrapClientFactory
+	if factory == nil {
+		factory = newSpacesS3Client
+	}
+	return p.bootstrapStateBackendWithFactory(ctx, cfg, factory)
 }
 
 // bootstrapStateBackendWithFactory is the testable core of BootstrapStateBackend.

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -215,10 +215,7 @@ func (m *doModuleInstance) invokeProviderResolveSizing(args map[string]any) (map
 // invokeProviderBootstrapStateBackend decodes the cfg map and calls
 // IaCProvider.BootstrapStateBackend, returning the result as a flat map.
 func (m *doModuleInstance) invokeProviderBootstrapStateBackend(args map[string]any) (map[string]any, error) {
-	var cfg map[string]any
-	if args != nil {
-		cfg, _ = args["cfg"].(map[string]any)
-	}
+	cfg := args // args IS the cfg map (wfctl sends it unwrapped, matching Initialize convention)
 	if cfg == nil {
 		cfg = map[string]any{}
 	}

--- a/internal/module_instance_test.go
+++ b/internal/module_instance_test.go
@@ -662,9 +662,13 @@ func TestDoModuleInstance_InvokeMethod_ResolveSizing_NoHints(t *testing.T) {
 	}
 }
 
-// ── IaCProvider.BootstrapStateBackend dispatch test ───────────────────────────
+// ── IaCProvider.BootstrapStateBackend dispatch tests ─────────────────────────
+//
+// wfctl sends cfg directly as args (same convention as IaCProvider.Initialize),
+// NOT wrapped under a "cfg" key.
 
 func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_Dispatches(t *testing.T) {
+	// Args are sent flat (unwrapped) — bucket/region/accessKey/secretKey at top level.
 	fake := &fakeIaCProvider{
 		bootstrapResult: &interfaces.BootstrapResult{
 			Bucket:   "bmw-state",
@@ -676,12 +680,10 @@ func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_Dispatches(t *testi
 	mi := &doModuleInstance{provider: fake}
 
 	result, err := mi.InvokeMethod("IaCProvider.BootstrapStateBackend", map[string]any{
-		"cfg": map[string]any{
-			"bucket":    "bmw-state",
-			"region":    "nyc3",
-			"accessKey": "k",
-			"secretKey": "s",
-		},
+		"bucket":    "bmw-state",
+		"region":    "nyc3",
+		"accessKey": "k",
+		"secretKey": "s",
 	})
 	if err != nil {
 		t.Fatalf("BootstrapStateBackend dispatch: %v", err)
@@ -689,11 +691,15 @@ func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_Dispatches(t *testi
 	if !fake.bootstrapCalled {
 		t.Error("expected BootstrapStateBackend to be called on the provider")
 	}
+	// Verify the cfg keys were passed through to the provider.
+	if fake.bootstrapCfg["bucket"] != "bmw-state" {
+		t.Errorf("provider received bucket = %q, want %q", fake.bootstrapCfg["bucket"], "bmw-state")
+	}
 	if result["bucket"] != "bmw-state" {
-		t.Errorf("bucket = %q, want %q", result["bucket"], "bmw-state")
+		t.Errorf("result bucket = %q, want %q", result["bucket"], "bmw-state")
 	}
 	if result["region"] != "nyc3" {
-		t.Errorf("region = %q, want %q", result["region"], "nyc3")
+		t.Errorf("result region = %q, want %q", result["region"], "nyc3")
 	}
 }
 
@@ -711,20 +717,6 @@ func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_NilResult(t *testin
 	}
 }
 
-func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_NilCfgArg(t *testing.T) {
-	// Missing cfg arg should be treated as empty map, not panic.
-	fake := &fakeIaCProvider{bootstrapResult: &interfaces.BootstrapResult{Bucket: "b"}}
-	mi := &doModuleInstance{provider: fake}
-
-	_, err := mi.InvokeMethod("IaCProvider.BootstrapStateBackend", map[string]any{})
-	if err != nil {
-		t.Fatalf("nil cfg arg should not error: %v", err)
-	}
-	if fake.bootstrapCfg == nil {
-		t.Error("expected non-nil cfg passed to provider (empty map)")
-	}
-}
-
 func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_NilArgs(t *testing.T) {
 	// InvokeMethod may be called with nil args — must not panic.
 	fake := &fakeIaCProvider{bootstrapResult: &interfaces.BootstrapResult{Bucket: "b"}}
@@ -739,6 +731,37 @@ func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_NilArgs(t *testing.
 	}
 	if !fake.bootstrapCalled {
 		t.Error("expected BootstrapStateBackend to be called on the provider")
+	}
+}
+
+func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_EndToEnd(t *testing.T) {
+	// End-to-end: InvokeMethod → DOProvider.bootstrapStateBackendWithFactory with
+	// a fake S3 client. Exercises the full dispatch+config-parse path without network I/O.
+	// This catches the class of bug where args schema and dispatch don't align.
+	fakeBucket := &fakeBucketClient{headErr: nil} // bucket exists — no create
+	p := NewDOProvider()
+	p.bootstrapClientFactory = func(accessKey, secretKey, region string) spacesBucketClient {
+		return fakeBucket
+	}
+	mi := &doModuleInstance{provider: p}
+
+	result, err := mi.InvokeMethod("IaCProvider.BootstrapStateBackend", map[string]any{
+		"bucket":    "bmw-state",
+		"region":    "nyc3",
+		"accessKey": "test-key",
+		"secretKey": "test-secret",
+	})
+	if err != nil {
+		t.Fatalf("end-to-end dispatch: %v", err)
+	}
+	if result["bucket"] != "bmw-state" {
+		t.Errorf("bucket = %q, want %q", result["bucket"], "bmw-state")
+	}
+	if result["region"] != "nyc3" {
+		t.Errorf("region = %q, want %q", result["region"], "nyc3")
+	}
+	if !fakeBucket.headCalled {
+		t.Error("expected HeadBucket to be called on the fake S3 client")
 	}
 }
 

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -27,6 +27,10 @@ type DOProvider struct {
 	client  *godo.Client
 	region  string
 	drivers map[string]interfaces.ResourceDriver
+
+	// bootstrapClientFactory is used by BootstrapStateBackend to build the S3
+	// client. Nil means use the default newSpacesS3Client. Tests inject a fake.
+	bootstrapClientFactory func(accessKey, secretKey, region string) spacesBucketClient
 }
 
 var _ interfaces.IaCProvider = (*DOProvider)(nil)


### PR DESCRIPTION
## Summary

- **Root cause:** v0.7.5 dispatch extracted `args["cfg"].(map[string]any)` but wfctl sends cfg as args directly (unwrapped), same convention as `IaCProvider.Initialize`. Result: `args["cfg"]` always nil → empty cfg → `errMissingBucket` on every BMW bootstrap call.
- **Fix:** `cfg := args` (4-line change) with nil guard preserved.
- **Integration test:** Adds `DOProvider.bootstrapClientFactory` injectable field; new `TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_EndToEnd` exercises the full `InvokeMethod → DOProvider.BootstrapStateBackend → bootstrapStateBackendWithFactory → fakeBucketClient` path without network I/O. Would have caught both the v0.7.4 (missing case) and v0.7.6 (schema mismatch) bugs.
- Removes now-incorrect `NilCfgArg` test (no longer a "cfg" key), updates `Dispatches` test to pass args flat, retains `NilResult` and `NilArgs` tests.

## Test plan

- [ ] `GOWORK=off go test -race -short -count=1 ./internal/...` — all pass
- [ ] `TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_EndToEnd` — full dispatch chain, HeadBucket called on fake
- [ ] `TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_Dispatches` — flat args, cfg keys forwarded to provider
- [ ] `TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_NilArgs` — nil args no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)