### PR TITLE
feat(app-platform): v0.7.8 — Troubleshoot impl + gRPC dispatch (Tasks 11-13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ### Changed
 
-- Depends on workflow v0.18.10 (was v0.18.9).
+- Depends on workflow v0.18.10.1 (was v0.18.6).
 - `AppPlatformDriver.Troubleshoot`: empty `ProviderID` now returns `(nil, nil)` instead
   of an error; `ListDeployments` errors are best-effort (swallowed, slot-based data used).
 - Test ProviderIDs updated from `"app-123"` to proper UUID format throughout driver tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,18 +23,47 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 ### Fixed
 
 - **State-heal for stale name-as-ProviderID** — `AppPlatformDriver.Update` and `Delete`
-  now call `resolveProviderID` before hitting the DO API. If `ref.ProviderID` is not
-  UUID-like (36 chars, hyphens at 8/13/18/23), the driver logs a WARN and performs a
-  name-based lookup via `findAppByName`, recovering the real UUID from the DO API. This
-  transparently heals state entries left by pre-v0.7.7 broken runs (e.g. BMW staging
-  `ProviderID="bmw-staging"`) without any manual teardown or state editing.
+  now call `resolveProviderID` before hitting the DO API. When `ref.ProviderID` is not a
+  canonical UUID (36 chars, hyphens at positions 8/13/18/23), the driver logs a WARN and
+  transparently falls back to `findAppByName` to recover the real UUID. The healed UUID is
+  returned in `ResourceOutput.ProviderID` so wfctl rewrites state on the next Apply — no
+  manual teardown or state editing required.
+
+  Root-cause: a pre-v0.7.7 code path in `DOProvider.Apply` substituted `spec.Name` as
+  `ProviderID` when the godo API returned a zero-ID response. v0.7.7 added an empty-ID
+  guard on the Create path but did not heal existing stale state. v0.7.8 heals it at
+  Update/Delete time. Triggered by BMW staging deploy `24901939350` where
+  `state.json` contained `ProviderID="bmw-staging"` instead of the app UUID.
+
+- New shared helper `isUUIDLike(s string) bool` in `internal/drivers/shared.go` — used
+  by `resolveProviderID`; 11-case table-driven unit test in `shared_test.go`.
+- A WARN log (`"state-heal"` keyword) is emitted when heal fires so operators can observe
+  state drift in CI output without the deploy failing.
+- New integration-test harness in `internal/drivers/integration_test_helpers_test.go`:
+  `fakeAppsClient` (full `AppPlatformClient` stub with per-method call tracking),
+  `inMemoryState` (minimal state round-trip store), and `applySim` (mimics wfctl's
+  Apply→persist loop). Five integration tests in `app_platform_integration_test.go`
+  exercise the full Create → state persist → Update flow including:
+  - UUID stored (not spec name) after Create
+  - No heal for valid UUID on Update
+  - Stale name healed on Update (core BMW regression test)
+  - Stale name healed on Delete
+  - Clear error when heal can't resolve the name
 
 ### Changed
 
-- Depends on workflow v0.18.10 (was v0.18.9) once tagged.
+- Depends on workflow v0.18.10 (was v0.18.9).
 - `AppPlatformDriver.Troubleshoot`: empty `ProviderID` now returns `(nil, nil)` instead
   of an error; `ListDeployments` errors are best-effort (swallowed, slot-based data used).
-- Test ProviderIDs updated from `"app-123"` to proper UUID format throughout driver tests.
+- Test ProviderIDs updated from `"app-123"` to proper UUID format throughout driver tests
+  (required because `"app-123"` is not UUID-like and would trigger the heal path).
+
+### Known follow-up (v0.7.9)
+
+- Replicate state-heal (`resolveProviderID` equivalent) across the other UUID-based
+  drivers (`vpc`, `firewall`, `database`, `cache`, `load_balancer`, `certificate`,
+  `api_gateway`, `kubernetes`, `droplet`) — the same class of stale state is theoretically
+  possible for any driver that was deployed before v0.7.7's empty-ID guard.
 
 ## [v0.7.7] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to workflow-plugin-digitalocean are documented here.
 
+## [v0.7.8] - 2026-04-24
+
+### Added
+
+- `AppPlatformDriver.Troubleshoot` implements `interfaces.Troubleshooter` from workflow
+  v0.18.10. On deploy health-check failure wfctl automatically fetches the app's
+  in-progress/pending/active deployment slots (prioritised in that order) plus up to
+  5 recent historical deployments, synthesises `[]Diagnostic` entries with per-phase
+  root-cause lines extracted from `Progress.SummarySteps` and `Progress.Steps`, and
+  surfaces them in CI output — no DO console trip required to diagnose failures.
+- `pickTroubleshootDeployments` helper: priority-ordered candidate selection with dedup.
+- `buildDiagnosticFor` helper: structured Diagnostic extraction per deployment.
+- `extractCause` helper: scans log tail / reason messages for common error patterns
+  (`Error:`, `exit status`, `panic:`, `fatal:`, `failed to`, …) with last-line fallback.
+- `ResourceDriver.Troubleshoot` gRPC dispatch in plugin `InvokeMethod`; returns
+  `codes.Unimplemented` for drivers that don't implement `Troubleshooter` so wfctl
+  silently no-ops without error.
+
+### Changed
+
+- Depends on workflow v0.18.10 (was v0.18.9) once tagged.
+- `AppPlatformDriver.Troubleshoot`: empty `ProviderID` now returns `(nil, nil)` instead
+  of an error; `ListDeployments` errors are best-effort (swallowed, slot-based data used).
+
 ## [v0.7.7] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,21 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   `codes.Unimplemented` for drivers that don't implement `Troubleshooter` so wfctl
   silently no-ops without error.
 
+### Fixed
+
+- **State-heal for stale name-as-ProviderID** — `AppPlatformDriver.Update` and `Delete`
+  now call `resolveProviderID` before hitting the DO API. If `ref.ProviderID` is not
+  UUID-like (36 chars, hyphens at 8/13/18/23), the driver logs a WARN and performs a
+  name-based lookup via `findAppByName`, recovering the real UUID from the DO API. This
+  transparently heals state entries left by pre-v0.7.7 broken runs (e.g. BMW staging
+  `ProviderID="bmw-staging"`) without any manual teardown or state editing.
+
 ### Changed
 
 - Depends on workflow v0.18.10 (was v0.18.9) once tagged.
 - `AppPlatformDriver.Troubleshoot`: empty `ProviderID` now returns `(nil, nil)` instead
   of an error; `ListDeployments` errors are best-effort (swallowed, slot-based data used).
+- Test ProviderIDs updated from `"app-123"` to proper UUID format throughout driver tests.
 
 ## [v0.7.7] - 2026-04-24
 

--- a/docs/plans/2026-04-24-provider-id-state-heal-design.md
+++ b/docs/plans/2026-04-24-provider-id-state-heal-design.md
@@ -1,0 +1,159 @@
+# DO Plugin — ProviderID State-Heal + Integration Test Coverage
+
+**Status:** Approved (autonomous pipeline, 2026-04-24)
+
+**Target release:** workflow-plugin-digitalocean v0.7.8 (bundle into in-flight PR #22)
+
+**Related tasks:** #67 (this work), #58 (v0.7.7 empty-ID guards — prior attempt), #25 (BMW staging deploy unblock), #64 / #72 (wfctl observability).
+
+---
+
+## Problem
+
+BMW staging deploy has failed twice tonight with the same error:
+
+```
+update/bmw-staging: PUT https://api.digitalocean.com/v2/apps/bmw-staging: 400 invalid uuid
+```
+
+DO's App Platform API requires a UUID in the URL path (`/v2/apps/{uuid}`). BMW's IaC state at `s3://bmw-iac-state/staging/state.json` has `ProviderID = "bmw-staging"` (the resource name) instead of the real UUID (`f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5`). DO rejects the PUT.
+
+v0.7.7 shipped as the fix for this bug class ("empty-ID guards + capture UUID from API response"), but the bug recurred — meaning either (a) v0.7.7 doesn't actually prevent the UUID→name substitution in all code paths, or (b) the state that's been failing was populated by an earlier version and never healed.
+
+User mandate: proper fix, with the test that would have caught this. No teardown. No hand-edit of state files.
+
+---
+
+## What's verified
+
+1. **wfctl is a passthrough for `ProviderID`.** `cmd/wfctl/infra_apply.go:281-299` reads `result.Resources[i].ProviderID` directly into `ResourceState.ProviderID` — if the driver returns the correct UUID, state gets the UUID. So the bug lives in the driver or its call chain, not wfctl.
+2. **`AppPlatformDriver.Create` writes `ProviderID: app.ID`** (line 403 via `appOutput(app)`). On the success path, the UUID flows correctly.
+3. **State-heal is already drafted** on feat/v0.7.8-troubleshoot (uncommitted): `resolveProviderID(ctx, ref)` + `isUUIDLike` + wired into Update/Delete. The draft matches the design below.
+4. **Other DO drivers are vulnerable** to the same class of bug where UUID-format providers are concerned (api_gateway, database, cache, certificate, droplet, load_balancer, vpc, firewall, reserved_ip). DNS and spaces use non-UUID identifiers so are not affected.
+
+---
+
+## Approach
+
+Three layers of defense, each addressable independently, bundled together for v0.7.8:
+
+### Layer 1 — Root-cause audit of `v0.7.7` empty-ID guard
+
+The v0.7.7 "empty-ID guard" (commit `94c9227`) is suspect. Audit it:
+
+- Does any path in `Create` fall back to `ref.Name` when `app.ID == ""`? If yes, that's wrong — it should error out loudly so state never silently persists a name-as-UUID.
+- Is there a gRPC-boundary issue where `ResourceOutput.ProviderID` is getting dropped in marshaling, causing wfctl to reuse the previous state's (broken) ProviderID?
+- Was the BMW-staging state originally populated pre-v0.7.7, and the v0.7.7 fix only prevents NEW-creation drift but doesn't heal EXISTING drift?
+
+**Deliverable:** a brief root-cause write-up in the PR body naming the specific code path that produced BMW's bad state. Fix it if it still exists (e.g., replace silent fallback with `return nil, fmt.Errorf(...)` at the offending site).
+
+### Layer 2 — State-heal in the driver, per-driver
+
+Each DO driver using UUID-format identifiers validates `ref.ProviderID` shape before hitting the API. On mismatch, fall back to the driver's existing name-based lookup (`findAppByName` / `findDatabaseByName` / etc.) to resolve the real UUID, use it for the API call, and return `ResourceOutput.ProviderID` containing the healed UUID so wfctl rewrites state transparently.
+
+Shape check is per-driver because DO's identifier formats differ:
+- App Platform, Database, Cache, Certificate, Droplet, Load Balancer, VPC, Firewall, Reserved IP → UUID
+- DNS Domain → domain name (no heal needed; the name IS the ID)
+- Spaces → bucket name (same)
+
+A shared `isUUIDLike(s string) bool` helper in `internal/drivers/shared.go` (or equivalent) removes per-driver duplication. Drivers that need heal call it; drivers that don't skip it.
+
+**For v0.7.8 (tonight's scope):** implement state-heal on `AppPlatformDriver` only — that's the unblocker for BMW. Ship.
+
+**For v0.7.9 (follow-up, separate task):** audit + replicate heal across the remaining UUID drivers. Each needs its own `findByName` prerequisite (most have it per task #21 v0.7.3).
+
+### Layer 3 — Integration-test harness
+
+The test infrastructure that would have caught v0.7.7's regression. New file `internal/drivers/app_platform_integration_test.go` plus supporting scaffolding in `internal/drivers/testhelpers_test.go`:
+
+**Harness components:**
+- `fakeAppsClient` — embeds `godo.AppsService` interface, tracks calls (which method, with which arguments), returns configurable responses with real UUIDs
+- `inMemoryState` — implementing enough of workflow's state-store surface to round-trip `ResourceState` writes and reads
+- `apply(driver, spec)` helper that mimics what wfctl's `infra_apply.go` does: call `Create`/`Update`, take returned `ResourceOutput`, persist to in-memory state, return the state snapshot
+
+**Tests:**
+
+| Test | Seed state | Action | Assertion |
+|---|---|---|---|
+| `TestAppPlatform_Create_PersistsUUIDInState` | empty | Create with mock returning `App{ID:"uuid-abc", Name:"bmw-staging"}` | state has `ProviderID="uuid-abc"` |
+| `TestAppPlatform_Update_UsesExistingUUID` | `ProviderID="uuid-abc"` | Update | fakeClient saw `Update(ctx, "uuid-abc", ...)`; no `findByName` call |
+| `TestAppPlatform_Update_HealsStaleName` | `ProviderID="bmw-staging"` (stale name) | Update | fakeClient saw `findAppByName` → Update with real UUID; returned `ResourceOutput.ProviderID` is the UUID; warn log captured |
+| `TestAppPlatform_Delete_HealsStaleName` | `ProviderID="bmw-staging"` | Delete | Same as Update but for Delete |
+| `TestIsUUIDLike_TableDriven` | n/a | pure function | canonical UUIDs pass; names, empty, too-short, missing-hyphens all fail |
+
+**Why these tests pin down the regression:**
+- The "happy Create → state has UUID" test fails loudly if anyone ever adds a silent name-fallback in Create. That's the test v0.7.7 didn't have.
+- The heal tests cover the defense-in-depth path that matters when state is already corrupt.
+
+### Layer 4 (optional, out of scope) — wfctl-core generic heal hook
+
+Considered and deferred. Reasoning:
+
+**For:** a generic `driver.ValidateProviderID(id) bool` + wfctl calling it before every Update/Delete with Read-by-name fallback means all drivers across all providers benefit uniformly. Less per-driver boilerplate.
+
+**Against:** `ValidateProviderID` shape varies (UUIDs for DO, ARNs for AWS, project/location/resource strings for GCP) — the contract essentially devolves to "let the driver decide." At which point pushing the heal into the driver (where it already has the name-lookup logic) is simpler and more honest. The generic hook buys only marginal deduplication and constrains future providers who may have their own ID conventions.
+
+Verdict: skip the generic hook. Each driver owns its heal.
+
+---
+
+## Data flow (post-v0.7.8, BMW-like recovery)
+
+```
+wfctl infra apply --env staging
+  → planResourcesForEnv → Plan: 1 action(s): update bmw-staging
+  → provider.Apply(plan)
+    → AppPlatformDriver.Update(ctx, ref{Name:"bmw-staging", ProviderID:"bmw-staging"}, spec)
+      → resolveProviderID(ctx, ref)
+        → isUUIDLike("bmw-staging") → false
+        → log.Printf("warn: app platform \"bmw-staging\": ProviderID \"bmw-staging\" is not UUID-like; resolving by name (state-heal)")
+        → findAppByName(ctx, "bmw-staging") → App{ID:"f8b6200c-...", ...}
+        → return "f8b6200c-..."
+      → client.Update(ctx, "f8b6200c-...", AppUpdateRequest{Spec:...}) → App{ID:"f8b6200c-...", ...}
+      → client.CreateDeployment(ctx, "f8b6200c-...", ...)
+      → return ResourceOutput{ProviderID:"f8b6200c-...", ...}
+  → wfctl persists ResourceState{ProviderID:"f8b6200c-..."} (healed)
+  → Deploy continues: pre_deploy migrations run, app becomes ACTIVE
+```
+
+Same flow applies to `Delete` on stale state; user never sees the "invalid uuid" error again.
+
+---
+
+## Rollout
+
+**v0.7.8 (this PR #22):**
+1. Root-cause audit write-up in PR description.
+2. Shared `isUUIDLike` helper in `internal/drivers/shared.go`.
+3. `AppPlatformDriver.resolveProviderID` wired into Update, Delete (already drafted, commit it).
+4. Integration-test harness + 5 tests from the table above.
+5. CHANGELOG v0.7.8 entry describing the heal, the root-cause finding, and the integration-test harness.
+6. Continue to bundle Troubleshoot work from earlier in PR #22.
+
+**v0.7.9 (follow-up task, filed post-merge):**
+- Audit + replicate heal across: database, cache, certificate, droplet, load_balancer, vpc, firewall, reserved_ip, api_gateway.
+- One commit per driver, same pattern.
+- Integration tests for each (parameterize the existing harness).
+
+**BMW consumer bump:**
+- Single PR: setup-wfctl v0.18.9 → v0.18.10.1 (after v0.18.10.1 tags) + workflow-plugin-digitalocean v0.7.7 → v0.7.8.
+- Retries deploy. State-heal kicks in on the stale `ProviderID="bmw-staging"` during the infra apply step, state gets rewritten with the real UUID, deploy proceeds.
+
+---
+
+## Success criteria
+
+- `internal/drivers/app_platform_integration_test.go` exercises the bug that produced BMW's failure and passes (TDD — write the stale-name test FIRST, watch it fail against main, then apply the heal patch).
+- `v0.7.8` merges and tags.
+- BMW deploy retry on v0.7.8 against the current (broken-state) staging env completes successfully: `wfctl infra apply` heals state, pre-deploy migration runs, app reaches ACTIVE, /healthz returns 200, auto-promote to prod fires on /healthz green.
+- No future regression in the "happy Create produces UUID-state" path — golden test pins it.
+
+---
+
+## Non-goals
+
+- wfctl-core generic `ValidateProviderID` hook (deferred, may never be needed).
+- Other DO drivers' heal (v0.7.9).
+- AWS / GCP / Azure equivalents (each provider audits + fixes its own drivers in its own repo).
+- `wfctl infra heal` command for ad-hoc recovery (nice-to-have, not needed once driver-level heal exists).
+- Retroactive state-file repair tool (not needed — first Update on stale state heals it transparently).

--- a/docs/plans/2026-04-24-provider-id-state-heal.md
+++ b/docs/plans/2026-04-24-provider-id-state-heal.md
@@ -1,0 +1,808 @@
+# DO Plugin ProviderID State-Heal Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Ship workflow-plugin-digitalocean v0.7.8 with per-driver state-heal (Update/Delete), shared `isUUIDLike` helper, root-cause audit + fix, and an integration-test harness that pins down the "BMW invalid-uuid" regression so it cannot silently return.
+
+**Architecture:** `AppPlatformDriver.Update` and `Delete` call a new `resolveProviderID(ctx, ref)` helper that validates `ref.ProviderID` shape via a shared `isUUIDLike`. Stale name-as-ProviderID state falls back to `findAppByName` to resolve the real UUID; returned `ResourceOutput.ProviderID` contains the healed UUID so wfctl rewrites state transparently. Root-cause is audited + fixed or documented as historic. Integration-test harness exercises the full Apply/Update loop against a fake `godo.AppsService` + in-memory state, including the specific "stale name heals to UUID" scenario.
+
+**Tech Stack:** Go 1.26, `github.com/digitalocean/godo`, `github.com/GoCodeAlone/workflow` v0.18.10 (v0.18.10.1 after impl-migrations' hotfix tags).
+
+---
+
+## Repo + branch
+
+**Repo:** `/Users/jon/workspace/workflow-plugin-digitalocean`
+**Branch:** `feat/v0.7.8-troubleshoot` (already open as PR #22)
+
+impl-digitalocean-2 has uncommitted local work that implements Layer 2 (state-heal wiring in Update/Delete + `resolveProviderID` + `isUUIDLike`). Task 1 commits that in its current form; Task 2 extracts `isUUIDLike` to a shared location.
+
+## Prereqs
+
+- Workflow v0.18.10.1 tagged (impl-migrations' in-flight PR #478). go.mod on this branch is already bumped to v0.18.10 (commit 5bb52f4); Task 0 below re-bumps to v0.18.10.1 when it ships.
+
+---
+
+### Task 0: Bump go.mod to v0.18.10.1 (blocked on impl-migrations tag)
+
+**Files:**
+- Modify: `go.mod`, `go.sum`
+
+**Step 1: Wait for `v0.18.10.1` tag on GoCodeAlone/workflow**
+
+Check via: `gh release view v0.18.10.1 --repo GoCodeAlone/workflow --json tagName`.
+If not yet tagged, keep working on Tasks 1-6 which don't depend on the bump.
+
+**Step 2: Bump**
+
+```bash
+cd /Users/jon/workspace/workflow-plugin-digitalocean
+go get github.com/GoCodeAlone/workflow@v0.18.10.1
+go mod tidy
+```
+
+**Step 3: Verify**
+
+Run: `GOWORK=off go build ./... && GOWORK=off go test -race -short ./...`
+Expected: all packages green.
+
+**Step 4: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "deps: bump workflow v0.18.10 → v0.18.10.1 (Troubleshoot hotfix)"
+```
+
+---
+
+### Task 1: Commit the already-drafted state-heal in AppPlatformDriver
+
+**Files:**
+- Modify: `internal/drivers/app_platform.go` (uncommitted local changes)
+
+**Step 1: Verify the working-tree diff matches the design**
+
+```bash
+git diff internal/drivers/app_platform.go
+```
+
+Expected content:
+- New `resolveProviderID(ctx, ref) (string, error)` method that returns `ref.ProviderID` when `isUUIDLike` is true, else logs a WARN and falls back to `findAppByName(ctx, ref.Name)` for the real UUID
+- New `isUUIDLike(s string) bool` helper (36 chars, hyphens at 8/13/18/23)
+- `Update` calls `resolveProviderID` first, then uses the resolved ID for both `client.Update` and `client.CreateDeployment`
+- `Delete` calls `resolveProviderID` first, then uses the resolved ID for `client.Delete`
+
+If the diff deviates (e.g., missing Delete wiring), adjust so it matches before committing.
+
+**Step 2: Stage + commit — just the driver change, not the design doc (committed separately)**
+
+```bash
+git add internal/drivers/app_platform.go
+git commit -m "$(cat <<'EOF'
+fix(app-platform): state-heal stale non-UUID ProviderID in Update/Delete
+
+When state has a ProviderID that is not a canonical UUID (e.g., legacy state
+that stored the resource name), Update/Delete fall back to findAppByName to
+resolve the real UUID. The returned ResourceOutput carries the healed
+ProviderID so wfctl rewrites state transparently on the next Apply.
+
+Heal fires silently with a WARN log so operators can observe drift without
+the deploy failing. Unit + integration test coverage in follow-up tasks.
+EOF
+)"
+```
+
+---
+
+### Task 2: Extract `isUUIDLike` to shared helper
+
+**Files:**
+- Create: `internal/drivers/shared.go`
+- Create: `internal/drivers/shared_test.go`
+- Modify: `internal/drivers/app_platform.go` (remove local declaration)
+
+**Step 1: Write the failing test**
+
+Create `internal/drivers/shared_test.go`:
+
+```go
+package drivers
+
+import "testing"
+
+func TestIsUUIDLike_TableDriven(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical uuid", "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", true},
+		{"lowercase letters", "abcdef01-2345-6789-abcd-ef0123456789", true},
+		{"uppercase letters", "ABCDEF01-2345-6789-ABCD-EF0123456789", true},
+		{"resource name", "bmw-staging", false},
+		{"empty string", "", false},
+		{"too short", "f8b6200c-3bba-48a7-8bf1", false},
+		{"too long", "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5-extra", false},
+		{"missing first hyphen", "f8b6200c03bba-48a7-8bf1-7a3e3a885eb5", false},
+		{"wrong hyphen positions", "f8b6200-c3bba-48a7-8bf1-7a3e3a885eb5X", false},
+		{"36 chars but no hyphens", "f8b6200c3bba48a78bf17a3e3a885eb5foo12", false},
+		{"spaces", "f8b6200c 3bba 48a7 8bf1 7a3e3a885eb5 ", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isUUIDLike(c.in); got != c.want {
+				t.Errorf("isUUIDLike(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run — expect compile error (isUUIDLike not in shared.go yet)**
+
+```bash
+GOWORK=off go test ./internal/drivers/... -run TestIsUUIDLike_TableDriven -v
+```
+Expected: test runs against the one in `app_platform.go` and passes (duplicate not yet present). OK, then go to step 3.
+
+**Step 3: Create `internal/drivers/shared.go`**
+
+```go
+// Package drivers implements per-resource DigitalOcean drivers used by the
+// plugin. shared.go holds helpers that are used by more than one driver.
+package drivers
+
+// isUUIDLike returns true when s has the canonical UUID shape:
+// 36 characters with hyphens at positions 8, 13, 18, and 23.
+//
+// Used by drivers whose DO API requires a UUID in the URL path (app platform,
+// databases, certificates, load balancers, VPCs, firewalls, droplets, etc.)
+// to detect stale state that stored a resource name instead of the UUID,
+// so callers can fall back to a name-based lookup instead of sending a
+// malformed path parameter to the DO API.
+func isUUIDLike(s string) bool {
+	return len(s) == 36 && s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
+}
+```
+
+**Step 4: Remove the duplicate from `app_platform.go`**
+
+Delete the `isUUIDLike` function and its doc comment from `app_platform.go`. Leave `resolveProviderID` alone — it uses the shared helper.
+
+**Step 5: Run tests**
+
+```bash
+GOWORK=off go build ./... && GOWORK=off go test -race -short ./internal/drivers/...
+```
+Expected: all green.
+
+**Step 6: Commit**
+
+```bash
+git add internal/drivers/shared.go internal/drivers/shared_test.go internal/drivers/app_platform.go
+git commit -m "refactor(drivers): extract isUUIDLike to shared helper with tests"
+```
+
+---
+
+### Task 3: Root-cause audit + PR-body write-up
+
+**Files:**
+- Read: `internal/drivers/app_platform.go`
+- Read: any commit `94c9227` diff (v0.7.7 "empty-ID guard")
+- Modify: PR #22 description (via `gh pr edit`)
+- Possibly modify: `internal/drivers/app_platform.go` if root-cause is still-present
+
+**Step 1: Audit v0.7.7's empty-ID guard**
+
+```bash
+git show 94c9227 -- internal/drivers/app_platform.go | head -100
+```
+
+Look for: does any code path in `Create` or downstream helpers silently substitute `ref.Name` for `ProviderID` when `app.ID == ""`? v0.7.7's intent was to *guard against* an empty ID by enabling the upsert path, but the guard might accidentally produce a name-as-ProviderID.
+
+Also audit `appOutput(app *godo.App)` (the helper at ~line 403):
+- Verify it uses `app.ID` for the ProviderID field
+- Verify there is no fallback to `app.Spec.Name` or similar
+
+**Step 2: Audit the gRPC marshaling path**
+
+Check `internal/plugin.go` (plugin's gRPC dispatcher) for:
+- Does `ResourceOutput` round-trip correctly through `structpb.NewStruct` / back? Specifically, the `ProviderID` string field — does it survive marshaling?
+- Is there any default-on-empty logic that would substitute a name?
+
+**Step 3: Write the write-up**
+
+Draft a ~200-word explanation covering:
+- **What happened in BMW:** state has `ProviderID="bmw-staging"` (name) despite v0.7.7 being deployed. When wfctl called Update, DO rejected the PUT because "bmw-staging" isn't a UUID.
+- **Where the name came from:** most likely a pre-v0.7.7 Create that never had the empty-ID guard. Once BMW's state had the bad shape, every subsequent Update re-used it without healing (v0.7.7 only guards NEW creates, not existing state).
+- **Why v0.7.7 didn't catch it:** unit-test coverage but no integration test that round-trips state through Apply/Update. Tonight's integration test harness (Task 4) covers that gap.
+- **What changes in v0.7.8:** state-heal in Update/Delete plus integration tests that would have caught tonight's regression. If the Create path *does* still have a silent name-fallback, add a commit that replaces it with an explicit error so state can never be populated in the bad shape going forward.
+
+**Step 4: Push write-up to PR body**
+
+```bash
+gh pr edit 22 --repo GoCodeAlone/workflow-plugin-digitalocean --body "$(cat <<'EOF'
+<existing PR body>
+
+## Root-cause (v0.7.8 addendum)
+
+<write-up from step 3>
+EOF
+)"
+```
+
+(Preserve the existing PR body; append the root-cause section.)
+
+**Step 5: If a fix in Create is needed, commit separately**
+
+```bash
+git add internal/drivers/app_platform.go
+git commit -m "fix(app-platform): error explicitly on empty app.ID in Create, never substitute name"
+```
+
+---
+
+### Task 4: Integration-test harness
+
+**Files:**
+- Create: `internal/drivers/integration_test_helpers_test.go`
+
+**Step 1: Write the fake godo.AppsService + in-memory state harness**
+
+Create `internal/drivers/integration_test_helpers_test.go`:
+
+```go
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// fakeAppsClient implements AppsClient for integration tests. It tracks every
+// call so tests can assert which DO API methods were invoked and with which
+// identifiers, and it returns configurable responses seeded per test.
+type fakeAppsClient struct {
+	// Seeded responses.
+	createResp *godo.App // returned by Create
+	getByID    map[string]*godo.App // keyed by app ID
+	listApps   []godo.App // returned by List
+	updateResp map[string]*godo.App // keyed by app ID (what Update returns)
+	deleteErrs map[string]error // keyed by app ID (nil ⇒ 204)
+
+	// Call log.
+	createCalls        []string // app names created
+	getCalls           []string // app IDs or names passed to Get
+	updateCalls        []string // app IDs passed to Update
+	createDeployCalls  []string
+	deleteCalls        []string
+	listCalls          int
+	listDeploymentsFor []string
+}
+
+func newFakeAppsClient() *fakeAppsClient {
+	return &fakeAppsClient{
+		getByID:    map[string]*godo.App{},
+		updateResp: map[string]*godo.App{},
+		deleteErrs: map[string]error{},
+	}
+}
+
+// --- AppsClient interface implementation ---
+
+func (f *fakeAppsClient) Create(_ context.Context, req *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	f.createCalls = append(f.createCalls, req.Spec.Name)
+	if f.createResp != nil {
+		f.getByID[f.createResp.ID] = f.createResp
+		return f.createResp, resp(http.StatusCreated), nil
+	}
+	// Default: return an App with a deterministic UUID.
+	app := &godo.App{
+		ID:   fmt.Sprintf("uuid-%s", req.Spec.Name),
+		Spec: req.Spec,
+		CreatedAt: time.Now(),
+	}
+	f.getByID[app.ID] = app
+	return app, resp(http.StatusCreated), nil
+}
+
+func (f *fakeAppsClient) Get(_ context.Context, id string) (*godo.App, *godo.Response, error) {
+	f.getCalls = append(f.getCalls, id)
+	if app, ok := f.getByID[id]; ok {
+		return app, resp(http.StatusOK), nil
+	}
+	return nil, resp(http.StatusNotFound), fmt.Errorf("not found")
+}
+
+func (f *fakeAppsClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.App, *godo.Response, error) {
+	f.listCalls++
+	// Synthesize list from seeded apps if listApps is nil.
+	if f.listApps != nil {
+		return f.listApps, resp(http.StatusOK), nil
+	}
+	out := make([]godo.App, 0, len(f.getByID))
+	for _, a := range f.getByID {
+		out = append(out, *a)
+	}
+	return out, resp(http.StatusOK), nil
+}
+
+func (f *fakeAppsClient) Update(_ context.Context, id string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	f.updateCalls = append(f.updateCalls, id)
+	if app, ok := f.updateResp[id]; ok {
+		return app, resp(http.StatusOK), nil
+	}
+	if app, ok := f.getByID[id]; ok {
+		return app, resp(http.StatusOK), nil
+	}
+	return nil, resp(http.StatusNotFound), fmt.Errorf("update: not found: %s", id)
+}
+
+func (f *fakeAppsClient) CreateDeployment(_ context.Context, id string, _ *godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	f.createDeployCalls = append(f.createDeployCalls, id)
+	return &godo.Deployment{ID: fmt.Sprintf("dep-%s", id)}, resp(http.StatusOK), nil
+}
+
+func (f *fakeAppsClient) Delete(_ context.Context, id string) (*godo.Response, error) {
+	f.deleteCalls = append(f.deleteCalls, id)
+	if err, ok := f.deleteErrs[id]; ok {
+		return resp(http.StatusConflict), err
+	}
+	delete(f.getByID, id)
+	return resp(http.StatusNoContent), nil
+}
+
+func (f *fakeAppsClient) ListDeployments(_ context.Context, id string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	f.listDeploymentsFor = append(f.listDeploymentsFor, id)
+	return nil, resp(http.StatusOK), nil
+}
+
+func (f *fakeAppsClient) GetLogs(_ context.Context, _ string, _ string, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return &godo.AppLogs{}, resp(http.StatusOK), nil
+}
+
+// Helper: canned godo.Response.
+func resp(status int) *godo.Response {
+	return &godo.Response{Response: &http.Response{StatusCode: status}}
+}
+
+// --- inMemoryState: minimal state-round-trip store ---
+
+type inMemoryState struct {
+	resources map[string]interfaces.ResourceState // keyed by Name
+}
+
+func newInMemoryState() *inMemoryState {
+	return &inMemoryState{resources: map[string]interfaces.ResourceState{}}
+}
+
+func (s *inMemoryState) get(name string) (interfaces.ResourceState, bool) {
+	r, ok := s.resources[name]
+	return r, ok
+}
+
+func (s *inMemoryState) put(r interfaces.ResourceState) {
+	s.resources[r.Name] = r
+}
+
+// --- applySim: mimic wfctl's apply→persist flow for tests ---
+
+// applySim simulates the wfctl Apply pattern: for a spec, either Create (if
+// no state) or Update (if state has ProviderID), then persist the returned
+// ResourceOutput to the in-memory state.
+func applySim(t *testing.T, ctx context.Context, driver *AppPlatformDriver, state *inMemoryState, spec interfaces.ResourceSpec) interfaces.ResourceState {
+	t.Helper()
+
+	existing, have := state.get(spec.Name)
+	var out *interfaces.ResourceOutput
+	var err error
+	if !have {
+		out, err = driver.Create(ctx, spec)
+	} else {
+		ref := interfaces.ResourceRef{
+			Name:       existing.Name,
+			Type:       existing.Type,
+			ProviderID: existing.ProviderID,
+		}
+		out, err = driver.Update(ctx, ref, spec)
+	}
+	if err != nil {
+		t.Fatalf("applySim: %v", err)
+	}
+
+	rs := interfaces.ResourceState{
+		ID:         spec.Name,
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: out.ProviderID, // ← the field under test
+		Outputs:    out.Outputs,
+		UpdatedAt:  time.Now().UTC(),
+	}
+	state.put(rs)
+	return rs
+}
+
+// newTestDriver returns an AppPlatformDriver wired to a fakeAppsClient + default region.
+func newTestDriver(t *testing.T) (*AppPlatformDriver, *fakeAppsClient) {
+	t.Helper()
+	client := newFakeAppsClient()
+	return &AppPlatformDriver{client: client, region: "nyc3"}, client
+}
+
+// helpful: tests can use `strings.Contains(logCapture.String(), "state-heal")`
+// once we add a log capture — see next task.
+var _ = strings.Contains
+```
+
+**Step 2: Run (should compile but no tests yet)**
+
+```bash
+GOWORK=off go build ./internal/drivers/... && GOWORK=off go test -race -short ./internal/drivers/...
+```
+Expected: existing tests still pass. Harness compiles.
+
+**Step 3: Commit**
+
+```bash
+git add internal/drivers/integration_test_helpers_test.go
+git commit -m "test: integration harness for AppPlatformDriver (fakeAppsClient + inMemoryState)"
+```
+
+---
+
+### Task 5: Integration tests for the state-heal behavior
+
+**Files:**
+- Create: `internal/drivers/app_platform_integration_test.go`
+
+**Step 1: Write the tests — ALL MUST FAIL or cover edge cases matching the design**
+
+Create `internal/drivers/app_platform_integration_test.go`:
+
+```go
+package drivers
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// TestAppPlatform_Create_PersistsUUIDInState asserts that Create returns a
+// ResourceOutput with the UUID from the API response (never the name), and
+// that the resulting ResourceState stored the UUID.
+func TestAppPlatform_Create_PersistsUUIDInState(t *testing.T) {
+	driver, client := newTestDriver(t)
+	client.createResp = &godo.App{
+		ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+		Spec: &godo.AppSpec{Name: "bmw-staging"},
+	}
+	state := newInMemoryState()
+
+	rs := applySim(t, context.Background(), driver, state, interfaces.ResourceSpec{
+		Name: "bmw-staging",
+		Type: "infra.app_platform",
+		Config: map[string]any{
+			"region": "nyc3",
+			"name":   "bmw-staging",
+		},
+	})
+
+	if rs.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("state.ProviderID = %q, want UUID %q", rs.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
+	}
+	if rs.ProviderID == "bmw-staging" {
+		t.Errorf("state.ProviderID is the NAME %q — regression of the v0.7.8 bug class", rs.ProviderID)
+	}
+}
+
+// TestAppPlatform_Update_UsesExistingUUID asserts that when state already
+// has a valid UUID, Update uses it directly and does NOT invoke findAppByName.
+func TestAppPlatform_Update_UsesExistingUUID(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	existing := &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}}
+	client.getByID[uuid] = existing
+	client.updateResp[uuid] = existing
+
+	state := newInMemoryState()
+	state.put(interfaces.ResourceState{
+		Name:       "bmw-staging",
+		Type:       "infra.app_platform",
+		ProviderID: uuid,
+	})
+
+	rs := applySim(t, context.Background(), driver, state, interfaces.ResourceSpec{
+		Name: "bmw-staging",
+		Type: "infra.app_platform",
+		Config: map[string]any{"region": "nyc3", "name": "bmw-staging"},
+	})
+
+	// Update called with UUID exactly once.
+	if len(client.updateCalls) != 1 || client.updateCalls[0] != uuid {
+		t.Errorf("updateCalls = %v, want exactly [%q]", client.updateCalls, uuid)
+	}
+	// List (used by findAppByName) never called.
+	if client.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal should not fire for valid UUID)", client.listCalls)
+	}
+	if rs.ProviderID != uuid {
+		t.Errorf("state.ProviderID = %q, want %q", rs.ProviderID, uuid)
+	}
+}
+
+// TestAppPlatform_Update_HealsStaleName asserts that when state has a stale
+// name-as-ProviderID, Update heals it: calls findAppByName to resolve UUID,
+// uses UUID for the API call, returns ResourceOutput with the healed UUID
+// so wfctl rewrites state.
+func TestAppPlatform_Update_HealsStaleName(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	const name = "bmw-staging"
+
+	// Seed: fakeAppsClient has the real app (UUID id). State has the NAME.
+	client.getByID[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+	client.updateResp[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+
+	state := newInMemoryState()
+	state.put(interfaces.ResourceState{
+		Name:       name,
+		Type:       "infra.app_platform",
+		ProviderID: name, // ← STALE: name substituted for UUID
+	})
+
+	// Capture WARN log so we can assert the heal fired.
+	var logBuf bytes.Buffer
+	oldOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldOut)
+
+	rs := applySim(t, context.Background(), driver, state, interfaces.ResourceSpec{
+		Name: name,
+		Type: "infra.app_platform",
+		Config: map[string]any{"region": "nyc3", "name": name},
+	})
+
+	// List (via findAppByName) called at least once during heal.
+	if client.listCalls < 1 {
+		t.Errorf("expected findAppByName to be called (listCalls ≥ 1), got %d", client.listCalls)
+	}
+	// Update called with the real UUID, not the name.
+	if len(client.updateCalls) != 1 || client.updateCalls[0] != uuid {
+		t.Errorf("updateCalls = %v, want exactly [%q]", client.updateCalls, uuid)
+	}
+	// State was rewritten with the healed UUID.
+	if rs.ProviderID != uuid {
+		t.Errorf("state.ProviderID = %q after heal, want %q", rs.ProviderID, uuid)
+	}
+	// WARN log captured.
+	if !strings.Contains(logBuf.String(), "state-heal") {
+		t.Errorf("expected WARN log containing 'state-heal', got: %q", logBuf.String())
+	}
+}
+
+// TestAppPlatform_Delete_HealsStaleName asserts the same heal on the Delete path.
+func TestAppPlatform_Delete_HealsStaleName(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	const name = "bmw-staging"
+
+	client.getByID[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+
+	err := driver.Delete(context.Background(), interfaces.ResourceRef{
+		Name:       name,
+		Type:       "infra.app_platform",
+		ProviderID: name, // stale
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// Delete called with the real UUID.
+	if len(client.deleteCalls) != 1 || client.deleteCalls[0] != uuid {
+		t.Errorf("deleteCalls = %v, want exactly [%q]", client.deleteCalls, uuid)
+	}
+	// List (via findAppByName) called during heal.
+	if client.listCalls < 1 {
+		t.Errorf("expected findAppByName to be called (listCalls ≥ 1), got %d", client.listCalls)
+	}
+}
+
+// TestAppPlatform_Update_HealFails_WhenAppNotFound asserts that when the app
+// genuinely doesn't exist by that name either, the heal returns a clear error
+// instead of silently substituting the wrong ID.
+func TestAppPlatform_Update_HealFails_WhenAppNotFound(t *testing.T) {
+	driver, _ := newTestDriver(t)
+
+	_, err := driver.Update(context.Background(), interfaces.ResourceRef{
+		Name:       "ghost-app",
+		Type:       "infra.app_platform",
+		ProviderID: "ghost-app",
+	}, interfaces.ResourceSpec{
+		Name: "ghost-app",
+		Type: "infra.app_platform",
+		Config: map[string]any{"region": "nyc3", "name": "ghost-app"},
+	})
+	if err == nil {
+		t.Fatal("expected error when heal can't find app by name, got nil")
+	}
+	if !strings.Contains(err.Error(), "state-heal") {
+		t.Errorf("expected error mentioning 'state-heal', got: %v", err)
+	}
+}
+```
+
+**Step 2: Run — test for regression first**
+
+```bash
+GOWORK=off go test -race -short ./internal/drivers/... -run TestAppPlatform_ -v
+```
+
+Expected: all 5 tests pass against the state-heal committed in Task 1. If any test fails, adjust the tested code (not the test) until they all pass.
+
+To be confident the test *would* have caught the regression, temporarily revert the heal (e.g., comment out `resolveProviderID` call in Update) and confirm `TestAppPlatform_Update_HealsStaleName` fails loudly. Restore and re-run — all green.
+
+**Step 3: Commit**
+
+```bash
+git add internal/drivers/app_platform_integration_test.go
+git commit -m "test: integration tests for app platform state-heal (bug would be caught)"
+```
+
+---
+
+### Task 6: CHANGELOG v0.7.8 update
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Step 1: Open existing CHANGELOG entry for v0.7.8 and extend**
+
+Current v0.7.8 entry covers Troubleshoot. Add a "State-heal" subsection:
+
+```markdown
+## v0.7.8 — 2026-04-24
+
+<existing Troubleshoot content>
+
+### State-heal for stale ProviderIDs
+
+- `AppPlatformDriver.Update` and `Delete` now validate the caller's
+  `ResourceRef.ProviderID` shape before hitting the DO API. When the value
+  is not a canonical UUID (e.g., legacy state that accidentally stored the
+  resource name), the driver transparently falls back to `findAppByName` to
+  resolve the real UUID, uses it for the API call, and returns
+  `ResourceOutput.ProviderID` with the healed value so `wfctl` rewrites
+  state on the next Apply.
+- A WARN log is emitted when heal fires so operators can observe drift in
+  CI output without the deploy failing.
+- New shared helper `isUUIDLike(s string) bool` in `internal/drivers/shared.go`.
+- New integration-test harness (`internal/drivers/integration_test_helpers_test.go`)
+  exercises the full Create/Update loop against a fake `godo.AppsService`
+  and in-memory state store. Pins down the "invalid uuid" regression class:
+  if the Create path ever starts persisting a name instead of a UUID, or if
+  Update stops healing stale names, the new tests fail loudly.
+- Root-cause of tonight's BMW deploy failure documented in PR #22's description.
+
+### Known follow-up (v0.7.9)
+
+- Replicate state-heal across other UUID-ID drivers (database, cache,
+  certificate, droplet, load balancer, VPC, firewall, reserved IP, API
+  gateway). Same pattern, one commit per driver, parameterized over the
+  integration-test harness.
+```
+
+**Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: CHANGELOG v0.7.8 — add state-heal + integration test section"
+```
+
+---
+
+### Task 7: Review + push + Copilot + merge approval
+
+**Files:** none (process).
+
+**Step 1: DM code-reviewer for LOCAL diff review**
+
+Send via team SendMessage:
+> PR #22 ready for LOCAL review — 6 commits on top of prior Troubleshoot work: isUUIDLike extract, state-heal commit, (optional) root-cause Create fix, integration harness, integration tests, CHANGELOG. Branch `feat/v0.7.8-troubleshoot`. Please verify: (a) tests actually would catch regression (try reverting heal to confirm), (b) no hidden scope creep.
+
+Wait for approval.
+
+**Step 2: Push**
+
+```bash
+git push origin feat/v0.7.8-troubleshoot
+```
+
+(force-push may be needed if rebase was done during Task 0; use `--force-with-lease`).
+
+**Step 3: Re-request Copilot**
+
+```bash
+gh pr edit 22 --repo GoCodeAlone/workflow-plugin-digitalocean --add-reviewer copilot-pull-request-reviewer
+```
+
+**Step 4: Wait 15+ min for Copilot; address any comments via new commits + reply-on-thread**
+
+If Copilot flags issues, address with additional commits. Never `@copilot` in comment bodies — team rule.
+
+**Step 5: DM team-lead when ready for merge**
+
+Send via team SendMessage:
+> PR #22 ready for merge — all Copilot threads addressed, CI green, v0.7.8 scope complete (Troubleshoot + state-heal + integration tests).
+
+---
+
+### Task 8: Tag v0.7.8 (team-lead action)
+
+**Files:** none.
+
+**Step 1: After PR merges, team-lead:**
+
+```bash
+cd /Users/jon/workspace/workflow-plugin-digitalocean
+git checkout main && git pull
+git log --oneline -3 # verify merge commit
+git tag -a v0.7.8 -m "v0.7.8: Troubleshoot interface + AppPlatform state-heal + integration tests"
+git push origin v0.7.8
+```
+
+**Step 2: Verify release workflow fires**
+
+```bash
+gh run list --repo GoCodeAlone/workflow-plugin-digitalocean --workflow=Release --limit 1
+```
+
+**Step 3: After release assets publish, file the v0.7.9 follow-up task**
+
+TaskCreate:
+```
+subject: DO plugin v0.7.9 — replicate state-heal across remaining UUID drivers
+description: Generalize v0.7.8's AppPlatformDriver state-heal pattern to database, cache, certificate, droplet, load_balancer, vpc, firewall, reserved_ip, and api_gateway drivers. Each needs its own findByName-style helper (most have one from task #21 v0.7.3). Parameterize the integration-test harness to cover each driver with the same 5-test matrix (Create persists UUID, Update uses valid UUID, Update heals stale name, Delete heals stale name, Update fails clearly when app not found). Non-goals: DNS driver (uses domain name, not UUID).
+```
+
+---
+
+## Dependency summary
+
+```
+Task 1, 2 (shared helper + commit heal)  ─────┐
+Task 3 (root-cause)                       ────┼──► Task 7 (PR review cycle) ──► Task 8 (tag)
+Task 4, 5 (harness + integration tests)   ────┤
+Task 6 (CHANGELOG)                        ────┘
+
+Task 0 (go.mod bump to v0.18.10.1) — parallel to Tasks 1-6, committed before push.
+```
+
+## Success criteria
+
+- All 5 integration tests pass on the final HEAD.
+- Temporarily reverting the heal makes `TestAppPlatform_Update_HealsStaleName` fail — proving the test catches the regression.
+- `go test -race -short ./...` clean at merge time.
+- CHANGELOG v0.7.8 reflects both Troubleshoot and state-heal deliverables.
+- After v0.7.8 tags + BMW bumps pins, BMW deploy retries on the stale-state env, heal fires silently, deploy completes.
+
+## Non-goals (explicit)
+
+- wfctl-core generic `ValidateProviderID` hook — deferred; each driver owns its heal since ID format varies per provider.
+- Other DO drivers' heal — task #69 follow-up for v0.7.9.
+- `wfctl infra heal` command — not needed once driver-level heal exists.
+- Retroactive state-file repair tool — first Update on stale state heals transparently; no offline tool needed.
+- AWS / GCP / Azure replication — each provider's plugin audits its own drivers in its own repo.

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.18.6
+	github.com/GoCodeAlone/workflow v0.18.10
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
 	github.com/digitalocean/godo v1.178.0
 	golang.org/x/oauth2 v0.36.0
+	google.golang.org/grpc v1.80.0
 )
 
 require (
@@ -218,7 +219,6 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260406210006-6f92a3bedf2d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260406210006-6f92a3bedf2d // indirect
-	google.golang.org/grpc v1.80.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.70.0 // indirect
@@ -226,5 +226,3 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.47.0 // indirect
 )
-
-replace github.com/GoCodeAlone/workflow => ../workflow

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.18.10
+	github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.mod
+++ b/go.mod
@@ -226,3 +226,5 @@ require (
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.47.0 // indirect
 )
+
+replace github.com/GoCodeAlone/workflow => ../workflow

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
+github.com/GoCodeAlone/workflow v0.18.10 h1:NimMy9KAbetm3tRVL5GbMkfvl7I63knwa2Thq15c2Nc=
+github.com/GoCodeAlone/workflow v0.18.10/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,6 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.18.6 h1:SmwU9cscZ/lMzNrdDXS+k7ivvWSRp0GYNR8Ljs8ney4=
-github.com/GoCodeAlone/workflow v0.18.6/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.18.10 h1:NimMy9KAbetm3tRVL5GbMkfvl7I63knwa2Thq15c2Nc=
-github.com/GoCodeAlone/workflow v0.18.10/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
+github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08 h1:NE32kfrXMJ5rx3nh6FxH3Er7cJYvJKYmKF+oMmoVc4I=
+github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -241,7 +241,7 @@ func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.Res
 	if app == nil {
 		return nil, nil
 	}
-	hist, _, _ := d.client.ListDeployments(ctx, ref.ProviderID, &godo.ListOptions{PerPage: troubleshootMaxDeployments})
+	hist, _, _ := d.client.ListDeployments(ctx, ref.ProviderID, &godo.ListOptions{Page: 1, PerPage: troubleshootMaxDeployments})
 	candidates := pickTroubleshootDeployments(app, hist)
 	if len(candidates) == 0 {
 		return nil, nil
@@ -257,8 +257,8 @@ func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.Res
 
 // pickTroubleshootDeployments returns up to 3 candidate deployments in priority
 // order: InProgress > Pending > Active, followed by unique historical entries.
-// The active-deployment slot is included only when the other two are absent,
-// since an active-and-healthy deployment seldom needs troubleshooting.
+// All three deployment slots (InProgress, Pending, Active) are collected in
+// priority order; historical deployments fill remaining capacity up to 3 total.
 func pickTroubleshootDeployments(app *godo.App, historical []*godo.Deployment) []*godo.Deployment {
 	seen := map[string]bool{}
 	var result []*godo.Deployment

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -250,7 +250,8 @@ func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRe
 }
 
 // troubleshootMaxDeployments is the maximum number of recent historical
-// deployments fetched by Troubleshoot beyond the active/in-progress slots.
+// deployments fetched by Troubleshoot (slot-based candidates are always
+// included; this cap applies separately to the historical listing pass).
 const troubleshootMaxDeployments = 5
 
 // Troubleshoot implements interfaces.Troubleshooter for AppPlatformDriver.

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -22,6 +22,7 @@ type AppPlatformClient interface {
 	List(ctx context.Context, opts *godo.ListOptions) ([]*godo.App, *godo.Response, error)
 	Update(ctx context.Context, appID string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error)
 	CreateDeployment(ctx context.Context, appID string, req ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error)
+	ListDeployments(ctx context.Context, appID string, opts *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error)
 	Delete(ctx context.Context, appID string) (*godo.Response, error)
 }
 
@@ -218,6 +219,44 @@ func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRe
 		return nil, fmt.Errorf("app platform scale update %q: %w", ref.Name, WrapGodoError(err))
 	}
 	return appOutput(updated), nil
+}
+
+// troubleshootMaxDeployments is the maximum number of recent deployments fetched
+// by Troubleshoot to avoid overwhelming the output.
+const troubleshootMaxDeployments = 5
+
+// Troubleshoot implements interfaces.Troubleshooter for AppPlatformDriver.
+// It fetches the most recent deployments for the app and returns them as
+// Diagnostics so wfctl can print a structured failure block on health-check
+// timeout without requiring the user to visit the DO console.
+func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.ResourceRef, _ string) ([]interfaces.Diagnostic, error) {
+	if ref.ProviderID == "" {
+		return nil, fmt.Errorf("app platform troubleshoot %q: no ProviderID available", ref.Name)
+	}
+	deps, _, err := d.client.ListDeployments(ctx, ref.ProviderID, &godo.ListOptions{PerPage: troubleshootMaxDeployments})
+	if err != nil {
+		return nil, fmt.Errorf("app platform list deployments %q: %w", ref.Name, WrapGodoError(err))
+	}
+	diags := make([]interfaces.Diagnostic, 0, len(deps))
+	for _, dep := range deps {
+		cause := dep.Cause
+		// Surface the first non-empty error step message when cause is empty.
+		if cause == "" && dep.Progress != nil {
+			for _, step := range dep.Progress.Steps {
+				if step.Status == godo.DeploymentProgressStepStatus_Error && step.Reason != nil && step.Reason.Message != "" {
+					cause = step.Reason.Message
+					break
+				}
+			}
+		}
+		diags = append(diags, interfaces.Diagnostic{
+			ID:    dep.ID,
+			Phase: string(dep.Phase),
+			Cause: cause,
+			At:    dep.CreatedAt,
+		})
+	}
+	return diags, nil
 }
 
 func appOutput(app *godo.App) *interfaces.ResourceOutput {

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -102,6 +103,11 @@ func (d *AppPlatformDriver) findAppByName(ctx context.Context, name string) (*in
 }
 
 func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+
 	region, _ := spec.Config["region"].(string)
 	if region == "" {
 		region = d.region
@@ -111,12 +117,12 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 		return nil, fmt.Errorf("app platform build spec: %w", err)
 	}
 
-	app, _, err := d.client.Update(ctx, ref.ProviderID, &godo.AppUpdateRequest{Spec: appSpec})
+	app, _, err := d.client.Update(ctx, providerID, &godo.AppUpdateRequest{Spec: appSpec})
 	if err != nil {
 		return nil, fmt.Errorf("app platform update %q: %w", ref.Name, WrapGodoError(err))
 	}
 	// Trigger a new deployment — Update only changes the spec; DO does not auto-deploy.
-	dep, _, err := d.client.CreateDeployment(ctx, ref.ProviderID, &godo.DeploymentCreateRequest{ForceBuild: true})
+	dep, _, err := d.client.CreateDeployment(ctx, providerID, &godo.DeploymentCreateRequest{ForceBuild: true})
 	if err != nil {
 		return nil, fmt.Errorf("app platform create deployment %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -125,11 +131,39 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 }
 
 func (d *AppPlatformDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("app platform delete %q: %w", ref.Name, WrapGodoError(err))
 	}
 	return nil
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref.
+// If ref.ProviderID is already a valid UUID it is returned as-is.
+// If it looks like a name (legacy stale state), a name-based lookup is
+// performed and the real UUID is returned so callers never send a non-UUID
+// path parameter to the DO API.
+func (d *AppPlatformDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: app platform %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findAppByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("app platform state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
+// isUUIDLike returns true when s has the canonical UUID shape:
+// 36 characters with hyphens at positions 8, 13, 18, and 23.
+func isUUIDLike(s string) bool {
+	return len(s) == 36 && s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
 }
 
 func (d *AppPlatformDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -221,42 +221,145 @@ func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRe
 	return appOutput(updated), nil
 }
 
-// troubleshootMaxDeployments is the maximum number of recent deployments fetched
-// by Troubleshoot to avoid overwhelming the output.
+// troubleshootMaxDeployments is the maximum number of recent historical
+// deployments fetched by Troubleshoot beyond the active/in-progress slots.
 const troubleshootMaxDeployments = 5
 
 // Troubleshoot implements interfaces.Troubleshooter for AppPlatformDriver.
-// It fetches the most recent deployments for the app and returns them as
-// Diagnostics so wfctl can print a structured failure block on health-check
-// timeout without requiring the user to visit the DO console.
+// It fetches the app (to inspect its three deployment slots: InProgress,
+// Pending, Active) plus recent historical deployments, prioritises them, and
+// returns per-deployment Diagnostics so wfctl can render a structured failure
+// block on health-check timeout without requiring a DO console visit.
 func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.ResourceRef, _ string) ([]interfaces.Diagnostic, error) {
 	if ref.ProviderID == "" {
-		return nil, fmt.Errorf("app platform troubleshoot %q: no ProviderID available", ref.Name)
+		return nil, nil
 	}
-	deps, _, err := d.client.ListDeployments(ctx, ref.ProviderID, &godo.ListOptions{PerPage: troubleshootMaxDeployments})
+	app, _, err := d.client.Get(ctx, ref.ProviderID)
 	if err != nil {
-		return nil, fmt.Errorf("app platform list deployments %q: %w", ref.Name, WrapGodoError(err))
+		return nil, fmt.Errorf("troubleshoot: get app %q: %w", ref.Name, WrapGodoError(err))
 	}
-	diags := make([]interfaces.Diagnostic, 0, len(deps))
-	for _, dep := range deps {
-		cause := dep.Cause
-		// Surface the first non-empty error step message when cause is empty.
-		if cause == "" && dep.Progress != nil {
-			for _, step := range dep.Progress.Steps {
-				if step.Status == godo.DeploymentProgressStepStatus_Error && step.Reason != nil && step.Reason.Message != "" {
-					cause = step.Reason.Message
-					break
+	if app == nil {
+		return nil, nil
+	}
+	hist, _, _ := d.client.ListDeployments(ctx, ref.ProviderID, &godo.ListOptions{PerPage: troubleshootMaxDeployments})
+	candidates := pickTroubleshootDeployments(app, hist)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+	var out []interfaces.Diagnostic
+	for _, dep := range candidates {
+		if diag := buildDiagnosticFor(dep); diag != nil {
+			out = append(out, *diag)
+		}
+	}
+	return out, nil
+}
+
+// pickTroubleshootDeployments returns up to 3 candidate deployments in priority
+// order: InProgress > Pending > Active, followed by unique historical entries.
+// The active-deployment slot is included only when the other two are absent,
+// since an active-and-healthy deployment seldom needs troubleshooting.
+func pickTroubleshootDeployments(app *godo.App, historical []*godo.Deployment) []*godo.Deployment {
+	seen := map[string]bool{}
+	var result []*godo.Deployment
+	add := func(dep *godo.Deployment) {
+		if dep == nil || dep.ID == "" || seen[dep.ID] {
+			return
+		}
+		seen[dep.ID] = true
+		result = append(result, dep)
+	}
+	add(app.InProgressDeployment)
+	add(app.PendingDeployment)
+	add(app.ActiveDeployment)
+	for _, dep := range historical {
+		if len(result) >= 3 {
+			break
+		}
+		add(dep)
+	}
+	return result
+}
+
+// buildDiagnosticFor synthesises a Diagnostic from a single deployment's state.
+// It scans Progress.SummarySteps for a failed phase name (e.g. "pre_deploy",
+// "build") first, then falls back to leaf Progress.Steps, and finally to the
+// deployment-level Cause field.
+// Returns nil when there is nothing actionable to report (active/healthy).
+func buildDiagnosticFor(dep *godo.Deployment) *interfaces.Diagnostic {
+	cause, phase := deploymentCauseAndPhase(dep)
+	if cause == "" {
+		return nil
+	}
+	return &interfaces.Diagnostic{
+		ID:    dep.ID,
+		Phase: phase,
+		Cause: cause,
+		At:    dep.CreatedAt,
+	}
+}
+
+// deploymentCauseAndPhase extracts the most actionable (cause, phase) pair.
+// Priority: SummarySteps error > Steps error > dep.Cause > terminal phase.
+func deploymentCauseAndPhase(dep *godo.Deployment) (cause, phase string) {
+	if dep.Progress != nil {
+		// SummarySteps carry DO's high-level phase names ("pre_deploy", "build", …).
+		for _, step := range dep.Progress.SummarySteps {
+			if step.Status == godo.DeploymentProgressStepStatus_Error {
+				msg := ""
+				if step.Reason != nil {
+					msg = step.Reason.Message
+				}
+				if msg == "" {
+					msg = dep.Cause
+				}
+				if msg != "" {
+					return extractCause(msg), step.Name
 				}
 			}
 		}
-		diags = append(diags, interfaces.Diagnostic{
-			ID:    dep.ID,
-			Phase: string(dep.Phase),
-			Cause: cause,
-			At:    dep.CreatedAt,
-		})
+		// Fall back to leaf-level steps.
+		for _, step := range dep.Progress.Steps {
+			if step.Status == godo.DeploymentProgressStepStatus_Error &&
+				step.Reason != nil && step.Reason.Message != "" {
+				return extractCause(step.Reason.Message), string(dep.Phase)
+			}
+		}
 	}
-	return diags, nil
+	if dep.Cause != "" {
+		return dep.Cause, string(dep.Phase)
+	}
+	// Report explicitly terminal phases even without a message.
+	switch dep.Phase {
+	case godo.DeploymentPhase_Error, godo.DeploymentPhase_Canceled:
+		return string(dep.Phase), string(dep.Phase)
+	}
+	return "", ""
+}
+
+// extractCause scans a log tail (or a short message) for common error
+// patterns and returns the first matching line. Falls back to the last
+// non-empty line when no pattern matches.
+func extractCause(tail string) string {
+	patterns := []string{
+		"Error:", "error:", "exit status", "exit code",
+		"failed to", "panic:", "fatal:", "FATAL",
+	}
+	for _, line := range strings.Split(tail, "\n") {
+		for _, p := range patterns {
+			if strings.Contains(line, p) {
+				return strings.TrimSpace(line)
+			}
+		}
+	}
+	// Fallback: last non-empty line.
+	lines := strings.Split(strings.TrimRight(tail, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(lines[i]); s != "" {
+			return s
+		}
+	}
+	return ""
 }
 
 func appOutput(app *godo.App) *interfaces.ResourceOutput {

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -160,12 +160,6 @@ func (d *AppPlatformDriver) resolveProviderID(ctx context.Context, ref interface
 	return out.ProviderID, nil
 }
 
-// isUUIDLike returns true when s has the canonical UUID shape:
-// 36 characters with hyphens at positions 8, 13, 18, and 23.
-func isUUIDLike(s string) bool {
-	return len(s) == 36 && s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
-}
-
 func (d *AppPlatformDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
 	if current == nil {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -32,7 +32,7 @@ func buildSpecViaUpdate(t *testing.T, cfg map[string]any) *godo.AppSpec {
 	t.Helper()
 	mock := &mockAppClient{app: testApp()}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
-	_, err := d.Update(t.Context(), interfaces.ResourceRef{Name: "test-app", ProviderID: "app-1"},
+	_, err := d.Update(t.Context(), interfaces.ResourceRef{Name: "test-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"},
 		interfaces.ResourceSpec{Name: "test-app", Config: cfg})
 	if err != nil {
 		t.Fatalf("Update: %v", err)

--- a/internal/drivers/app_platform_integration_test.go
+++ b/internal/drivers/app_platform_integration_test.go
@@ -1,0 +1,163 @@
+package drivers
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// bmwSpec is a minimal valid ResourceSpec that mirrors BMW staging config.
+func bmwSpec(name string) interfaces.ResourceSpec {
+	return interfaces.ResourceSpec{
+		Name: name,
+		Type: "infra.app_platform",
+		Config: map[string]any{
+			"region": "nyc3",
+			"image":  "docker.io/myorg/bmw:latest",
+		},
+	}
+}
+
+// TestAppPlatform_Create_PersistsUUIDInState asserts that Create returns a
+// ResourceOutput with the UUID from the API response (never the name), and
+// that the resulting ResourceState stores the UUID — not the spec name.
+func TestAppPlatform_Create_PersistsUUIDInState(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	client.createResp = &godo.App{
+		ID:   wantUUID,
+		Spec: &godo.AppSpec{Name: "bmw-staging"},
+	}
+	state := newInMemoryState()
+
+	rs := applySim(t, context.Background(), driver, state, bmwSpec("bmw-staging"))
+
+	if rs.ProviderID != wantUUID {
+		t.Errorf("state.ProviderID = %q, want UUID %q", rs.ProviderID, wantUUID)
+	}
+	if rs.ProviderID == "bmw-staging" {
+		t.Errorf("state.ProviderID is the spec NAME — regression of the v0.7.8 bug class")
+	}
+}
+
+// TestAppPlatform_Update_UsesExistingUUID asserts that when state already
+// has a valid UUID, Update uses it directly without invoking findAppByName.
+func TestAppPlatform_Update_UsesExistingUUID(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	existing := &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}}
+	client.getByID[uuid] = existing
+	client.updateResp[uuid] = existing
+
+	state := newInMemoryState()
+	state.put(interfaces.ResourceState{
+		Name: "bmw-staging", Type: "infra.app_platform", ProviderID: uuid,
+	})
+
+	rs := applySim(t, context.Background(), driver, state, bmwSpec("bmw-staging"))
+
+	// Update called with UUID exactly once.
+	if len(client.updateCalls) != 1 || client.updateCalls[0] != uuid {
+		t.Errorf("updateCalls = %v, want exactly [%q]", client.updateCalls, uuid)
+	}
+	// List (used by findAppByName) must never be called.
+	if client.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", client.listCalls)
+	}
+	if rs.ProviderID != uuid {
+		t.Errorf("state.ProviderID = %q, want %q", rs.ProviderID, uuid)
+	}
+}
+
+// TestAppPlatform_Update_HealsStaleName is the core regression test.
+// It seeds state with ProviderID="bmw-staging" (the stale shape that caused
+// BMW deploy 24901939350 to fail), calls applySim, and asserts:
+//   - findAppByName was invoked (listCalls ≥ 1)
+//   - Update API call used the UUID, not the name
+//   - Returned ResourceState has the healed UUID
+//   - WARN log was emitted containing "state-heal"
+func TestAppPlatform_Update_HealsStaleName(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	const name = "bmw-staging"
+
+	client.getByID[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+	client.updateResp[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+
+	state := newInMemoryState()
+	state.put(interfaces.ResourceState{
+		Name:       name,
+		Type:       "infra.app_platform",
+		ProviderID: name, // ← STALE: name substituted for UUID
+	})
+
+	// Capture WARN log.
+	var logBuf bytes.Buffer
+	oldOut := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(oldOut)
+
+	rs := applySim(t, context.Background(), driver, state, bmwSpec(name))
+
+	// findAppByName must have been called.
+	if client.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (findAppByName must fire during heal)", client.listCalls)
+	}
+	// Update must use the real UUID, not the stale name.
+	if len(client.updateCalls) != 1 || client.updateCalls[0] != uuid {
+		t.Errorf("updateCalls = %v, want exactly [%q]", client.updateCalls, uuid)
+	}
+	// State is rewritten with the healed UUID.
+	if rs.ProviderID != uuid {
+		t.Errorf("state.ProviderID = %q after heal, want %q", rs.ProviderID, uuid)
+	}
+	// WARN log captured.
+	if !strings.Contains(logBuf.String(), "state-heal") {
+		t.Errorf("expected WARN log containing 'state-heal', got: %q", logBuf.String())
+	}
+}
+
+// TestAppPlatform_Delete_HealsStaleName asserts the same heal on the Delete path.
+func TestAppPlatform_Delete_HealsStaleName(t *testing.T) {
+	driver, client := newTestDriver(t)
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	const name = "bmw-staging"
+
+	client.getByID[uuid] = &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: name}}
+
+	err := driver.Delete(context.Background(), interfaces.ResourceRef{
+		Name: name, Type: "infra.app_platform", ProviderID: name,
+	})
+	if err != nil {
+		t.Fatalf("Delete with stale name: %v", err)
+	}
+	if len(client.deleteCalls) != 1 || client.deleteCalls[0] != uuid {
+		t.Errorf("deleteCalls = %v, want exactly [%q]", client.deleteCalls, uuid)
+	}
+	if client.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (findAppByName must fire during heal)", client.listCalls)
+	}
+}
+
+// TestAppPlatform_Update_HealFails_WhenAppNotFound asserts that a clear error
+// is returned when the stale name can't be resolved — never sending the name
+// as a path parameter to the DO API.
+func TestAppPlatform_Update_HealFails_WhenAppNotFound(t *testing.T) {
+	driver, _ := newTestDriver(t)
+
+	_, err := driver.Update(context.Background(),
+		interfaces.ResourceRef{Name: "ghost-app", Type: "infra.app_platform", ProviderID: "ghost-app"},
+		bmwSpec("ghost-app"),
+	)
+	if err == nil {
+		t.Fatal("expected error when heal can't find app by name, got nil")
+	}
+	if !strings.Contains(err.Error(), "state-heal") {
+		t.Errorf("expected error mentioning 'state-heal', got: %v", err)
+	}
+}

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -1,0 +1,246 @@
+package drivers
+
+// State-heal tests for AppPlatformDriver.Update / Delete / isUUIDLike.
+// Uses package drivers (not drivers_test) so unexported helpers are accessible.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// ── mock client for state-heal tests ─────────────────────────────────────────
+
+type stateHealClient struct {
+	// Create
+	createApp *godo.App
+	createErr error
+
+	// List (for findAppByName)
+	listApps []*godo.App
+	listErr  error
+
+	// Update captures the appID it was called with and returns updatedApp.
+	updatedApp     *godo.App
+	updateErr      error
+	updateCalledID string
+
+	// CreateDeployment returns dep or depErr.
+	dep    *godo.Deployment
+	depErr error
+
+	// Delete captures the appID it was called with.
+	deleteCalledID string
+	deleteErr      error
+}
+
+func (c *stateHealClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return c.createApp, &godo.Response{Response: &http.Response{StatusCode: 200}}, c.createErr
+}
+func (c *stateHealClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in stateHealClient")
+}
+func (c *stateHealClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	resp := &godo.Response{Response: &http.Response{StatusCode: 200}, Links: &godo.Links{}}
+	return c.listApps, resp, c.listErr
+}
+func (c *stateHealClient) Update(_ context.Context, appID string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	c.updateCalledID = appID
+	return c.updatedApp, &godo.Response{Response: &http.Response{StatusCode: 200}}, c.updateErr
+}
+func (c *stateHealClient) CreateDeployment(_ context.Context, _ string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	if c.depErr != nil {
+		return nil, nil, c.depErr
+	}
+	if c.dep == nil {
+		return &godo.Deployment{ID: "dep-triggered"}, &godo.Response{}, nil
+	}
+	return c.dep, &godo.Response{}, nil
+}
+func (c *stateHealClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return nil, &godo.Response{}, nil
+}
+func (c *stateHealClient) Delete(_ context.Context, appID string) (*godo.Response, error) {
+	c.deleteCalledID = appID
+	return &godo.Response{Response: &http.Response{StatusCode: 204}}, c.deleteErr
+}
+
+// ── isUUIDLike tests ──────────────────────────────────────────────────────────
+
+func TestIsUUIDLike_TableDriven(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", true},
+		{"00000000-0000-0000-0000-000000000000", true},
+		{"bmw-staging", false},
+		{"", false},
+		{"f8b6200c3bba48a78bf17a3e3a885eb5", false},   // no hyphens
+		{"f8b6200c-3bba-48a7-8bf1", false},             // too short
+		{"f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5-xx", false}, // too long
+		{"f8b6200c_3bba_48a7_8bf1_7a3e3a885eb5", false}, // wrong separator
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got := isUUIDLike(c.in)
+			if got != c.want {
+				t.Errorf("isUUIDLike(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// ── Create preserves UUID (regression: name must not be used as ProviderID) ──
+
+func TestCreate_ProviderIDIsUUIDFromAPI(t *testing.T) {
+	// API returns an app with a real UUID. ProviderID in the returned
+	// ResourceOutput must equal that UUID, not the spec name.
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		createApp: &godo.App{
+			ID:   wantUUID,
+			Spec: &godo.AppSpec{Name: "bmw-staging"},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	spec := interfaces.ResourceSpec{
+		Name:   "bmw-staging",
+		Config: map[string]any{"image": "docker.io/myorg/myapp:latest"},
+	}
+	out, err := d.Create(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "bmw-staging" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update state-heal tests ──────────────────────────────────────────────────
+
+func TestUpdate_UsesUUIDWhenProviderIDIsValid(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		updatedApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "bmw-staging"},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: uuid}
+	spec := interfaces.ResourceSpec{
+		Name:   "bmw-staging",
+		Config: map[string]any{"image": "docker.io/myorg/myapp:latest"},
+	}
+	_, err := d.Update(context.Background(), ref, spec)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if c.updateCalledID != uuid {
+		t.Errorf("Update called with ID %q, want UUID %q", c.updateCalledID, uuid)
+	}
+	// findAppByName should NOT have been called (List should not have been invoked).
+	if len(c.listApps) != 0 && c.updateCalledID != uuid {
+		t.Error("findAppByName should not be called when ProviderID is already a UUID")
+	}
+}
+
+func TestUpdate_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		// List returns the real app so findAppByName resolves name → UUID.
+		listApps: []*godo.App{
+			{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		},
+		updatedApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "bmw-staging"},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	// Stale state: ProviderID is the name, not a UUID.
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"}
+	spec := interfaces.ResourceSpec{
+		Name:   "bmw-staging",
+		Config: map[string]any{"image": "docker.io/myorg/myapp:latest"},
+	}
+	out, err := d.Update(context.Background(), ref, spec)
+	if err != nil {
+		t.Fatalf("Update with stale name ProviderID: %v", err)
+	}
+	// Update API must have been called with the UUID, not the name.
+	if c.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q (state-heal failed)", c.updateCalledID, uuid)
+	}
+	// Returned output must carry the healed UUID.
+	if out.ProviderID != uuid {
+		t.Errorf("ResourceOutput.ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestUpdate_HealStaleName_LookupFails(t *testing.T) {
+	// findAppByName fails — Update must propagate the error rather than
+	// silently using the stale name as a path parameter.
+	c := &stateHealClient{
+		listErr: errors.New("api unavailable"),
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"}
+	spec := interfaces.ResourceSpec{
+		Name:   "bmw-staging",
+		Config: map[string]any{"image": "docker.io/myorg/myapp:latest"},
+	}
+	_, err := d.Update(context.Background(), ref, spec)
+	if err == nil {
+		t.Fatal("expected error when name lookup fails, got nil")
+	}
+}
+
+// ── Delete state-heal tests ──────────────────────────────────────────────────
+
+func TestDelete_UsesUUIDWhenProviderIDIsValid(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: uuid}
+	if err := d.Delete(context.Background(), ref); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if c.deleteCalledID != uuid {
+		t.Errorf("Delete called with ID %q, want UUID %q", c.deleteCalledID, uuid)
+	}
+}
+
+func TestDelete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		listApps: []*godo.App{
+			{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"}
+	if err := d.Delete(context.Background(), ref); err != nil {
+		t.Fatalf("Delete with stale name ProviderID: %v", err)
+	}
+	if c.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q (state-heal failed)", c.deleteCalledID, uuid)
+	}
+}
+
+func TestDelete_HealStaleName_LookupFails(t *testing.T) {
+	c := &stateHealClient{listErr: errors.New("api unavailable")}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"}
+	if err := d.Delete(context.Background(), ref); err == nil {
+		t.Fatal("expected error when name lookup fails, got nil")
+	}
+}

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -21,8 +21,9 @@ type stateHealClient struct {
 	createErr error
 
 	// List (for findAppByName)
-	listApps []*godo.App
-	listErr  error
+	listApps  []*godo.App
+	listErr   error
+	listCalls int // incremented on every List invocation
 
 	// Update captures the appID it was called with and returns updatedApp.
 	updatedApp     *godo.App
@@ -45,6 +46,7 @@ func (c *stateHealClient) Get(_ context.Context, _ string) (*godo.App, *godo.Res
 	return nil, nil, errors.New("not implemented in stateHealClient")
 }
 func (c *stateHealClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	c.listCalls++
 	resp := &godo.Response{Response: &http.Response{StatusCode: 200}, Links: &godo.Links{}}
 	return c.listApps, resp, c.listErr
 }
@@ -121,9 +123,9 @@ func TestUpdate_UsesUUIDWhenProviderIDIsValid(t *testing.T) {
 	if c.updateCalledID != uuid {
 		t.Errorf("Update called with ID %q, want UUID %q", c.updateCalledID, uuid)
 	}
-	// findAppByName should NOT have been called (List should not have been invoked).
-	if len(c.listApps) != 0 && c.updateCalledID != uuid {
-		t.Error("findAppByName should not be called when ProviderID is already a UUID")
+	// findAppByName must NOT fire when ProviderID is already a valid UUID.
+	if c.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", c.listCalls)
 	}
 }
 
@@ -149,6 +151,10 @@ func TestUpdate_HealsStaleName(t *testing.T) {
 	out, err := d.Update(context.Background(), ref, spec)
 	if err != nil {
 		t.Fatalf("Update with stale name ProviderID: %v", err)
+	}
+	// findAppByName must have fired (List called at least once).
+	if c.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (findAppByName must fire during heal)", c.listCalls)
 	}
 	// Update API must have been called with the UUID, not the name.
 	if c.updateCalledID != uuid {

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -69,32 +69,6 @@ func (c *stateHealClient) Delete(_ context.Context, appID string) (*godo.Respons
 	return &godo.Response{Response: &http.Response{StatusCode: 204}}, c.deleteErr
 }
 
-// ── isUUIDLike tests ──────────────────────────────────────────────────────────
-
-func TestIsUUIDLike_TableDriven(t *testing.T) {
-	cases := []struct {
-		in   string
-		want bool
-	}{
-		{"f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", true},
-		{"00000000-0000-0000-0000-000000000000", true},
-		{"bmw-staging", false},
-		{"", false},
-		{"f8b6200c3bba48a78bf17a3e3a885eb5", false},   // no hyphens
-		{"f8b6200c-3bba-48a7-8bf1", false},             // too short
-		{"f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5-xx", false}, // too long
-		{"f8b6200c_3bba_48a7_8bf1_7a3e3a885eb5", false}, // wrong separator
-	}
-	for _, c := range cases {
-		t.Run(c.in, func(t *testing.T) {
-			got := isUUIDLike(c.in)
-			if got != c.want {
-				t.Errorf("isUUIDLike(%q) = %v, want %v", c.in, got, c.want)
-			}
-		})
-	}
-}
-
 // ── Create preserves UUID (regression: name must not be used as ProviderID) ──
 
 func TestCreate_ProviderIDIsUUIDFromAPI(t *testing.T) {

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -26,9 +26,11 @@ func makeGodoErr(statusCode int) error {
 type mockAppClient struct {
 	app                    *godo.App
 	err                    error
-	listApps               []*godo.App // returned by List
-	listErr                error       // error returned by List
-	createDeploymentErr    error       // error returned by CreateDeployment
+	listApps               []*godo.App       // returned by List
+	listErr                error             // error returned by List
+	deployments            []*godo.Deployment // returned by ListDeployments
+	listDeploymentsErr     error             // error returned by ListDeployments
+	createDeploymentErr    error             // error returned by CreateDeployment
 	createDeploymentCalled bool
 	lastCreateDeployReq    *godo.DeploymentCreateRequest
 	lastCreateReq          *godo.AppCreateRequest
@@ -55,6 +57,9 @@ func (m *mockAppClient) CreateDeployment(_ context.Context, _ string, reqs ...*g
 		m.lastCreateDeployReq = r
 	}
 	return &godo.Deployment{ID: "dep-1"}, nil, m.createDeploymentErr
+}
+func (m *mockAppClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return m.deployments, &godo.Response{}, m.listDeploymentsErr
 }
 func (m *mockAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, m.err
@@ -832,5 +837,61 @@ func TestAppPlatformDriver_Create_ProviderIDIsAPIAssigned(t *testing.T) {
 	}
 	if out.ProviderID == "" {
 		t.Errorf("ProviderID must not be empty")
+	}
+}
+
+func TestTroubleshoot_ReturnsDiagnostics(t *testing.T) {
+	mock := &mockAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		deployments: []*godo.Deployment{
+			{ID: "dep-abc", Phase: godo.DeploymentPhase_Error, Cause: "image pull failed"},
+			{ID: "dep-xyz", Phase: godo.DeploymentPhase_Canceled, Cause: "superseded"},
+		},
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}
+	diags, err := d.Troubleshoot(context.Background(), ref, "no deployment found")
+	if err != nil {
+		t.Fatalf("Troubleshoot: %v", err)
+	}
+	if len(diags) != 2 {
+		t.Fatalf("want 2 diagnostics, got %d", len(diags))
+	}
+	if diags[0].ID != "dep-abc" {
+		t.Errorf("diags[0].ID = %q, want %q", diags[0].ID, "dep-abc")
+	}
+	if diags[0].Cause != "image pull failed" {
+		t.Errorf("diags[0].Cause = %q, want %q", diags[0].Cause, "image pull failed")
+	}
+	if diags[0].Phase != string(godo.DeploymentPhase_Error) {
+		t.Errorf("diags[0].Phase = %q, want %q", diags[0].Phase, godo.DeploymentPhase_Error)
+	}
+}
+
+func TestTroubleshoot_NoProviderID(t *testing.T) {
+	// Empty ProviderID returns (nil, nil) — nothing to query.
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{}, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app"} // no ProviderID
+	diags, err := d.Troubleshoot(context.Background(), ref, "")
+	if err != nil {
+		t.Fatalf("expected nil error for empty ProviderID, got %v", err)
+	}
+	if diags != nil {
+		t.Fatalf("expected nil diagnostics for empty ProviderID, got %v", diags)
+	}
+}
+
+func TestTroubleshoot_APIError(t *testing.T) {
+	// ListDeployments errors are best-effort: Troubleshoot continues with
+	// whatever deployment slots the app has.
+	mock := &mockAppClient{
+		app:                &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		listDeploymentsErr: errors.New("api timeout"),
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}
+	_, err := d.Troubleshoot(context.Background(), ref, "")
+	if err != nil {
+		t.Fatalf("ListDeployments error should not propagate; got: %v", err)
 	}
 }

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -67,7 +67,7 @@ func (m *mockAppClient) Delete(_ context.Context, _ string) (*godo.Response, err
 
 func testApp() *godo.App {
 	return &godo.App{
-		ID:      "app-123",
+		ID:      "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		LiveURL: "https://test.app.example.com",
 		Spec:    &godo.AppSpec{Name: "my-app"},
 		ActiveDeployment: &godo.Deployment{
@@ -93,8 +93,8 @@ func TestAppPlatformDriver_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if out.ProviderID != "app-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 	if out.Status != "running" {
 		t.Errorf("Status = %q, want %q", out.Status, "running")
@@ -107,13 +107,13 @@ func TestAppPlatformDriver_Read(t *testing.T) {
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
 		Name:       "my-app",
-		ProviderID: "app-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if out.ProviderID != "app-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -123,7 +123,7 @@ func TestAppPlatformDriver_Delete(t *testing.T) {
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
 		Name:       "my-app",
-		ProviderID: "app-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -136,7 +136,7 @@ func TestAppPlatformDriver_HealthCheck(t *testing.T) {
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
 		Name:       "my-app",
-		ProviderID: "app-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -164,7 +164,7 @@ func TestAppPlatformDriver_Update_Success(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	out, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-app",
 		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2", "instance_count": 3},
@@ -172,8 +172,8 @@ func TestAppPlatformDriver_Update_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if out.ProviderID != "app-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -182,7 +182,7 @@ func TestAppPlatformDriver_Update_Error(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-app",
 		Config: map[string]any{},
@@ -200,7 +200,7 @@ func TestAppPlatformDriver_Update_TriggersCreateDeployment(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-app",
 		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
@@ -224,7 +224,7 @@ func TestAppPlatformDriver_Update_CreateDeploymentFails(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-app",
 		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
@@ -245,7 +245,7 @@ func TestAppPlatformDriver_Update_CreateDeploymentSentinelPropagates(t *testing.
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-app",
 		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
@@ -260,7 +260,7 @@ func TestAppPlatformDriver_Delete_Error(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -361,7 +361,7 @@ func TestAppPlatformDriver_Update_EnvVars(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name: "my-app",
 		Config: map[string]any{
@@ -405,7 +405,7 @@ func TestAppPlatformDriver_Create_NoEnvVars(t *testing.T) {
 
 func TestAppPlatformDriver_HealthCheck_Unhealthy(t *testing.T) {
 	app := &godo.App{
-		ID:   "app-123",
+		ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Spec: &godo.AppSpec{Name: "my-app"},
 		// ActiveDeployment nil => pending/unhealthy
 	}
@@ -413,7 +413,7 @@ func TestAppPlatformDriver_HealthCheck_Unhealthy(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-app", ProviderID: "app-123",
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -680,7 +680,7 @@ func TestAppPlatformDriver_Update_BuildsNestedImageSpec(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "bmw-app", ProviderID: "app-123",
+		Name: "bmw-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name: "bmw-app",
 		Config: map[string]any{
@@ -763,13 +763,13 @@ func TestAppPlatformDriver_Read_ByID_StillWorks(t *testing.T) {
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
 		Name:       "my-app",
-		ProviderID: "app-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read by ID: unexpected error: %v", err)
 	}
-	if out.ProviderID != "app-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -845,14 +845,14 @@ func TestTroubleshoot_ReturnsDiagnostics(t *testing.T) {
 	// ListDeployments. The app has no current deployment slots, so both
 	// historical error deployments should produce diagnostics.
 	mock := &mockAppClient{
-		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		app: &godo.App{ID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", Spec: &godo.AppSpec{Name: "my-app"}},
 		deployments: []*godo.Deployment{
 			{ID: "dep-abc", Phase: godo.DeploymentPhase_Error, Cause: "image pull failed"},
 			{ID: "dep-xyz", Phase: godo.DeploymentPhase_Canceled, Cause: "superseded"},
 		},
 	}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
-	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
 	diags, err := d.Troubleshoot(context.Background(), ref, "no deployment found")
 	if err != nil {
 		t.Fatalf("Troubleshoot: %v", err)
@@ -889,11 +889,11 @@ func TestTroubleshoot_APIError(t *testing.T) {
 	// whatever deployment slots the app has. If the app itself has no
 	// slots and Get returns a valid app, result is empty (not an error).
 	mock := &mockAppClient{
-		app:                &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		app:                &godo.App{ID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", Spec: &godo.AppSpec{Name: "my-app"}},
 		listDeploymentsErr: errors.New("api timeout"),
 	}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
-	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
 	_, err := d.Troubleshoot(context.Background(), ref, "")
 	if err != nil {
 		t.Fatalf("ListDeployments error should not propagate; got: %v", err)

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -841,6 +841,9 @@ func TestAppPlatformDriver_Create_ProviderIDIsAPIAssigned(t *testing.T) {
 }
 
 func TestTroubleshoot_ReturnsDiagnostics(t *testing.T) {
+	// Troubleshoot calls client.Get first; historical deployments come from
+	// ListDeployments. The app has no current deployment slots, so both
+	// historical error deployments should produce diagnostics.
 	mock := &mockAppClient{
 		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
 		deployments: []*godo.Deployment{
@@ -883,7 +886,8 @@ func TestTroubleshoot_NoProviderID(t *testing.T) {
 
 func TestTroubleshoot_APIError(t *testing.T) {
 	// ListDeployments errors are best-effort: Troubleshoot continues with
-	// whatever deployment slots the app has.
+	// whatever deployment slots the app has. If the app itself has no
+	// slots and Get returns a valid app, result is empty (not an error).
 	mock := &mockAppClient{
 		app:                &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}},
 		listDeploymentsErr: errors.New("api timeout"),

--- a/internal/drivers/app_platform_troubleshoot_test.go
+++ b/internal/drivers/app_platform_troubleshoot_test.go
@@ -1,0 +1,473 @@
+package drivers
+
+// White-box tests for Troubleshoot helpers.
+// Using package drivers (not drivers_test) so unexported helpers are accessible.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// ── stub AppPlatformClient ──────────────────────────────────────────────────
+
+type stubAppClient struct {
+	app        *godo.App
+	appErr     error
+	deps       []*godo.Deployment
+	depsErr    error
+}
+
+func (s *stubAppClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in stub")
+}
+func (s *stubAppClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return s.app, &godo.Response{Response: &http.Response{StatusCode: 200}}, s.appErr
+}
+func (s *stubAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in stub")
+}
+func (s *stubAppClient) Update(_ context.Context, _ string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in stub")
+}
+func (s *stubAppClient) CreateDeployment(_ context.Context, _ string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in stub")
+}
+func (s *stubAppClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return s.deps, &godo.Response{}, s.depsErr
+}
+func (s *stubAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, errors.New("not implemented in stub")
+}
+
+// ── Troubleshoot tests ─────────────────────────────────────────────────────
+
+func TestTroubleshoot_EmptyProviderID(t *testing.T) {
+	d := NewAppPlatformDriverWithClient(&stubAppClient{}, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: ""}, "")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if diags != nil {
+		t.Fatalf("expected nil diagnostics, got %v", diags)
+	}
+}
+
+func TestTroubleshoot_GetAppError(t *testing.T) {
+	stub := &stubAppClient{appErr: errors.New("network error")}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	_, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err == nil {
+		t.Fatal("expected error from Get, got nil")
+	}
+}
+
+func TestTroubleshoot_NilApp(t *testing.T) {
+	stub := &stubAppClient{app: nil}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if diags != nil {
+		t.Fatalf("expected nil diagnostics for nil app, got %v", diags)
+	}
+}
+
+func TestTroubleshoot_ActiveApp_NoCandidates(t *testing.T) {
+	// A cleanly-active app with no InProgress/Pending slot and no
+	// historical deps returns an empty slice, not an error.
+	app := &godo.App{
+		ID: "app-123",
+		Spec: &godo.AppSpec{Name: "my-app"},
+		ActiveDeployment: &godo.Deployment{
+			ID:    "dep-active",
+			Phase: godo.DeploymentPhase_Active,
+		},
+	}
+	stub := &stubAppClient{app: app, deps: nil}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Active deployment with no error SummarySteps → buildDiagnosticFor returns nil.
+	if len(diags) != 0 {
+		t.Fatalf("expected 0 diagnostics for active healthy app, got %d: %+v", len(diags), diags)
+	}
+}
+
+func TestTroubleshoot_InProgressDeploymentError(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:        "dep-err",
+		Phase:     godo.DeploymentPhase_Error,
+		Cause:     "workflow-migrate up: first .: file does not exist",
+		CreatedAt: time.Now().UTC(),
+	}
+	app := &godo.App{
+		ID:                   "app-123",
+		Spec:                 &godo.AppSpec{Name: "my-app"},
+		InProgressDeployment: dep,
+	}
+	stub := &stubAppClient{app: app, deps: nil}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	if diags[0].ID != "dep-err" {
+		t.Errorf("unexpected ID: %s", diags[0].ID)
+	}
+	if diags[0].Cause == "" {
+		t.Error("Cause should not be empty")
+	}
+}
+
+func TestTroubleshoot_SummaryStepFailure(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:        "dep-123",
+		Phase:     godo.DeploymentPhase_Error,
+		CreatedAt: time.Now().UTC(),
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: []*godo.DeploymentProgressStep{
+				{
+					Name:   "pre_deploy",
+					Status: godo.DeploymentProgressStepStatus_Error,
+					Reason: &godo.DeploymentProgressStepReason{
+						Message: "exit status 1: workflow-migrate up failed",
+					},
+				},
+			},
+		},
+	}
+	app := &godo.App{
+		ID:                   "app-123",
+		Spec:                 &godo.AppSpec{Name: "my-app"},
+		InProgressDeployment: dep,
+	}
+	stub := &stubAppClient{app: app, deps: nil}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Phase != "pre_deploy" {
+		t.Errorf("expected phase 'pre_deploy', got %q", diags[0].Phase)
+	}
+	if diags[0].Cause == "" {
+		t.Error("Cause should not be empty from SummaryStep reason")
+	}
+}
+
+func TestTroubleshoot_ListDeploymentsError_BestEffort(t *testing.T) {
+	// ListDeployments error should be ignored; we still return diagnostics
+	// derived from the app's deployment slots.
+	dep := &godo.Deployment{
+		ID:    "dep-err",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "out of memory",
+	}
+	app := &godo.App{
+		ID:                   "app-123",
+		Spec:                 &godo.AppSpec{Name: "my-app"},
+		InProgressDeployment: dep,
+	}
+	stub := &stubAppClient{
+		app:     app,
+		depsErr: errors.New("API unavailable"),
+	}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("ListDeployments error should not propagate; got: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Error("expected diagnostics from InProgressDeployment despite ListDeployments error")
+	}
+}
+
+func TestTroubleshoot_HistoricalDeploymentUsed(t *testing.T) {
+	// No deployment slots on the app, but ListDeployments has an errored one.
+	hist := []*godo.Deployment{
+		{ID: "dep-hist", Phase: godo.DeploymentPhase_Error, Cause: "build failed"},
+	}
+	app := &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "my-app"}}
+	stub := &stubAppClient{app: app, deps: hist}
+	d := NewAppPlatformDriverWithClient(stub, "nyc3")
+	diags, err := d.Troubleshoot(context.Background(), interfaces.ResourceRef{Name: "my-app", ProviderID: "app-123"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diags) != 1 || diags[0].ID != "dep-hist" {
+		t.Fatalf("expected dep-hist from history, got %+v", diags)
+	}
+}
+
+// ── pickTroubleshootDeployments tests ──────────────────────────────────────
+
+func TestPickTroubleshootDeployments_PrioritizesInProgress(t *testing.T) {
+	inProgress := &godo.Deployment{ID: "in-progress"}
+	pending := &godo.Deployment{ID: "pending"}
+	active := &godo.Deployment{ID: "active"}
+	hist := []*godo.Deployment{{ID: "hist-1"}}
+
+	app := &godo.App{
+		InProgressDeployment: inProgress,
+		PendingDeployment:    pending,
+		ActiveDeployment:     active,
+	}
+	result := pickTroubleshootDeployments(app, hist)
+	if len(result) == 0 || result[0].ID != "in-progress" {
+		t.Errorf("expected InProgress first, got %+v", result)
+	}
+	if result[1].ID != "pending" {
+		t.Errorf("expected Pending second, got %+v", result[1])
+	}
+	if result[2].ID != "active" {
+		t.Errorf("expected Active third, got %+v", result[2])
+	}
+	// hist-1 should not appear: already at 3 items
+	if len(result) > 3 {
+		t.Errorf("expected max 3, got %d", len(result))
+	}
+}
+
+func TestPickTroubleshootDeployments_DeduplicatesIDs(t *testing.T) {
+	dep := &godo.Deployment{ID: "dup"}
+	app := &godo.App{
+		InProgressDeployment: dep,
+		PendingDeployment:    dep, // same pointer / ID
+	}
+	hist := []*godo.Deployment{dep}
+	result := pickTroubleshootDeployments(app, hist)
+	if len(result) != 1 {
+		t.Errorf("expected 1 (deduped), got %d: %+v", len(result), result)
+	}
+}
+
+func TestPickTroubleshootDeployments_NilSlotsUsesHistory(t *testing.T) {
+	app := &godo.App{ID: "app-123"}
+	hist := []*godo.Deployment{
+		{ID: "h1"}, {ID: "h2"}, {ID: "h3"}, {ID: "h4"},
+	}
+	result := pickTroubleshootDeployments(app, hist)
+	if len(result) != 3 {
+		t.Errorf("expected 3 from history, got %d", len(result))
+	}
+}
+
+// ── buildDiagnosticFor tests ──────────────────────────────────────────────
+
+func TestBuildDiagnosticFor_ErrorPhase_ReturnsDiagnostic(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:        "dep-1",
+		Phase:     godo.DeploymentPhase_Error,
+		Cause:     "build failed",
+		CreatedAt: time.Now().UTC(),
+	}
+	diag := buildDiagnosticFor(dep)
+	if diag == nil {
+		t.Fatal("expected non-nil diagnostic for ERROR phase")
+	}
+	if diag.ID != "dep-1" {
+		t.Errorf("expected ID dep-1, got %s", diag.ID)
+	}
+	if diag.Cause != "build failed" {
+		t.Errorf("unexpected Cause: %q", diag.Cause)
+	}
+}
+
+func TestBuildDiagnosticFor_ActivePhase_ReturnsNil(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-ok",
+		Phase: godo.DeploymentPhase_Active,
+	}
+	if diag := buildDiagnosticFor(dep); diag != nil {
+		t.Errorf("expected nil for ACTIVE phase, got %+v", diag)
+	}
+}
+
+func TestBuildDiagnosticFor_SummaryStepPhaseNameUsed(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-2",
+		Phase: godo.DeploymentPhase_Error,
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: []*godo.DeploymentProgressStep{
+				{
+					Name:   "build",
+					Status: godo.DeploymentProgressStepStatus_Error,
+					Reason: &godo.DeploymentProgressStepReason{Message: "image pull failed"},
+				},
+			},
+		},
+	}
+	diag := buildDiagnosticFor(dep)
+	if diag == nil {
+		t.Fatal("expected non-nil diagnostic")
+	}
+	if diag.Phase != "build" {
+		t.Errorf("expected phase 'build' from SummaryStep, got %q", diag.Phase)
+	}
+}
+
+func TestBuildDiagnosticFor_LeafStepFallback(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-3",
+		Phase: godo.DeploymentPhase_Error,
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: nil, // no summary steps
+			Steps: []*godo.DeploymentProgressStep{
+				{
+					Status: godo.DeploymentProgressStepStatus_Error,
+					Reason: &godo.DeploymentProgressStepReason{Message: "exit status 2"},
+				},
+			},
+		},
+	}
+	diag := buildDiagnosticFor(dep)
+	if diag == nil {
+		t.Fatal("expected non-nil diagnostic from leaf step")
+	}
+	if diag.Cause == "" {
+		t.Error("expected non-empty Cause from leaf step")
+	}
+}
+
+func TestBuildDiagnosticFor_CanceledPhase_ReturnsDiagnostic(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-canceled",
+		Phase: godo.DeploymentPhase_Canceled,
+	}
+	if diag := buildDiagnosticFor(dep); diag == nil {
+		t.Error("expected non-nil diagnostic for CANCELED phase")
+	}
+}
+
+// ── extractCause tests ──────────────────────────────────────────────────────
+
+func TestExtractCause_TableDriven(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{
+			name: "go panic",
+			in:   "some output\npanic: runtime error: index out of range\ngoroutine 1",
+			want: "panic: runtime error: index out of range",
+		},
+		{
+			name: "exit status line",
+			in:   "running migrations\nError: exit status 1\ndone",
+			want: "Error: exit status 1",
+		},
+		{
+			name: "failed to pattern",
+			in:   "starting\nfailed to connect to database\n",
+			want: "failed to connect to database",
+		},
+		{
+			name: "fatal uppercase",
+			in:   "FATAL: configuration file error",
+			want: "FATAL: configuration file error",
+		},
+		{
+			name: "no pattern fallback to last line",
+			in:   "line one\nline two\ngoodbye world",
+			want: "goodbye world",
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "whitespace only",
+			in:   "   \n  \n",
+			want: "",
+		},
+		{
+			name: "single error line",
+			in:   "error: something went wrong",
+			want: "error: something went wrong",
+		},
+		{
+			name: "exit code variant",
+			in:   "process exited with exit code 127",
+			want: "process exited with exit code 127",
+		},
+		{
+			name: "trimmed whitespace",
+			in:   "  Error: too many connections  ",
+			want: "Error: too many connections",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractCause(c.in)
+			if got != c.want {
+				t.Errorf("extractCause(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// ── deploymentCauseAndPhase tests ──────────────────────────────────────────
+
+func TestDeploymentCauseAndPhase_NoProgress(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-1",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "image not found",
+	}
+	cause, phase := deploymentCauseAndPhase(dep)
+	if cause != "image not found" {
+		t.Errorf("expected cause %q, got %q", "image not found", cause)
+	}
+	if phase != string(godo.DeploymentPhase_Error) {
+		t.Errorf("expected phase %q, got %q", string(godo.DeploymentPhase_Error), phase)
+	}
+}
+
+func TestDeploymentCauseAndPhase_SummaryStepNoReason(t *testing.T) {
+	// SummaryStep error with no Reason.Message; cause falls back to dep.Cause
+	// but the step's Name is still used as phase since the SummaryStep matched.
+	dep := &godo.Deployment{
+		ID:    "dep-1",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "deployment timed out",
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: []*godo.DeploymentProgressStep{
+				{Name: "deploy", Status: godo.DeploymentProgressStepStatus_Error, Reason: nil},
+			},
+		},
+	}
+	cause, phase := deploymentCauseAndPhase(dep)
+	if cause != "deployment timed out" {
+		t.Errorf("expected fallback to dep.Cause, got %q", cause)
+	}
+	// Phase comes from the matching SummaryStep name, not dep.Phase.
+	if phase != "deploy" {
+		t.Errorf("expected phase %q from SummaryStep name, got %q", "deploy", phase)
+	}
+}
+
+func TestDeploymentCauseAndPhase_ActivePhase_EmptyCause(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-ok",
+		Phase: godo.DeploymentPhase_Active,
+	}
+	cause, _ := deploymentCauseAndPhase(dep)
+	if cause != "" {
+		t.Errorf("expected empty cause for ACTIVE phase, got %q", cause)
+	}
+}

--- a/internal/drivers/app_platform_troubleshoot_test.go
+++ b/internal/drivers/app_platform_troubleshoot_test.go
@@ -471,3 +471,32 @@ func TestDeploymentCauseAndPhase_ActivePhase_EmptyCause(t *testing.T) {
 		t.Errorf("expected empty cause for ACTIVE phase, got %q", cause)
 	}
 }
+
+func TestDeploymentCauseAndPhase_LeafStepFallback_NoCause(t *testing.T) {
+	// dep.Cause is empty and SummarySteps has no error; cause must come from
+	// Progress.Steps leaf step Reason.Message.
+	dep := &godo.Deployment{
+		ID:    "dep-leaf",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "", // explicitly empty
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: nil,
+			Steps: []*godo.DeploymentProgressStep{
+				{
+					Status: godo.DeploymentProgressStepStatus_Error,
+					Reason: &godo.DeploymentProgressStepReason{Message: "exit status 2"},
+				},
+			},
+		},
+	}
+	cause, phase := deploymentCauseAndPhase(dep)
+	if cause == "" {
+		t.Fatal("expected cause from Progress.Steps, got empty")
+	}
+	if cause != "exit status 2" {
+		t.Errorf("expected cause %q, got %q", "exit status 2", cause)
+	}
+	if phase != string(godo.DeploymentPhase_Error) {
+		t.Errorf("expected phase from dep.Phase, got %q", phase)
+	}
+}

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -83,6 +83,9 @@ func (m *deployMockClient) CreateDeployment(_ context.Context, _ string, _ ...*g
 	return &godo.Deployment{ID: "dep-deploy"}, nil, nil
 }
 
+func (m *deployMockClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return nil, &godo.Response{}, m.err
+}
 func (m *deployMockClient) Delete(_ context.Context, appID string) (*godo.Response, error) {
 	if m.err != nil {
 		return nil, m.err

--- a/internal/drivers/integration_test_helpers_test.go
+++ b/internal/drivers/integration_test_helpers_test.go
@@ -1,0 +1,185 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// fakeAppsClient implements AppPlatformClient for integration tests.
+// It tracks every call so tests can assert which DO API methods were invoked
+// and with which identifiers, returning configurable responses seeded per test.
+type fakeAppsClient struct {
+	// Seeded responses.
+	createResp *godo.App            // returned by Create
+	getByID    map[string]*godo.App // keyed by app ID
+	updateResp map[string]*godo.App // keyed by app ID (what Update returns)
+	deleteErrs map[string]error     // keyed by app ID (nil ⇒ 204)
+
+	// Call log.
+	createCalls        []string // app names created
+	getCalls           []string // app IDs passed to Get
+	updateCalls        []string // app IDs passed to Update
+	createDeployCalls  []string // app IDs passed to CreateDeployment
+	deleteCalls        []string // app IDs passed to Delete
+	listCalls          int
+	listDeploymentsFor []string
+}
+
+func newFakeAppsClient() *fakeAppsClient {
+	return &fakeAppsClient{
+		getByID:    map[string]*godo.App{},
+		updateResp: map[string]*godo.App{},
+		deleteErrs: map[string]error{},
+	}
+}
+
+// ── AppPlatformClient interface ───────────────────────────────────────────────
+
+func (f *fakeAppsClient) Create(_ context.Context, req *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	f.createCalls = append(f.createCalls, req.Spec.Name)
+	if f.createResp != nil {
+		f.getByID[f.createResp.ID] = f.createResp
+		return f.createResp, fakeResp(http.StatusCreated), nil
+	}
+	// Default: deterministic fake UUID based on name.
+	app := &godo.App{
+		ID:        fmt.Sprintf("fake-uuid-for-%s", req.Spec.Name),
+		Spec:      req.Spec,
+		CreatedAt: time.Now(),
+	}
+	f.getByID[app.ID] = app
+	return app, fakeResp(http.StatusCreated), nil
+}
+
+func (f *fakeAppsClient) Get(_ context.Context, id string) (*godo.App, *godo.Response, error) {
+	f.getCalls = append(f.getCalls, id)
+	if app, ok := f.getByID[id]; ok {
+		return app, fakeResp(http.StatusOK), nil
+	}
+	return nil, fakeResp(http.StatusNotFound), &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "not found",
+	}
+}
+
+func (f *fakeAppsClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	f.listCalls++
+	out := make([]*godo.App, 0, len(f.getByID))
+	for _, a := range f.getByID {
+		out = append(out, a)
+	}
+	resp := &godo.Response{
+		Response: &http.Response{StatusCode: http.StatusOK},
+		Links:    &godo.Links{},
+	}
+	return out, resp, nil
+}
+
+func (f *fakeAppsClient) Update(_ context.Context, id string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	f.updateCalls = append(f.updateCalls, id)
+	if app, ok := f.updateResp[id]; ok {
+		return app, fakeResp(http.StatusOK), nil
+	}
+	if app, ok := f.getByID[id]; ok {
+		return app, fakeResp(http.StatusOK), nil
+	}
+	return nil, fakeResp(http.StatusNotFound), &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  fmt.Sprintf("not found: %s", id),
+	}
+}
+
+func (f *fakeAppsClient) CreateDeployment(_ context.Context, id string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	f.createDeployCalls = append(f.createDeployCalls, id)
+	return &godo.Deployment{ID: fmt.Sprintf("dep-%s", id)}, fakeResp(http.StatusOK), nil
+}
+
+func (f *fakeAppsClient) ListDeployments(_ context.Context, id string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	f.listDeploymentsFor = append(f.listDeploymentsFor, id)
+	return nil, fakeResp(http.StatusOK), nil
+}
+
+func (f *fakeAppsClient) Delete(_ context.Context, id string) (*godo.Response, error) {
+	f.deleteCalls = append(f.deleteCalls, id)
+	if err, ok := f.deleteErrs[id]; ok && err != nil {
+		return fakeResp(http.StatusConflict), err
+	}
+	delete(f.getByID, id)
+	return fakeResp(http.StatusNoContent), nil
+}
+
+// fakeResp creates a minimal *godo.Response with the given status.
+func fakeResp(status int) *godo.Response {
+	return &godo.Response{Response: &http.Response{StatusCode: status}}
+}
+
+// ── inMemoryState: minimal state round-trip store ─────────────────────────────
+
+type inMemoryState struct {
+	resources map[string]interfaces.ResourceState // keyed by Name
+}
+
+func newInMemoryState() *inMemoryState {
+	return &inMemoryState{resources: map[string]interfaces.ResourceState{}}
+}
+
+func (s *inMemoryState) get(name string) (interfaces.ResourceState, bool) {
+	r, ok := s.resources[name]
+	return r, ok
+}
+
+func (s *inMemoryState) put(r interfaces.ResourceState) {
+	s.resources[r.Name] = r
+}
+
+// ── applySim: simulate wfctl's apply→persist flow for tests ──────────────────
+
+// applySim mimics wfctl's Apply pattern: if no state exists it calls Create,
+// otherwise it calls Update with the stored ref. The returned ResourceOutput
+// is persisted back to the in-memory state, mirroring wfctl's state-write loop:
+//
+//	state.ProviderID = out.ProviderID  // wfctl trusts the driver
+func applySim(t *testing.T, ctx context.Context, driver *AppPlatformDriver, state *inMemoryState, spec interfaces.ResourceSpec) interfaces.ResourceState {
+	t.Helper()
+
+	existing, have := state.get(spec.Name)
+	var out *interfaces.ResourceOutput
+	var err error
+	if !have {
+		out, err = driver.Create(ctx, spec)
+	} else {
+		ref := interfaces.ResourceRef{
+			Name:       existing.Name,
+			Type:       existing.Type,
+			ProviderID: existing.ProviderID,
+		}
+		out, err = driver.Update(ctx, ref, spec)
+	}
+	if err != nil {
+		t.Fatalf("applySim %q: %v", spec.Name, err)
+	}
+
+	rs := interfaces.ResourceState{
+		ID:         spec.Name,
+		Name:       spec.Name,
+		Type:       spec.Type,
+		ProviderID: out.ProviderID, // ← the field under test
+		Outputs:    out.Outputs,
+		UpdatedAt:  time.Now().UTC(),
+	}
+	state.put(rs)
+	return rs
+}
+
+// newTestDriver returns an AppPlatformDriver wired to a fakeAppsClient.
+func newTestDriver(t *testing.T) (*AppPlatformDriver, *fakeAppsClient) {
+	t.Helper()
+	client := newFakeAppsClient()
+	return &AppPlatformDriver{client: client, region: "nyc3"}, client
+}

--- a/internal/drivers/shared.go
+++ b/internal/drivers/shared.go
@@ -1,0 +1,15 @@
+// Package drivers implements per-resource DigitalOcean drivers used by the
+// plugin. shared.go holds helpers that are used by more than one driver.
+package drivers
+
+// isUUIDLike returns true when s has the canonical UUID shape:
+// 36 characters with hyphens at positions 8, 13, 18, and 23.
+//
+// Used by drivers whose DO API requires a UUID in the URL path (app platform,
+// databases, certificates, load balancers, VPCs, firewalls, droplets, etc.)
+// to detect stale state that stored a resource name instead of the UUID,
+// so callers can fall back to a name-based lookup instead of sending a
+// malformed path parameter to the DO API.
+func isUUIDLike(s string) bool {
+	return len(s) == 36 && s[8] == '-' && s[13] == '-' && s[18] == '-' && s[23] == '-'
+}

--- a/internal/drivers/shared_test.go
+++ b/internal/drivers/shared_test.go
@@ -1,0 +1,30 @@
+package drivers
+
+import "testing"
+
+func TestIsUUIDLike_TableDriven(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"canonical uuid", "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", true},
+		{"lowercase letters", "abcdef01-2345-6789-abcd-ef0123456789", true},
+		{"uppercase letters", "ABCDEF01-2345-6789-ABCD-EF0123456789", true},
+		{"resource name", "bmw-staging", false},
+		{"empty string", "", false},
+		{"too short", "f8b6200c-3bba-48a7-8bf1", false},
+		{"too long", "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5-extra", false},
+		{"missing first hyphen", "f8b6200c03bba-48a7-8bf1-7a3e3a885eb5", false},
+		{"36 chars but no hyphens", "f8b6200c3bba48a78bf17a3e3a885eb5foo1", false},
+		{"spaces", "f8b6200c 3bba 48a7 8bf1 7a3e3a885eb51", false},
+		{"zeroes uuid", "00000000-0000-0000-0000-000000000000", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isUUIDLike(c.in); got != c.want {
+				t.Errorf("isUUIDLike(%q) = %v, want %v", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // doModuleInstance wraps an IaCProvider as an sdk.ModuleInstance + sdk.ServiceInvoker.
@@ -96,6 +99,9 @@ func (m *doModuleInstance) InvokeMethod(method string, args map[string]any) (map
 
 	case "ResourceDriver.SensitiveKeys":
 		return m.invokeDriverSensitiveKeys(args)
+
+	case "ResourceDriver.Troubleshoot":
+		return m.invokeDriverTroubleshoot(args)
 
 	default:
 		return nil, fmt.Errorf("digitalocean plugin: unknown method %q", method)
@@ -359,6 +365,41 @@ func (m *doModuleInstance) invokeDriverSensitiveKeys(args map[string]any) (map[s
 		return nil, fmt.Errorf("ResourceDriver.SensitiveKeys: %w", err)
 	}
 	return map[string]any{"keys": driver.SensitiveKeys()}, nil
+}
+
+// invokeDriverTroubleshoot checks whether the driver implements
+// interfaces.Troubleshooter and, if so, calls Troubleshoot and serialises the
+// result. Returns codes.Unimplemented when the driver does not implement the
+// interface so wfctl's remoteResourceDriver can silently no-op.
+func (m *doModuleInstance) invokeDriverTroubleshoot(args map[string]any) (map[string]any, error) {
+	resourceType, _ := args["resource_type"].(string)
+	if resourceType == "" {
+		return nil, fmt.Errorf("ResourceDriver.Troubleshoot: missing resource_type arg")
+	}
+	driver, err := m.provider.ResourceDriver(resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("ResourceDriver.Troubleshoot: %w", err)
+	}
+	ts, ok := driver.(interfaces.Troubleshooter)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "driver does not implement Troubleshooter")
+	}
+	ref := refFromArgs(args)
+	failureMsg, _ := args["failure_msg"].(string)
+	diags, err := ts.Troubleshoot(context.Background(), ref, failureMsg)
+	if err != nil {
+		return nil, err
+	}
+	diagList := make([]any, len(diags))
+	for i, d := range diags {
+		diagList[i] = map[string]any{
+			"id":    d.ID,
+			"phase": d.Phase,
+			"cause": d.Cause,
+			"at":    d.At.Format(time.RFC3339),
+		}
+	}
+	return map[string]any{"diagnostics": diagList}, nil
 }
 
 // invokeDriverHealthCheck decodes args and calls ResourceDriver.HealthCheck.

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -382,7 +382,7 @@ func (m *doModuleInstance) invokeDriverTroubleshoot(args map[string]any) (map[st
 	}
 	ts, ok := driver.(interfaces.Troubleshooter)
 	if !ok {
-		return nil, status.Error(codes.Unimplemented, "driver does not implement Troubleshooter")
+		return nil, status.Error(codes.Unimplemented, fmt.Sprintf("resource driver %q does not implement Troubleshooter", resourceType))
 	}
 	ref := refFromArgs(args)
 	failureMsg, _ := args["failure_msg"].(string)


### PR DESCRIPTION
## Summary

- Refines \`AppPlatformDriver.Troubleshoot\` to prioritise the app's current deployment slots (InProgress > Pending > Active) before falling back to paginated history, so the most actionable failure context comes first.
- Adds \`pickTroubleshootDeployments\`, \`buildDiagnosticFor\`, \`deploymentCauseAndPhase\`, and \`extractCause\` helpers with full unit coverage.
- Adds \`ResourceDriver.Troubleshoot\` gRPC dispatch in \`InvokeMethod\`; returns \`codes.Unimplemented\` for non-Troubleshooter drivers (now includes \`resourceType\` in message) so wfctl silently no-ops.
- 23 new tests across 3 scenarios: slot/history ordering, phase name extraction (SummarySteps → leaf Steps → dep.Cause → terminal phase), and \`extractCause\` table (10 cases).
- **State-heal for stale name-as-ProviderID:** \`AppPlatformDriver.Update\` and \`Delete\` now call \`resolveProviderID\` — if \`ref.ProviderID\` is not a canonical UUID, a WARN is logged and a name-based lookup heals it transparently. Returns the healed UUID in \`ResourceOutput\` so wfctl rewrites state on the next Apply.
- Shared \`isUUIDLike\` helper in \`internal/drivers/shared.go\`.
- Integration-test harness (\`fakeAppsClient\` + \`inMemoryState\` + \`applySim\`) exercises the full Create/Update/Delete loop; 5 integration tests pin the "stale name heals to UUID" behavior.

## Root-cause (v0.7.8 addendum — BMW deploy failure 24901939350)

**What happened:** BMW staging \`state.json\` contained \`ProviderID="bmw-staging"\` (the app name) instead of a DO UUID. When wfctl called \`Update\`, the DO API rejected the \`PUT /v2/apps/bmw-staging\` with \`400 invalid uuid\`.

**Where the name came from:** A pre-v0.7.7 \`Create\` run hit a code path in \`DOProvider.Apply\` that substituted \`spec.Name\` for \`ProviderID\` when the godo API returned a zero-ID response (documented in v0.7.7 commit \`94c9227\`). That fallback has been removed.

**Why v0.7.7 didn't catch it:** v0.7.7's empty-ID guard only protects *new* Create calls — it errors out early rather than silently storing a name. But it can't retroactively fix *existing* state entries that already have the bad shape. BMW's state predated the guard.

**What v0.7.8 does:** \`resolveProviderID\` in \`Update\` and \`Delete\` detects the stale name shape (via \`isUUIDLike\`) and heals it via \`findAppByName\` on the fly, before any DO API call. The returned \`ResourceOutput.ProviderID\` carries the real UUID so wfctl transparently rewrites state. No manual teardown or state editing required.

**Verified: reverting \`resolveProviderID\` call causes \`TestUpdate_HealsStaleName\` to fail with:**
```
app_platform_stateheal_test.go:157: listCalls = 0, want ≥ 1 (findAppByName must fire during heal)
app_platform_stateheal_test.go:161: Update called with "bmw-staging", want UUID "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" (state-heal failed)
```
**Test has teeth.**

## Test plan

- \`GOWORK=off go test -race -short ./...\` — all green (commit 143aae7).
- \`TestAppPlatform_Update_HealsStaleName\` — stale name resolves to UUID, Update called with UUID, state rewritten, WARN log contains "state-heal".
- \`TestAppPlatform_Create_PersistsUUIDInState\` — Create returns UUID from API, not spec name.
- \`TestIsUUIDLike_TableDriven\` — 11 cases in \`shared_test.go\`.
- Copilot findings addressed: test quality (listCalls counter, not len(listApps)), comment accuracy, error message diagnosability, CHANGELOG version text.