### PR TITLE
feat(do): v0.7.9 — ProviderIDValidator + state-heal replication (Tasks 9-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,65 @@
 
 All notable changes to workflow-plugin-digitalocean are documented here.
 
+## [v0.7.9] - 2026-04-24
+
+### Added
+
+- **`ProviderIDValidator` on all 14 drivers** — every driver now implements
+  `interfaces.ProviderIDValidator` (workflow v0.18.11) by returning a
+  `ProviderIDFormat` declaration. wfctl uses the declaration to validate IDs
+  at two boundaries: input (warn-only on Update/Delete) and output (hard
+  failure on Apply to prevent state corruption).
+
+  Format assignments:
+  - `IDFormatUUID` — AppPlatform, APIGateway, Cache, Certificate, Database,
+    Firewall, Kubernetes, LoadBalancer, VPC
+  - `IDFormatDomainName` — DNS
+  - `IDFormatFreeform` — Droplet, Spaces, Registry, IAMRole
+
+  **Droplet deviation from plan table**: the v0.7.9 design doc listed Droplet
+  as `IDFormatUUID`. Droplet IDs are actually integers assigned by the DO API
+  (e.g. `"123456789"`), not canonical UUIDs. Corrected to `IDFormatFreeform`;
+  godo rejects stale names with a 404 at the API level — no UUID-based
+  state-heal is needed for Droplet.
+
+- **State-heal replication across all UUID drivers** (Tasks 11) — the
+  `resolveProviderID` → `findXxxByName` pattern introduced for `AppPlatformDriver`
+  in v0.7.8 is now replicated to every remaining UUID-shaped driver:
+
+  | Driver | List expansion |
+  |--------|---------------|
+  | VPC | — (List already in interface) |
+  | Firewall | — (List already in interface) |
+  | Database | — (List already in interface) |
+  | Certificate | — (List already in interface) |
+  | Cache | `CacheClient.List` added |
+  | APIGateway | `APIGatewayAppClient.List` added |
+  | LoadBalancer | `LoadBalancerClient.List` added (value slice `[]godo.LoadBalancer`) |
+  | Kubernetes | `KubernetesClient.List` added |
+
+  Each driver gained `findXxxByName` (paginated list → name match) and
+  `resolveProviderID` (UUID check → pass-through or WARN log + heal).
+  Update/Delete on all 8 drivers now route through `resolveProviderID`.
+
+- **Per-driver state-heal tests** — 5 tests per UUID driver (40 total) in
+  `*_stateheal_test.go` files (package `drivers`):
+  - `Create_PersistsUUIDInState` — ProviderID comes from API, not spec name
+  - `Update_UsesExistingUUID` — no `List` call when ProviderID is valid UUID
+  - `Update_HealsStaleName` — `List` fires, Update called with healed UUID
+  - `Update_HealFails_WhenResourceNotFound` — error propagated, no silent fallback
+  - `Delete_HealsStaleName` — Delete called with healed UUID
+
+- **`TestAllDrivers_DeclareProviderIDFormat`** — exhaustive coverage gate in
+  `providerid_format_test.go`; one entry per driver, fails if any driver returns
+  the wrong format or the method is missing.
+
+### Changed
+
+- Depends on workflow v0.18.11 (was v0.18.10.1).
+
+---
+
 ## [v0.7.8] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ### Changed
 
-- Depends on workflow v0.18.11 (was v0.18.10.1).
+- Depends on workflow v0.18.11.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   **Droplet deviation from plan table**: the v0.7.9 design doc listed Droplet
   as `IDFormatUUID`. Droplet IDs are actually integers assigned by the DO API
   (e.g. `"123456789"`), not canonical UUIDs. Corrected to `IDFormatFreeform`;
-  godo rejects stale names with a 404 at the API level — no UUID-based
-  state-heal is needed for Droplet.
+  `providerIDToInt` performs strict local validation (via `strconv.Atoi`) and
+  returns an explicit error for any non-integer ProviderID before any API call
+  is made — no UUID-based state-heal is needed for Droplet.
 
 - **State-heal replication across all UUID drivers** (Tasks 11) — the
   `resolveProviderID` → `findXxxByName` pattern introduced for `AppPlatformDriver`
@@ -48,12 +49,13 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   - `Create_PersistsUUIDInState` — ProviderID comes from API, not spec name
   - `Update_UsesExistingUUID` — no `List` call when ProviderID is valid UUID
   - `Update_HealsStaleName` — `List` fires, Update called with healed UUID
-  - `Update_HealFails_WhenResourceNotFound` — error propagated, no silent fallback
+  - `Update_HealFails_WhenListFails` — error propagated when the List API call fails, no silent fallback
   - `Delete_HealsStaleName` — Delete called with healed UUID
 
-- **`TestAllDrivers_DeclareProviderIDFormat`** — exhaustive coverage gate in
-  `providerid_format_test.go`; one entry per driver, fails if any driver returns
-  the wrong format or the method is missing.
+- **`TestAllDrivers_DeclareProviderIDFormat`** — manually maintained registry in
+  `providerid_format_test.go`; one entry per driver, fails if any listed driver
+  returns the wrong format or the method is missing. New drivers must be added
+  to this table manually.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08
+	github.com/GoCodeAlone/workflow v0.18.11
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08 h1:NE32kfrXMJ5rx3nh6FxH3Er7cJYvJKYmKF+oMmoVc4I=
-github.com/GoCodeAlone/workflow v0.19.0-alpha.1.0.20260424204713-c02f228f1e08/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
+github.com/GoCodeAlone/workflow v0.18.11 h1:mkCFHafJVKd6WCGT+IFcW9l5BGCUSl2PhICKsULeyNg=
+github.com/GoCodeAlone/workflow v0.18.11/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/drivers/api_gateway.go
+++ b/internal/drivers/api_gateway.go
@@ -200,3 +200,5 @@ func apiGatewayOutput(app *godo.App) *interfaces.ResourceOutput {
 }
 
 func (d *APIGatewayDriver) SensitiveKeys() []string { return nil }
+
+func (d *APIGatewayDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/api_gateway.go
+++ b/internal/drivers/api_gateway.go
@@ -138,7 +138,11 @@ func (d *APIGatewayDriver) Diff(_ context.Context, desired interfaces.ResourceSp
 }
 
 func (d *APIGatewayDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	app, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	app, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}

--- a/internal/drivers/api_gateway.go
+++ b/internal/drivers/api_gateway.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -12,6 +13,7 @@ import (
 type APIGatewayAppClient interface {
 	Create(ctx context.Context, req *godo.AppCreateRequest) (*godo.App, *godo.Response, error)
 	Get(ctx context.Context, appID string) (*godo.App, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]*godo.App, *godo.Response, error)
 	Update(ctx context.Context, appID string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error)
 	Delete(ctx context.Context, appID string) (*godo.Response, error)
 }
@@ -61,11 +63,55 @@ func (d *APIGatewayDriver) Read(ctx context.Context, ref interfaces.ResourceRef)
 	return apiGatewayOutput(app), nil
 }
 
+// findAPIGatewayByName iterates the paginated App Platform list and returns
+// the first app whose Spec.Name matches. Returns ErrResourceNotFound if no
+// match is found.
+func (d *APIGatewayDriver) findAPIGatewayByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		apps, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("api_gateway list: %w", WrapGodoError(err))
+		}
+		for _, app := range apps {
+			if app.Spec != nil && app.Spec.Name == name {
+				return apiGatewayOutput(app), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("api_gateway %q: %w", name, ErrResourceNotFound)
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *APIGatewayDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: api_gateway %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findAPIGatewayByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("api_gateway state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *APIGatewayDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	region := strFromConfig(spec.Config, "region", d.region)
 	appSpec := buildAPIGatewaySpec(spec.Name, region, spec.Config)
 
-	app, _, err := d.client.Update(ctx, ref.ProviderID, &godo.AppUpdateRequest{Spec: appSpec})
+	app, _, err := d.client.Update(ctx, providerID, &godo.AppUpdateRequest{Spec: appSpec})
 	if err != nil {
 		return nil, fmt.Errorf("api_gateway update %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -73,7 +119,11 @@ func (d *APIGatewayDriver) Update(ctx context.Context, ref interfaces.ResourceRe
 }
 
 func (d *APIGatewayDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("api_gateway delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/api_gateway_stateheal_test.go
+++ b/internal/drivers/api_gateway_stateheal_test.go
@@ -25,12 +25,18 @@ type apiGatewayStateHealMock struct {
 
 	createApp *godo.App
 	createErr error
+
+	// getApp is returned by Get (used by HealthCheck after heal).
+	getApp *godo.App
 }
 
 func (m *apiGatewayStateHealMock) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
 	return m.createApp, nil, m.createErr
 }
 func (m *apiGatewayStateHealMock) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	if m.getApp != nil {
+		return m.getApp, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in apiGatewayStateHealMock")
 }
 func (m *apiGatewayStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
@@ -144,5 +150,33 @@ func TestAPIGatewayDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestAPIGatewayDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &apiGatewayStateHealMock{
+		listApps: []*godo.App{{ID: uuid, Spec: &godo.AppSpec{Name: "my-gateway"}}},
+		getApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "my-gateway"},
+			ActiveDeployment: &godo.Deployment{
+				Phase: godo.DeploymentPhase_Active,
+			},
+		},
+	}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-gateway", ProviderID: "my-gateway"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
 	}
 }

--- a/internal/drivers/api_gateway_stateheal_test.go
+++ b/internal/drivers/api_gateway_stateheal_test.go
@@ -1,0 +1,148 @@
+package drivers
+
+// State-heal tests for APIGatewayDriver.Update / Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type apiGatewayStateHealMock struct {
+	listApps  []*godo.App
+	listErr   error
+	listCalls int
+
+	updatedApp     *godo.App
+	updateErr      error
+	updateCalledID string
+
+	deleteCalledID string
+	deleteErr      error
+
+	createApp *godo.App
+	createErr error
+}
+
+func (m *apiGatewayStateHealMock) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return m.createApp, nil, m.createErr
+}
+func (m *apiGatewayStateHealMock) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in apiGatewayStateHealMock")
+}
+func (m *apiGatewayStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	m.listCalls++
+	return m.listApps, nil, m.listErr
+}
+func (m *apiGatewayStateHealMock) Update(_ context.Context, appID string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	m.updateCalledID = appID
+	return m.updatedApp, nil, m.updateErr
+}
+func (m *apiGatewayStateHealMock) Delete(_ context.Context, appID string) (*godo.Response, error) {
+	m.deleteCalledID = appID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestAPIGatewayDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &apiGatewayStateHealMock{
+		createApp: &godo.App{ID: wantUUID, Spec: &godo.AppSpec{Name: "my-gateway"}},
+	}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-gateway",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-gateway" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestAPIGatewayDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &apiGatewayStateHealMock{
+		updatedApp: &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: "my-gateway"}},
+	}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-gateway", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-gateway", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want %q", m.updateCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestAPIGatewayDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &apiGatewayStateHealMock{
+		listApps:   []*godo.App{{ID: uuid, Spec: &godo.AppSpec{Name: "my-gateway"}}},
+		updatedApp: &godo.App{ID: uuid, Spec: &godo.AppSpec{Name: "my-gateway"}},
+	}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-gateway", ProviderID: "my-gateway"}, // stale name
+		interfaces.ResourceSpec{Name: "my-gateway", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", m.updateCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestAPIGatewayDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &apiGatewayStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-gateway", ProviderID: "my-gateway"},
+		interfaces.ResourceSpec{Name: "my-gateway", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestAPIGatewayDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &apiGatewayStateHealMock{
+		listApps: []*godo.App{{ID: uuid, Spec: &godo.AppSpec{Name: "my-gateway"}}},
+	}
+	d := NewAPIGatewayDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-gateway", ProviderID: "my-gateway"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/api_gateway_stateheal_test.go
+++ b/internal/drivers/api_gateway_stateheal_test.go
@@ -123,7 +123,7 @@ func TestAPIGatewayDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestAPIGatewayDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestAPIGatewayDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &apiGatewayStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewAPIGatewayDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/api_gateway_test.go
+++ b/internal/drivers/api_gateway_test.go
@@ -37,7 +37,7 @@ func (m *mockAPIGatewayClient) Delete(_ context.Context, _ string) (*godo.Respon
 
 func testGatewayApp() *godo.App {
 	return &godo.App{
-		ID:      "app-gw-123",
+		ID:      "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		LiveURL: "https://gw.example.com",
 		Spec:    &godo.AppSpec{Name: "my-gateway"},
 		ActiveDeployment: &godo.Deployment{
@@ -61,8 +61,8 @@ func TestAPIGatewayDriver_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if out.ProviderID != "app-gw-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-gw-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 	if out.Status != "running" {
 		t.Errorf("Status = %q, want %q", out.Status, "running")
@@ -87,13 +87,13 @@ func TestAPIGatewayDriver_Read_Success(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if out.ProviderID != "app-gw-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-gw-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -102,7 +102,7 @@ func TestAPIGatewayDriver_Update_Success(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	out, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-gateway",
 		Config: map[string]any{"routes": []any{map[string]any{"path": "/v2", "component": "api-svc"}}},
@@ -110,8 +110,8 @@ func TestAPIGatewayDriver_Update_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if out.ProviderID != "app-gw-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "app-gw-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -120,7 +120,7 @@ func TestAPIGatewayDriver_Update_Error(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-gateway",
 		Config: map[string]any{},
@@ -135,7 +135,7 @@ func TestAPIGatewayDriver_Delete_Success(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -147,7 +147,7 @@ func TestAPIGatewayDriver_Delete_Error(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -171,7 +171,7 @@ func TestAPIGatewayDriver_Diff_NoChanges(t *testing.T) {
 	mock := &mockAPIGatewayClient{}
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
-	current := &interfaces.ResourceOutput{ProviderID: "app-gw-123"}
+	current := &interfaces.ResourceOutput{ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
 	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "my-gateway"}, current)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
@@ -186,7 +186,7 @@ func TestAPIGatewayDriver_HealthCheck(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -198,7 +198,7 @@ func TestAPIGatewayDriver_HealthCheck(t *testing.T) {
 
 func TestAPIGatewayDriver_HealthCheck_Unhealthy(t *testing.T) {
 	app := &godo.App{
-		ID:   "app-gw-123",
+		ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Spec: &godo.AppSpec{Name: "my-gateway"},
 		// ActiveDeployment nil => pending/unhealthy
 	}
@@ -206,7 +206,7 @@ func TestAPIGatewayDriver_HealthCheck_Unhealthy(t *testing.T) {
 	d := drivers.NewAPIGatewayDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-gateway", ProviderID: "app-gw-123",
+		Name: "my-gateway", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)

--- a/internal/drivers/api_gateway_test.go
+++ b/internal/drivers/api_gateway_test.go
@@ -22,6 +22,12 @@ func (m *mockAPIGatewayClient) Create(_ context.Context, _ *godo.AppCreateReques
 func (m *mockAPIGatewayClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
 	return m.app, nil, m.err
 }
+func (m *mockAPIGatewayClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	if m.app != nil {
+		return []*godo.App{m.app}, nil, nil
+	}
+	return nil, nil, m.err
+}
 func (m *mockAPIGatewayClient) Update(_ context.Context, _ string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
 	return m.app, nil, m.err
 }

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -175,7 +175,11 @@ func (d *AppPlatformDriver) Diff(_ context.Context, desired interfaces.ResourceS
 }
 
 func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	app, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	app, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
@@ -234,7 +238,11 @@ func appHealthResult(app *godo.App) *interfaces.HealthResult {
 }
 
 func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
-	app, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	app, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("app platform scale read %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -242,7 +250,7 @@ func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRe
 	for _, svc := range spec.Services {
 		svc.InstanceCount = int64(replicas)
 	}
-	updated, _, err := d.client.Update(ctx, ref.ProviderID, &godo.AppUpdateRequest{Spec: spec})
+	updated, _, err := d.client.Update(ctx, providerID, &godo.AppUpdateRequest{Spec: spec})
 	if err != nil {
 		return nil, fmt.Errorf("app platform scale update %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -557,3 +557,5 @@ func envVarsFromConfig(cfg map[string]any) []*godo.AppVariableDefinition {
 }
 
 func (d *AppPlatformDriver) SensitiveKeys() []string { return nil }
+
+func (d *AppPlatformDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -20,6 +20,9 @@ type stateHealClient struct {
 	createApp *godo.App
 	createErr error
 
+	// Get returns getApp when set (used by HealthCheck and Scale after heal).
+	getApp *godo.App
+
 	// List (for findAppByName)
 	listApps  []*godo.App
 	listErr   error
@@ -43,6 +46,9 @@ func (c *stateHealClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*
 	return c.createApp, &godo.Response{Response: &http.Response{StatusCode: 200}}, c.createErr
 }
 func (c *stateHealClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	if c.getApp != nil {
+		return c.getApp, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in stateHealClient")
 }
 func (c *stateHealClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
@@ -222,5 +228,66 @@ func TestDelete_HealStaleName_LookupFails(t *testing.T) {
 	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"}
 	if err := d.Delete(context.Background(), ref); err == nil {
 		t.Fatal("expected error when name lookup fails, got nil")
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestHealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		listApps: []*godo.App{
+			{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		},
+		getApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{
+				Phase: godo.DeploymentPhase_Active,
+			},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if c.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", c.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
+	}
+}
+
+// ── Scale state-heal tests ────────────────────────────────────────────────────
+
+func TestScale_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	c := &stateHealClient{
+		listApps: []*godo.App{
+			{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		},
+		getApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "bmw-staging", Services: []*godo.AppServiceSpec{{Name: "web", InstanceCount: 1}}},
+		},
+		updatedApp: &godo.App{
+			ID:   uuid,
+			Spec: &godo.AppSpec{Name: "bmw-staging", Services: []*godo.AppServiceSpec{{Name: "web", InstanceCount: 3}}},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	ref := interfaces.ResourceRef{Name: "bmw-staging", ProviderID: "bmw-staging"} // stale name
+	_, err := d.Scale(context.Background(), ref, 3)
+	if err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+	if c.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", c.listCalls)
+	}
+	if c.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", c.updateCalledID, uuid)
 	}
 }

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -21,7 +21,9 @@ type stateHealClient struct {
 	createErr error
 
 	// Get returns getApp when set (used by HealthCheck and Scale after heal).
-	getApp *godo.App
+	// getCalledID records the last appID passed to Get for assertion in tests.
+	getApp      *godo.App
+	getCalledID string
 
 	// List (for findAppByName)
 	listApps  []*godo.App
@@ -45,7 +47,8 @@ type stateHealClient struct {
 func (c *stateHealClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
 	return c.createApp, &godo.Response{Response: &http.Response{StatusCode: 200}}, c.createErr
 }
-func (c *stateHealClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+func (c *stateHealClient) Get(_ context.Context, appID string) (*godo.App, *godo.Response, error) {
+	c.getCalledID = appID
 	if c.getApp != nil {
 		return c.getApp, nil, nil
 	}
@@ -256,6 +259,9 @@ func TestHealthCheck_HealsStaleName(t *testing.T) {
 	if c.listCalls < 1 {
 		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", c.listCalls)
 	}
+	if c.getCalledID != uuid {
+		t.Errorf("Get called with %q, want healed UUID %q", c.getCalledID, uuid)
+	}
 	if !result.Healthy {
 		t.Errorf("Healthy = false, want true after state-heal")
 	}
@@ -286,6 +292,9 @@ func TestScale_HealsStaleName(t *testing.T) {
 	}
 	if c.listCalls < 1 {
 		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", c.listCalls)
+	}
+	if c.getCalledID != uuid {
+		t.Errorf("Get called with %q, want healed UUID %q", c.getCalledID, uuid)
 	}
 	if c.updateCalledID != uuid {
 		t.Errorf("Update called with %q, want UUID %q", c.updateCalledID, uuid)

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -426,7 +426,7 @@ func TestAppPlatformDriver_HealthCheck_Unhealthy(t *testing.T) {
 // ── HealthCheck deployment-phase tests ───────────────────────────────────────
 
 func appWithPhases(active, inProgress, pending *godo.DeploymentPhase) *godo.App {
-	app := &godo.App{ID: "app-999", Spec: &godo.AppSpec{Name: "phased-app"}}
+	app := &godo.App{ID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5", Spec: &godo.AppSpec{Name: "phased-app"}}
 	if active != nil {
 		app.ActiveDeployment = &godo.Deployment{Phase: *active}
 	}
@@ -445,7 +445,7 @@ func TestAppPlatformDriver_HealthCheck_Active(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(phasePtr(godo.DeploymentPhase_Active), nil, nil),
 	}, "nyc3")
-	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestAppPlatformDriver_HealthCheck_InProgress_Building(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, phasePtr(godo.DeploymentPhase_Building), nil),
 	}, "nyc3")
-	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -474,7 +474,7 @@ func TestAppPlatformDriver_HealthCheck_InProgress_Deploying(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, phasePtr(godo.DeploymentPhase_Deploying), nil),
 	}, "nyc3")
-	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if result.Healthy {
 		t.Error("expected Healthy=false while DEPLOYING")
 	}
@@ -487,7 +487,7 @@ func TestAppPlatformDriver_HealthCheck_InProgress_Failed(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, phasePtr(godo.DeploymentPhase_Error), nil),
 	}, "nyc3")
-	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if result.Healthy {
 		t.Error("expected Healthy=false for ERROR phase")
 	}
@@ -500,7 +500,7 @@ func TestAppPlatformDriver_HealthCheck_PendingDeployment(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, nil, phasePtr(godo.DeploymentPhase_PendingBuild)),
 	}, "nyc3")
-	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if result.Healthy {
 		t.Error("expected Healthy=false with only a pending deployment")
 	}
@@ -513,7 +513,7 @@ func TestAppPlatformDriver_HealthCheck_NoDeployment(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, nil, nil),
 	}, "nyc3")
-	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if result.Healthy {
 		t.Error("expected Healthy=false with no deployments")
 	}
@@ -526,7 +526,7 @@ func TestAppPlatformDriver_HealthCheck_InProgress_UnknownPhase(t *testing.T) {
 	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
 		app: appWithPhases(nil, phasePtr(godo.DeploymentPhase_Unknown), nil),
 	}, "nyc3")
-	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "app-999"})
+	result, _ := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
 	if result.Healthy {
 		t.Error("expected Healthy=false for unknown phase")
 	}

--- a/internal/drivers/cache.go
+++ b/internal/drivers/cache.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -12,6 +13,7 @@ import (
 type CacheClient interface {
 	Create(ctx context.Context, req *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error)
 	Get(ctx context.Context, databaseID string) (*godo.Database, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]godo.Database, *godo.Response, error)
 	Resize(ctx context.Context, databaseID string, req *godo.DatabaseResizeRequest) (*godo.Response, error)
 	Delete(ctx context.Context, databaseID string) (*godo.Response, error)
 }
@@ -66,21 +68,70 @@ func (d *CacheDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*in
 	return cacheOutput(db), nil
 }
 
+// findCacheByName iterates the paginated database list (Redis engine only)
+// and returns the first entry whose Name matches. Returns ErrResourceNotFound
+// if no match is found.
+func (d *CacheDriver) findCacheByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		dbs, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("cache list: %w", WrapGodoError(err))
+		}
+		for i := range dbs {
+			if dbs[i].Name == name {
+				return cacheOutput(&dbs[i]), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("cache %q: %w", name, ErrResourceNotFound)
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *CacheDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: cache %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findCacheByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("cache state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *CacheDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	size := strFromConfig(spec.Config, "size", "db-s-1vcpu-1gb")
 	numNodes, _ := intFromConfig(spec.Config, "num_nodes", 1)
-	_, err := d.client.Resize(ctx, ref.ProviderID, &godo.DatabaseResizeRequest{
+	_, err = d.client.Resize(ctx, providerID, &godo.DatabaseResizeRequest{
 		SizeSlug: size,
 		NumNodes: numNodes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cache update %q: %w", ref.Name, WrapGodoError(err))
 	}
+	ref.ProviderID = providerID // pass healed ID to Read
 	return d.Read(ctx, ref)
 }
 
 func (d *CacheDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("cache delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/cache.go
+++ b/internal/drivers/cache.go
@@ -197,3 +197,5 @@ func cacheOutput(db *godo.Database) *interfaces.ResourceOutput {
 }
 
 func (d *CacheDriver) SensitiveKeys() []string { return nil }
+
+func (d *CacheDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/cache.go
+++ b/internal/drivers/cache.go
@@ -79,7 +79,7 @@ func (d *CacheDriver) findCacheByName(ctx context.Context, name string) (*interf
 			return nil, fmt.Errorf("cache list: %w", WrapGodoError(err))
 		}
 		for i := range dbs {
-			if dbs[i].Name == name {
+			if dbs[i].Name == name && dbs[i].EngineSlug == "redis" {
 				return cacheOutput(&dbs[i]), nil
 			}
 		}
@@ -152,7 +152,11 @@ func (d *CacheDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, c
 }
 
 func (d *CacheDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	db, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	db, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
@@ -161,17 +165,22 @@ func (d *CacheDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRe
 }
 
 func (d *CacheDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
-	db, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	db, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("cache scale read %q: %w", ref.Name, WrapGodoError(err))
 	}
-	_, err = d.client.Resize(ctx, ref.ProviderID, &godo.DatabaseResizeRequest{
+	_, err = d.client.Resize(ctx, providerID, &godo.DatabaseResizeRequest{
 		SizeSlug: db.SizeSlug,
 		NumNodes: replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cache scale %q: %w", ref.Name, WrapGodoError(err))
 	}
+	ref.ProviderID = providerID
 	return d.Read(ctx, ref)
 }
 

--- a/internal/drivers/cache_stateheal_test.go
+++ b/internal/drivers/cache_stateheal_test.go
@@ -121,7 +121,7 @@ func TestCacheDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestCacheDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestCacheDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &cacheStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewCacheDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/cache_stateheal_test.go
+++ b/internal/drivers/cache_stateheal_test.go
@@ -1,0 +1,152 @@
+package drivers
+
+// State-heal tests for CacheDriver.Update / Delete.
+// Cache.Update calls Resize (not a direct Update), then Read.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type cacheStateHealMock struct {
+	listDBs   []godo.Database
+	listErr   error
+	listCalls int
+
+	resizeCalledID string
+	resizeErr      error
+
+	deleteCalledID string
+	deleteErr      error
+
+	// getDB is returned by Get (called by Read after Resize).
+	getDB  *godo.Database
+	getErr error
+
+	createDB  *godo.Database
+	createErr error
+}
+
+func (m *cacheStateHealMock) Create(_ context.Context, _ *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error) {
+	return m.createDB, nil, m.createErr
+}
+func (m *cacheStateHealMock) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
+	return m.getDB, nil, m.getErr
+}
+func (m *cacheStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	m.listCalls++
+	return m.listDBs, nil, m.listErr
+}
+func (m *cacheStateHealMock) Resize(_ context.Context, dbID string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
+	m.resizeCalledID = dbID
+	return nil, m.resizeErr
+}
+func (m *cacheStateHealMock) Delete(_ context.Context, dbID string) (*godo.Response, error) {
+	m.deleteCalledID = dbID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestCacheDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		createDB: &godo.Database{ID: wantUUID, Name: "my-cache"},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-cache",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-cache" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestCacheDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		getDB: &godo.Database{ID: uuid, Name: "my-cache", Status: "online"},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cache", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-cache", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want %q", m.resizeCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestCacheDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-cache", Status: "online"},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cache", ProviderID: "my-cache"}, // stale name
+		interfaces.ResourceSpec{Name: "my-cache", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want UUID %q", m.resizeCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestCacheDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &cacheStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cache", ProviderID: "my-cache"},
+		interfaces.ResourceSpec{Name: "my-cache", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestCacheDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache"}},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-cache", ProviderID: "my-cache"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/cache_stateheal_test.go
+++ b/internal/drivers/cache_stateheal_test.go
@@ -99,7 +99,7 @@ func TestCacheDriver_Update_UsesExistingUUID(t *testing.T) {
 func TestCacheDriver_Update_HealsStaleName(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	m := &cacheStateHealMock{
-		listDBs: []godo.Database{{ID: uuid, Name: "my-cache"}},
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache", EngineSlug: "redis"}},
 		getDB:   &godo.Database{ID: uuid, Name: "my-cache", Status: "online"},
 	}
 	d := NewCacheDriverWithClient(m, "nyc3")
@@ -138,7 +138,7 @@ func TestCacheDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
 func TestCacheDriver_Delete_HealsStaleName(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	m := &cacheStateHealMock{
-		listDBs: []godo.Database{{ID: uuid, Name: "my-cache"}},
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache", EngineSlug: "redis"}},
 	}
 	d := NewCacheDriverWithClient(m, "nyc3")
 	if err := d.Delete(context.Background(),
@@ -148,5 +148,49 @@ func TestCacheDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestCacheDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache", EngineSlug: "redis"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-cache", Status: "online"},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-cache", ProviderID: "my-cache"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
+	}
+}
+
+// ── Scale state-heal tests ────────────────────────────────────────────────────
+
+func TestCacheDriver_Scale_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &cacheStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-cache", EngineSlug: "redis"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-cache", Status: "online"},
+	}
+	d := NewCacheDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-cache", ProviderID: "my-cache"} // stale name
+	_, err := d.Scale(context.Background(), ref, 3)
+	if err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want UUID %q", m.resizeCalledID, uuid)
 	}
 }

--- a/internal/drivers/cache_test.go
+++ b/internal/drivers/cache_test.go
@@ -21,6 +21,12 @@ func (m *mockCacheClient) Create(_ context.Context, _ *godo.DatabaseCreateReques
 func (m *mockCacheClient) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
 	return m.db, nil, m.err
 }
+func (m *mockCacheClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	if m.db != nil {
+		return []godo.Database{*m.db}, nil, nil
+	}
+	return nil, nil, m.err
+}
 func (m *mockCacheClient) Resize(_ context.Context, _ string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
 	return nil, m.err
 }

--- a/internal/drivers/cache_test.go
+++ b/internal/drivers/cache_test.go
@@ -36,7 +36,7 @@ func (m *mockCacheClient) Delete(_ context.Context, _ string) (*godo.Response, e
 
 func testRedisDB() *godo.Database {
 	return &godo.Database{
-		ID:          "cache-123",
+		ID:          "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name:        "my-cache",
 		EngineSlug:  "redis",
 		VersionSlug: "7",
@@ -65,8 +65,8 @@ func TestCacheDriver_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if out.ProviderID != "cache-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "cache-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 	if out.Status != "online" {
 		t.Errorf("Status = %q, want %q", out.Status, "online")
@@ -91,13 +91,13 @@ func TestCacheDriver_Read_Success(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if out.ProviderID != "cache-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "cache-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -106,7 +106,7 @@ func TestCacheDriver_Update_Success(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	out, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-cache",
 		Config: map[string]any{"size": "db-s-2vcpu-2gb", "num_nodes": 1},
@@ -114,8 +114,8 @@ func TestCacheDriver_Update_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if out.ProviderID != "cache-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "cache-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -124,7 +124,7 @@ func TestCacheDriver_Update_Error(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-cache",
 		Config: map[string]any{"size": "db-s-2vcpu-2gb"},
@@ -139,7 +139,7 @@ func TestCacheDriver_Delete_Success(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -151,7 +151,7 @@ func TestCacheDriver_Delete_Error(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -199,7 +199,7 @@ func TestCacheDriver_HealthCheck(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -211,7 +211,7 @@ func TestCacheDriver_HealthCheck(t *testing.T) {
 
 func TestCacheDriver_HealthCheck_Unhealthy(t *testing.T) {
 	db := &godo.Database{
-		ID:     "cache-123",
+		ID:     "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name:   "my-cache",
 		Status: "migrating",
 	}
@@ -219,7 +219,7 @@ func TestCacheDriver_HealthCheck_Unhealthy(t *testing.T) {
 	d := drivers.NewCacheDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-cache", ProviderID: "cache-123",
+		Name: "my-cache", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)

--- a/internal/drivers/certificate.go
+++ b/internal/drivers/certificate.go
@@ -134,7 +134,11 @@ func (d *CertificateDriver) Diff(_ context.Context, desired interfaces.ResourceS
 }
 
 func (d *CertificateDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	cert, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	cert, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}

--- a/internal/drivers/certificate.go
+++ b/internal/drivers/certificate.go
@@ -161,3 +161,5 @@ func certOutput(cert *godo.Certificate, name string) *interfaces.ResourceOutput 
 }
 
 func (d *CertificateDriver) SensitiveKeys() []string { return nil }
+
+func (d *CertificateDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/certificate.go
+++ b/internal/drivers/certificate.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -65,6 +66,46 @@ func (d *CertificateDriver) Read(ctx context.Context, ref interfaces.ResourceRef
 	return certOutput(cert, ref.Name), nil
 }
 
+// findCertificateByName iterates the paginated certificate list and returns
+// the first certificate whose Name matches. Returns ErrResourceNotFound if
+// no match is found.
+func (d *CertificateDriver) findCertificateByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		certs, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("certificate list: %w", WrapGodoError(err))
+		}
+		for i := range certs {
+			if certs[i].Name == name {
+				return certOutput(&certs[i], name), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("certificate %q: %w", name, ErrResourceNotFound)
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *CertificateDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: certificate %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findCertificateByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("certificate state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *CertificateDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	// Certificates are immutable; delete and recreate.
 	if err := d.Delete(ctx, ref); err != nil {
@@ -74,7 +115,11 @@ func (d *CertificateDriver) Update(ctx context.Context, ref interfaces.ResourceR
 }
 
 func (d *CertificateDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("certificate delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/certificate_stateheal_test.go
+++ b/internal/drivers/certificate_stateheal_test.go
@@ -115,7 +115,7 @@ func TestCertificateDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestCertificateDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestCertificateDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &certificateStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewCertificateDriverWithClient(m)
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/certificate_stateheal_test.go
+++ b/internal/drivers/certificate_stateheal_test.go
@@ -1,0 +1,140 @@
+package drivers
+
+// State-heal tests for CertificateDriver.Update / Delete.
+// Certificate.Update is delete-then-recreate; heal is exercised through Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type certificateStateHealMock struct {
+	listCerts []godo.Certificate
+	listErr   error
+	listCalls int
+
+	deleteCalledID string
+	deleteErr      error
+
+	createCert *godo.Certificate
+	createErr  error
+}
+
+func (m *certificateStateHealMock) Create(_ context.Context, _ *godo.CertificateRequest) (*godo.Certificate, *godo.Response, error) {
+	return m.createCert, nil, m.createErr
+}
+func (m *certificateStateHealMock) Get(_ context.Context, _ string) (*godo.Certificate, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in certificateStateHealMock")
+}
+func (m *certificateStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Certificate, *godo.Response, error) {
+	m.listCalls++
+	return m.listCerts, nil, m.listErr
+}
+func (m *certificateStateHealMock) Delete(_ context.Context, certID string) (*godo.Response, error) {
+	m.deleteCalledID = certID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestCertificateDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &certificateStateHealMock{
+		createCert: &godo.Certificate{ID: wantUUID, Name: "my-cert"},
+	}
+	d := NewCertificateDriverWithClient(m)
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-cert",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-cert" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update (delete-then-recreate) ─────────────────────────────────────────────
+
+func TestCertificateDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &certificateStateHealMock{
+		// No list needed — ProviderID is already a valid UUID.
+		createCert: &godo.Certificate{ID: "new-cert-uuid-0000-000000000001", Name: "my-cert"},
+	}
+	d := NewCertificateDriverWithClient(m)
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cert", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-cert", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want %q", m.deleteCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestCertificateDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &certificateStateHealMock{
+		listCerts: []godo.Certificate{{ID: uuid, Name: "my-cert"}},
+		createCert: &godo.Certificate{ID: "new-cert-uuid-0000-000000000001", Name: "my-cert"},
+	}
+	d := NewCertificateDriverWithClient(m)
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cert", ProviderID: "my-cert"}, // stale name
+		interfaces.ResourceSpec{Name: "my-cert", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	// Delete (inside Update) must have been called with the healed UUID.
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+func TestCertificateDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &certificateStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewCertificateDriverWithClient(m)
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cert", ProviderID: "my-cert"},
+		interfaces.ResourceSpec{Name: "my-cert", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestCertificateDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &certificateStateHealMock{
+		listCerts: []godo.Certificate{{ID: uuid, Name: "my-cert"}},
+	}
+	d := NewCertificateDriverWithClient(m)
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-cert", ProviderID: "my-cert"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/certificate_stateheal_test.go
+++ b/internal/drivers/certificate_stateheal_test.go
@@ -22,12 +22,18 @@ type certificateStateHealMock struct {
 
 	createCert *godo.Certificate
 	createErr  error
+
+	// getCert is returned by Get (used by HealthCheck after heal).
+	getCert *godo.Certificate
 }
 
 func (m *certificateStateHealMock) Create(_ context.Context, _ *godo.CertificateRequest) (*godo.Certificate, *godo.Response, error) {
 	return m.createCert, nil, m.createErr
 }
 func (m *certificateStateHealMock) Get(_ context.Context, _ string) (*godo.Certificate, *godo.Response, error) {
+	if m.getCert != nil {
+		return m.getCert, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in certificateStateHealMock")
 }
 func (m *certificateStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Certificate, *godo.Response, error) {
@@ -136,5 +142,27 @@ func TestCertificateDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestCertificateDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &certificateStateHealMock{
+		listCerts: []godo.Certificate{{ID: uuid, Name: "my-cert"}},
+		getCert:   &godo.Certificate{ID: uuid, Name: "my-cert", State: "verified"},
+	}
+	d := NewCertificateDriverWithClient(m)
+	ref := interfaces.ResourceRef{Name: "my-cert", ProviderID: "my-cert"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
 	}
 }

--- a/internal/drivers/certificate_stateheal_test.go
+++ b/internal/drivers/certificate_stateheal_test.go
@@ -74,7 +74,7 @@ func TestCertificateDriver_Update_UsesExistingUUID(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	m := &certificateStateHealMock{
 		// No list needed — ProviderID is already a valid UUID.
-		createCert: &godo.Certificate{ID: "new-cert-uuid-0000-000000000001", Name: "my-cert"},
+		createCert: &godo.Certificate{ID: "a1b2c3d4-0000-0000-0000-ef1234567891", Name: "my-cert"},
 	}
 	d := NewCertificateDriverWithClient(m)
 	_, err := d.Update(context.Background(),
@@ -96,7 +96,7 @@ func TestCertificateDriver_Update_HealsStaleName(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	m := &certificateStateHealMock{
 		listCerts: []godo.Certificate{{ID: uuid, Name: "my-cert"}},
-		createCert: &godo.Certificate{ID: "new-cert-uuid-0000-000000000001", Name: "my-cert"},
+		createCert: &godo.Certificate{ID: "a1b2c3d4-0000-0000-0000-ef1234567891", Name: "my-cert"},
 	}
 	d := NewCertificateDriverWithClient(m)
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -279,3 +279,5 @@ func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 		Status:     db.Status,
 	}
 }
+
+func (d *DatabaseDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -99,10 +100,31 @@ func (d *DatabaseDriver) findDatabaseByName(ctx context.Context, name string) (*
 	return nil, fmt.Errorf("database %q: %w", name, ErrResourceNotFound)
 }
 
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *DatabaseDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: database %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findDatabaseByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("database state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	size := strFromConfig(spec.Config, "size", "db-s-1vcpu-1gb")
 	numNodes, _ := intFromConfig(spec.Config, "num_nodes", 1)
-	_, err := d.client.Resize(ctx, ref.ProviderID, &godo.DatabaseResizeRequest{
+	_, err = d.client.Resize(ctx, providerID, &godo.DatabaseResizeRequest{
 		SizeSlug: size,
 		NumNodes: numNodes,
 	})
@@ -112,18 +134,23 @@ func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef,
 	// Sync firewall rules when trusted_sources key is present in config.
 	// "present but empty" clears all rules; absent key leaves existing rules unchanged.
 	if rules, ok := trustedSourceFirewallRulesFromConfig(spec.Config); ok {
-		_, err = d.client.UpdateFirewallRules(ctx, ref.ProviderID, &godo.DatabaseUpdateFirewallRulesRequest{
+		_, err = d.client.UpdateFirewallRules(ctx, providerID, &godo.DatabaseUpdateFirewallRulesRequest{
 			Rules: rules,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("database update firewall %q: %w", ref.Name, WrapGodoError(err))
 		}
 	}
+	ref.ProviderID = providerID // pass healed ID to Read
 	return d.Read(ctx, ref)
 }
 
 func (d *DatabaseDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("database delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -171,7 +171,11 @@ func (d *DatabaseDriver) Diff(_ context.Context, desired interfaces.ResourceSpec
 }
 
 func (d *DatabaseDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	db, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	db, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
@@ -180,17 +184,22 @@ func (d *DatabaseDriver) HealthCheck(ctx context.Context, ref interfaces.Resourc
 }
 
 func (d *DatabaseDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
-	db, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	db, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("database scale read %q: %w", ref.Name, WrapGodoError(err))
 	}
-	_, err = d.client.Resize(ctx, ref.ProviderID, &godo.DatabaseResizeRequest{
+	_, err = d.client.Resize(ctx, providerID, &godo.DatabaseResizeRequest{
 		SizeSlug: db.SizeSlug,
 		NumNodes: replicas,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("database scale %q: %w", ref.Name, WrapGodoError(err))
 	}
+	ref.ProviderID = providerID
 	return d.Read(ctx, ref)
 }
 

--- a/internal/drivers/database_stateheal_test.go
+++ b/internal/drivers/database_stateheal_test.go
@@ -153,3 +153,47 @@ func TestDatabaseDriver_Delete_HealsStaleName(t *testing.T) {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
 	}
 }
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestDatabaseDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-db"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-db", Status: "online"},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-db", ProviderID: "my-db"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
+	}
+}
+
+// ── Scale state-heal tests ────────────────────────────────────────────────────
+
+func TestDatabaseDriver_Scale_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-db"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-db", Status: "online"},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-db", ProviderID: "my-db"} // stale name
+	_, err := d.Scale(context.Background(), ref, 3)
+	if err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want UUID %q", m.resizeCalledID, uuid)
+	}
+}

--- a/internal/drivers/database_stateheal_test.go
+++ b/internal/drivers/database_stateheal_test.go
@@ -1,0 +1,155 @@
+package drivers
+
+// State-heal tests for DatabaseDriver.Update / Delete.
+// Database.Update calls Resize (not a direct Update), then Read.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type databaseStateHealMock struct {
+	listDBs   []godo.Database
+	listErr   error
+	listCalls int
+
+	resizeCalledID string
+	resizeErr      error
+
+	deleteCalledID string
+	deleteErr      error
+
+	// getDB is returned by Get (called by Read after Resize).
+	getDB  *godo.Database
+	getErr error
+
+	createDB  *godo.Database
+	createErr error
+}
+
+func (m *databaseStateHealMock) Create(_ context.Context, _ *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error) {
+	return m.createDB, nil, m.createErr
+}
+func (m *databaseStateHealMock) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
+	return m.getDB, nil, m.getErr
+}
+func (m *databaseStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	m.listCalls++
+	return m.listDBs, nil, m.listErr
+}
+func (m *databaseStateHealMock) Resize(_ context.Context, dbID string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
+	m.resizeCalledID = dbID
+	return nil, m.resizeErr
+}
+func (m *databaseStateHealMock) Delete(_ context.Context, dbID string) (*godo.Response, error) {
+	m.deleteCalledID = dbID
+	return nil, m.deleteErr
+}
+func (m *databaseStateHealMock) UpdateFirewallRules(_ context.Context, _ string, _ *godo.DatabaseUpdateFirewallRulesRequest) (*godo.Response, error) {
+	return nil, nil
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestDatabaseDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		createDB: &godo.Database{ID: wantUUID, Name: "my-db"},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-db",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-db" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestDatabaseDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		getDB: &godo.Database{ID: uuid, Name: "my-db", Status: "online"},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-db", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-db", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want %q", m.resizeCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestDatabaseDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-db"}},
+		getDB:   &godo.Database{ID: uuid, Name: "my-db", Status: "online"},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-db", ProviderID: "my-db"}, // stale name
+		interfaces.ResourceSpec{Name: "my-db", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.resizeCalledID != uuid {
+		t.Errorf("Resize called with %q, want UUID %q", m.resizeCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestDatabaseDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &databaseStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-db", ProviderID: "my-db"},
+		interfaces.ResourceSpec{Name: "my-db", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestDatabaseDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &databaseStateHealMock{
+		listDBs: []godo.Database{{ID: uuid, Name: "my-db"}},
+	}
+	d := NewDatabaseDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-db", ProviderID: "my-db"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/database_stateheal_test.go
+++ b/internal/drivers/database_stateheal_test.go
@@ -124,7 +124,7 @@ func TestDatabaseDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestDatabaseDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestDatabaseDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &databaseStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewDatabaseDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -166,3 +166,5 @@ func dnsOutput(dom *godo.Domain, name string) *interfaces.ResourceOutput {
 }
 
 func (d *DNSDriver) SensitiveKeys() []string { return nil }
+
+func (d *DNSDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatDomainName }

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -107,7 +107,7 @@ func (d *DropletDriver) Diff(_ context.Context, desired interfaces.ResourceSpec,
 func (d *DropletDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
 	id, err := providerIDToInt(ref.ProviderID)
 	if err != nil {
-		return &interfaces.HealthResult{Healthy: false, Message: fmt.Sprintf("invalid ProviderID %q: %s", ref.ProviderID, err)}, nil
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
 	droplet, _, err := d.client.Get(ctx, id)
 	if err != nil {

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -141,11 +142,12 @@ func dropletOutput(droplet *godo.Droplet) *interfaces.ResourceOutput {
 }
 
 // providerIDToInt converts a string provider ID to int for godo Droplet API
-// calls. Returns an error if the string does not parse as a positive integer,
-// preventing silent calls against droplet ID 0 when state carries a stale name.
+// calls. Uses strconv.Atoi for strict whole-string parsing — partial matches
+// like "123abc" are rejected. Returns an error for any non-positive-integer
+// value, preventing silent API calls with droplet ID 0 or a wrong ID.
 func providerIDToInt(id string) (int, error) {
-	var n int
-	if _, err := fmt.Sscanf(id, "%d", &n); err != nil || n <= 0 {
+	n, err := strconv.Atoi(id)
+	if err != nil || n <= 0 {
 		return 0, fmt.Errorf("ProviderID %q is not a valid droplet integer ID", id)
 	}
 	return n, nil
@@ -154,6 +156,7 @@ func providerIDToInt(id string) (int, error) {
 func (d *DropletDriver) SensitiveKeys() []string { return nil }
 
 // ProviderIDFormat returns Freeform because DO Droplet IDs are integers, not
-// UUIDs. We declare Freeform and rely on godo's int-parsing to reject stale
-// name values with a 404 at the API level — no UUID-based state-heal needed.
+// UUIDs. We declare Freeform; providerIDToInt performs strict local validation
+// and rejects any non-integer ProviderID with an explicit error before any
+// API call is made — no UUID-based state-heal needed for Droplet.
 func (d *DropletDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -139,3 +139,8 @@ func providerIDToInt(id string) int {
 }
 
 func (d *DropletDriver) SensitiveKeys() []string { return nil }
+
+// ProviderIDFormat returns Freeform because DO Droplet IDs are integers, not
+// UUIDs. We declare Freeform and rely on godo's int-parsing to reject stale
+// name values with a 404 at the API level — no UUID-based state-heal needed.
+func (d *DropletDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -54,7 +54,10 @@ func (d *DropletDriver) Create(ctx context.Context, spec interfaces.ResourceSpec
 }
 
 func (d *DropletDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
-	id := providerIDToInt(ref.ProviderID)
+	id, err := providerIDToInt(ref.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("droplet read %q: invalid ProviderID %q: %w", ref.Name, ref.ProviderID, err)
+	}
 	droplet, _, err := d.client.Get(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("droplet read %q: %w", ref.Name, WrapGodoError(err))
@@ -67,8 +70,11 @@ func (d *DropletDriver) Update(_ context.Context, _ interfaces.ResourceRef, _ in
 }
 
 func (d *DropletDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	id := providerIDToInt(ref.ProviderID)
-	_, err := d.client.Delete(ctx, id)
+	id, err := providerIDToInt(ref.ProviderID)
+	if err != nil {
+		return fmt.Errorf("droplet delete %q: invalid ProviderID %q: %w", ref.Name, ref.ProviderID, err)
+	}
+	_, err = d.client.Delete(ctx, id)
 	if err != nil {
 		return fmt.Errorf("droplet delete %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -98,7 +104,10 @@ func (d *DropletDriver) Diff(_ context.Context, desired interfaces.ResourceSpec,
 }
 
 func (d *DropletDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	id := providerIDToInt(ref.ProviderID)
+	id, err := providerIDToInt(ref.ProviderID)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: fmt.Sprintf("invalid ProviderID %q: %s", ref.ProviderID, err)}, nil
+	}
 	droplet, _, err := d.client.Get(ctx, id)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
@@ -131,11 +140,15 @@ func dropletOutput(droplet *godo.Droplet) *interfaces.ResourceOutput {
 	}
 }
 
-// providerIDToInt converts a string provider ID to int for godo Droplet API calls.
-func providerIDToInt(id string) int {
+// providerIDToInt converts a string provider ID to int for godo Droplet API
+// calls. Returns an error if the string does not parse as a positive integer,
+// preventing silent calls against droplet ID 0 when state carries a stale name.
+func providerIDToInt(id string) (int, error) {
 	var n int
-	fmt.Sscanf(id, "%d", &n)
-	return n
+	if _, err := fmt.Sscanf(id, "%d", &n); err != nil || n <= 0 {
+		return 0, fmt.Errorf("ProviderID %q is not a valid droplet integer ID", id)
+	}
+	return n, nil
 }
 
 func (d *DropletDriver) SensitiveKeys() []string { return nil }

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -84,9 +85,30 @@ func (d *FirewallDriver) findFirewallByName(ctx context.Context, name string) (*
 	return nil, fmt.Errorf("firewall %q: %w", name, ErrResourceNotFound)
 }
 
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *FirewallDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: firewall %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findFirewallByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("firewall state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *FirewallDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	req := firewallRequest(spec)
-	fw, _, err := d.client.Update(ctx, ref.ProviderID, req)
+	fw, _, err := d.client.Update(ctx, providerID, req)
 	if err != nil {
 		return nil, fmt.Errorf("firewall update %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -94,7 +116,11 @@ func (d *FirewallDriver) Update(ctx context.Context, ref interfaces.ResourceRef,
 }
 
 func (d *FirewallDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("firewall delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -218,3 +218,5 @@ func fwOutput(fw *godo.Firewall) *interfaces.ResourceOutput {
 }
 
 func (d *FirewallDriver) SensitiveKeys() []string { return nil }
+
+func (d *FirewallDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -135,7 +135,11 @@ func (d *FirewallDriver) Diff(_ context.Context, desired interfaces.ResourceSpec
 }
 
 func (d *FirewallDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	fw, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	fw, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}

--- a/internal/drivers/firewall_stateheal_test.go
+++ b/internal/drivers/firewall_stateheal_test.go
@@ -25,12 +25,18 @@ type firewallStateHealMock struct {
 
 	createFW  *godo.Firewall
 	createErr error
+
+	// getFW is returned by Get (used by HealthCheck after heal).
+	getFW *godo.Firewall
 }
 
 func (m *firewallStateHealMock) Create(_ context.Context, _ *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
 	return m.createFW, nil, m.createErr
 }
 func (m *firewallStateHealMock) Get(_ context.Context, _ string) (*godo.Firewall, *godo.Response, error) {
+	if m.getFW != nil {
+		return m.getFW, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in firewallStateHealMock")
 }
 func (m *firewallStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
@@ -144,5 +150,27 @@ func TestFirewallDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestFirewallDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &firewallStateHealMock{
+		listFWs: []godo.Firewall{{ID: uuid, Name: "my-fw"}},
+		getFW:   &godo.Firewall{ID: uuid, Name: "my-fw", Status: "succeeded"},
+	}
+	d := NewFirewallDriverWithClient(m)
+	ref := interfaces.ResourceRef{Name: "my-fw", ProviderID: "my-fw"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
 	}
 }

--- a/internal/drivers/firewall_stateheal_test.go
+++ b/internal/drivers/firewall_stateheal_test.go
@@ -1,0 +1,148 @@
+package drivers
+
+// State-heal tests for FirewallDriver.Update / Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type firewallStateHealMock struct {
+	listFWs   []godo.Firewall
+	listErr   error
+	listCalls int
+
+	updatedFW      *godo.Firewall
+	updateErr      error
+	updateCalledID string
+
+	deleteCalledID string
+	deleteErr      error
+
+	createFW  *godo.Firewall
+	createErr error
+}
+
+func (m *firewallStateHealMock) Create(_ context.Context, _ *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+	return m.createFW, nil, m.createErr
+}
+func (m *firewallStateHealMock) Get(_ context.Context, _ string) (*godo.Firewall, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in firewallStateHealMock")
+}
+func (m *firewallStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Firewall, *godo.Response, error) {
+	m.listCalls++
+	return m.listFWs, nil, m.listErr
+}
+func (m *firewallStateHealMock) Update(_ context.Context, fwID string, _ *godo.FirewallRequest) (*godo.Firewall, *godo.Response, error) {
+	m.updateCalledID = fwID
+	return m.updatedFW, nil, m.updateErr
+}
+func (m *firewallStateHealMock) Delete(_ context.Context, fwID string) (*godo.Response, error) {
+	m.deleteCalledID = fwID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestFirewallDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &firewallStateHealMock{
+		createFW: &godo.Firewall{ID: wantUUID, Name: "my-fw"},
+	}
+	d := NewFirewallDriverWithClient(m)
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-fw",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-fw" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestFirewallDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &firewallStateHealMock{
+		updatedFW: &godo.Firewall{ID: uuid, Name: "my-fw"},
+	}
+	d := NewFirewallDriverWithClient(m)
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-fw", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-fw", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want %q", m.updateCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestFirewallDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &firewallStateHealMock{
+		listFWs:   []godo.Firewall{{ID: uuid, Name: "my-fw"}},
+		updatedFW: &godo.Firewall{ID: uuid, Name: "my-fw"},
+	}
+	d := NewFirewallDriverWithClient(m)
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-fw", ProviderID: "my-fw"}, // stale name
+		interfaces.ResourceSpec{Name: "my-fw", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", m.updateCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestFirewallDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &firewallStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewFirewallDriverWithClient(m)
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-fw", ProviderID: "my-fw"},
+		interfaces.ResourceSpec{Name: "my-fw", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestFirewallDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &firewallStateHealMock{
+		listFWs: []godo.Firewall{{ID: uuid, Name: "my-fw"}},
+	}
+	d := NewFirewallDriverWithClient(m)
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-fw", ProviderID: "my-fw"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/firewall_stateheal_test.go
+++ b/internal/drivers/firewall_stateheal_test.go
@@ -123,7 +123,7 @@ func TestFirewallDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestFirewallDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestFirewallDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &firewallStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewFirewallDriverWithClient(m)
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/iam_role.go
+++ b/internal/drivers/iam_role.go
@@ -87,3 +87,5 @@ func iamOutput(name string, config map[string]any) *interfaces.ResourceOutput {
 }
 
 func (d *IAMRoleDriver) SensitiveKeys() []string { return nil }
+
+func (d *IAMRoleDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }

--- a/internal/drivers/kubernetes.go
+++ b/internal/drivers/kubernetes.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -12,6 +13,7 @@ import (
 type KubernetesClient interface {
 	Create(ctx context.Context, req *godo.KubernetesClusterCreateRequest) (*godo.KubernetesCluster, *godo.Response, error)
 	Get(ctx context.Context, clusterID string) (*godo.KubernetesCluster, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]*godo.KubernetesCluster, *godo.Response, error)
 	Update(ctx context.Context, clusterID string, req *godo.KubernetesClusterUpdateRequest) (*godo.KubernetesCluster, *godo.Response, error)
 	Delete(ctx context.Context, clusterID string) (*godo.Response, error)
 	UpdateNodePool(ctx context.Context, clusterID, poolID string, req *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error)
@@ -70,11 +72,53 @@ func (d *KubernetesDriver) Read(ctx context.Context, ref interfaces.ResourceRef)
 	return k8sOutput(cluster), nil
 }
 
+// findClusterByName iterates the paginated cluster list and returns the first
+// entry whose Name matches. Returns ErrResourceNotFound if no match.
+func (d *KubernetesDriver) findClusterByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		clusters, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("kubernetes list: %w", WrapGodoError(err))
+		}
+		for _, c := range clusters {
+			if c.Name == name {
+				return k8sOutput(c), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("k8s_cluster %q: %w", name, ErrResourceNotFound)
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+func (d *KubernetesDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: k8s_cluster %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findClusterByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("k8s_cluster state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *KubernetesDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	req := &godo.KubernetesClusterUpdateRequest{
 		Name: spec.Name,
 	}
-	cluster, _, err := d.client.Update(ctx, ref.ProviderID, req)
+	cluster, _, err := d.client.Update(ctx, providerID, req)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes update %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -82,7 +126,11 @@ func (d *KubernetesDriver) Update(ctx context.Context, ref interfaces.ResourceRe
 }
 
 func (d *KubernetesDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("kubernetes delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/kubernetes.go
+++ b/internal/drivers/kubernetes.go
@@ -197,3 +197,5 @@ func k8sOutput(cluster *godo.KubernetesCluster) *interfaces.ResourceOutput {
 }
 
 func (d *KubernetesDriver) SensitiveKeys() []string { return nil }
+
+func (d *KubernetesDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/kubernetes.go
+++ b/internal/drivers/kubernetes.go
@@ -145,7 +145,11 @@ func (d *KubernetesDriver) Diff(_ context.Context, desired interfaces.ResourceSp
 }
 
 func (d *KubernetesDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	cluster, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	cluster, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
@@ -160,7 +164,11 @@ func (d *KubernetesDriver) HealthCheck(ctx context.Context, ref interfaces.Resou
 // Scale resizes the first node pool of the cluster to the given replica count
 // using godo.Kubernetes.UpdateNodePool.
 func (d *KubernetesDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
-	cluster, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	cluster, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes scale read %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -169,12 +177,13 @@ func (d *KubernetesDriver) Scale(ctx context.Context, ref interfaces.ResourceRef
 	}
 	pool := cluster.NodePools[0]
 	count := replicas
-	_, _, err = d.client.UpdateNodePool(ctx, ref.ProviderID, pool.ID, &godo.KubernetesNodePoolUpdateRequest{
+	_, _, err = d.client.UpdateNodePool(ctx, providerID, pool.ID, &godo.KubernetesNodePoolUpdateRequest{
 		Count: &count,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("kubernetes scale %q pool %q: %w", ref.Name, pool.ID, WrapGodoError(err))
 	}
+	ref.ProviderID = providerID
 	return d.Read(ctx, ref)
 }
 

--- a/internal/drivers/kubernetes_stateheal_test.go
+++ b/internal/drivers/kubernetes_stateheal_test.go
@@ -25,12 +25,18 @@ type k8sStateHealMock struct {
 
 	createCluster *godo.KubernetesCluster
 	createErr     error
+
+	// getCluster is returned by Get (used by HealthCheck and Scale after heal).
+	getCluster *godo.KubernetesCluster
 }
 
 func (m *k8sStateHealMock) Create(_ context.Context, _ *godo.KubernetesClusterCreateRequest) (*godo.KubernetesCluster, *godo.Response, error) {
 	return m.createCluster, nil, m.createErr
 }
 func (m *k8sStateHealMock) Get(_ context.Context, _ string) (*godo.KubernetesCluster, *godo.Response, error) {
+	if m.getCluster != nil {
+		return m.getCluster, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in k8sStateHealMock")
 }
 func (m *k8sStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.KubernetesCluster, *godo.Response, error) {
@@ -46,7 +52,7 @@ func (m *k8sStateHealMock) Delete(_ context.Context, clusterID string) (*godo.Re
 	return nil, m.deleteErr
 }
 func (m *k8sStateHealMock) UpdateNodePool(_ context.Context, _, _ string, _ *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error) {
-	return nil, nil, errors.New("not implemented in k8sStateHealMock")
+	return &godo.KubernetesNodePool{}, nil, nil
 }
 
 // ── Create ────────────────────────────────────────────────────────────────────
@@ -147,5 +153,51 @@ func TestKubernetesDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestKubernetesDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &k8sStateHealMock{
+		listClusters: []*godo.KubernetesCluster{{ID: uuid, Name: "my-cluster"}},
+		getCluster: &godo.KubernetesCluster{
+			ID:     uuid,
+			Name:   "my-cluster",
+			Status: &godo.KubernetesClusterStatus{State: godo.KubernetesClusterStatusRunning},
+		},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-cluster", ProviderID: "my-cluster"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
+	}
+}
+
+// ── Scale state-heal tests ────────────────────────────────────────────────────
+
+func TestKubernetesDriver_Scale_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	pool := &godo.KubernetesNodePool{ID: "pool-1", Count: 1}
+	m := &k8sStateHealMock{
+		listClusters: []*godo.KubernetesCluster{{ID: uuid, Name: "my-cluster"}},
+		getCluster:   &godo.KubernetesCluster{ID: uuid, Name: "my-cluster", NodePools: []*godo.KubernetesNodePool{pool}},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-cluster", ProviderID: "my-cluster"} // stale name
+	_, err := d.Scale(context.Background(), ref, 3)
+	if err != nil {
+		t.Fatalf("Scale: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
 	}
 }

--- a/internal/drivers/kubernetes_stateheal_test.go
+++ b/internal/drivers/kubernetes_stateheal_test.go
@@ -27,13 +27,19 @@ type k8sStateHealMock struct {
 	createErr     error
 
 	// getCluster is returned by Get (used by HealthCheck and Scale after heal).
-	getCluster *godo.KubernetesCluster
+	// getCalledID records the last clusterID passed to Get.
+	getCluster  *godo.KubernetesCluster
+	getCalledID string
+
+	// updateNodePoolCalledClusterID records the clusterID passed to UpdateNodePool.
+	updateNodePoolCalledClusterID string
 }
 
 func (m *k8sStateHealMock) Create(_ context.Context, _ *godo.KubernetesClusterCreateRequest) (*godo.KubernetesCluster, *godo.Response, error) {
 	return m.createCluster, nil, m.createErr
 }
-func (m *k8sStateHealMock) Get(_ context.Context, _ string) (*godo.KubernetesCluster, *godo.Response, error) {
+func (m *k8sStateHealMock) Get(_ context.Context, clusterID string) (*godo.KubernetesCluster, *godo.Response, error) {
+	m.getCalledID = clusterID
 	if m.getCluster != nil {
 		return m.getCluster, nil, nil
 	}
@@ -51,7 +57,8 @@ func (m *k8sStateHealMock) Delete(_ context.Context, clusterID string) (*godo.Re
 	m.deleteCalledID = clusterID
 	return nil, m.deleteErr
 }
-func (m *k8sStateHealMock) UpdateNodePool(_ context.Context, _, _ string, _ *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error) {
+func (m *k8sStateHealMock) UpdateNodePool(_ context.Context, clusterID, _ string, _ *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error) {
+	m.updateNodePoolCalledClusterID = clusterID
 	return &godo.KubernetesNodePool{}, nil, nil
 }
 
@@ -177,6 +184,9 @@ func TestKubernetesDriver_HealthCheck_HealsStaleName(t *testing.T) {
 	if m.listCalls < 1 {
 		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
 	}
+	if m.getCalledID != uuid {
+		t.Errorf("Get called with %q, want healed UUID %q", m.getCalledID, uuid)
+	}
 	if !result.Healthy {
 		t.Errorf("Healthy = false, want true after state-heal")
 	}
@@ -199,5 +209,11 @@ func TestKubernetesDriver_Scale_HealsStaleName(t *testing.T) {
 	}
 	if m.listCalls < 1 {
 		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if m.getCalledID != uuid {
+		t.Errorf("Get called with %q, want healed UUID %q", m.getCalledID, uuid)
+	}
+	if m.updateNodePoolCalledClusterID != uuid {
+		t.Errorf("UpdateNodePool called with clusterID %q, want healed UUID %q", m.updateNodePoolCalledClusterID, uuid)
 	}
 }

--- a/internal/drivers/kubernetes_stateheal_test.go
+++ b/internal/drivers/kubernetes_stateheal_test.go
@@ -1,0 +1,151 @@
+package drivers
+
+// State-heal tests for KubernetesDriver.Update / Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type k8sStateHealMock struct {
+	listClusters []*godo.KubernetesCluster
+	listErr      error
+	listCalls    int
+
+	updatedCluster *godo.KubernetesCluster
+	updateErr      error
+	updateCalledID string
+
+	deleteCalledID string
+	deleteErr      error
+
+	createCluster *godo.KubernetesCluster
+	createErr     error
+}
+
+func (m *k8sStateHealMock) Create(_ context.Context, _ *godo.KubernetesClusterCreateRequest) (*godo.KubernetesCluster, *godo.Response, error) {
+	return m.createCluster, nil, m.createErr
+}
+func (m *k8sStateHealMock) Get(_ context.Context, _ string) (*godo.KubernetesCluster, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in k8sStateHealMock")
+}
+func (m *k8sStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.KubernetesCluster, *godo.Response, error) {
+	m.listCalls++
+	return m.listClusters, nil, m.listErr
+}
+func (m *k8sStateHealMock) Update(_ context.Context, clusterID string, _ *godo.KubernetesClusterUpdateRequest) (*godo.KubernetesCluster, *godo.Response, error) {
+	m.updateCalledID = clusterID
+	return m.updatedCluster, nil, m.updateErr
+}
+func (m *k8sStateHealMock) Delete(_ context.Context, clusterID string) (*godo.Response, error) {
+	m.deleteCalledID = clusterID
+	return nil, m.deleteErr
+}
+func (m *k8sStateHealMock) UpdateNodePool(_ context.Context, _, _ string, _ *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in k8sStateHealMock")
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestKubernetesDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &k8sStateHealMock{
+		createCluster: &godo.KubernetesCluster{ID: wantUUID, Name: "my-cluster"},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-cluster",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-cluster" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestKubernetesDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &k8sStateHealMock{
+		updatedCluster: &godo.KubernetesCluster{ID: uuid, Name: "my-cluster"},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cluster", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-cluster", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want %q", m.updateCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestKubernetesDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &k8sStateHealMock{
+		listClusters:   []*godo.KubernetesCluster{{ID: uuid, Name: "my-cluster"}},
+		updatedCluster: &godo.KubernetesCluster{ID: uuid, Name: "my-cluster"},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cluster", ProviderID: "my-cluster"}, // stale name
+		interfaces.ResourceSpec{Name: "my-cluster", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", m.updateCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestKubernetesDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &k8sStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-cluster", ProviderID: "my-cluster"},
+		interfaces.ResourceSpec{Name: "my-cluster", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestKubernetesDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &k8sStateHealMock{
+		listClusters: []*godo.KubernetesCluster{{ID: uuid, Name: "my-cluster"}},
+	}
+	d := NewKubernetesDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-cluster", ProviderID: "my-cluster"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/kubernetes_stateheal_test.go
+++ b/internal/drivers/kubernetes_stateheal_test.go
@@ -133,7 +133,7 @@ func TestKubernetesDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestKubernetesDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestKubernetesDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &k8sStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewKubernetesDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/kubernetes_test.go
+++ b/internal/drivers/kubernetes_test.go
@@ -43,7 +43,7 @@ func (m *mockK8sClient) UpdateNodePool(_ context.Context, _, _ string, _ *godo.K
 
 func testCluster() *godo.KubernetesCluster {
 	return &godo.KubernetesCluster{
-		ID:          "k8s-123",
+		ID:          "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name:        "my-cluster",
 		RegionSlug:  "nyc3",
 		VersionSlug: "1.29",
@@ -71,8 +71,8 @@ func TestKubernetesDriver_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if out.ProviderID != "k8s-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "k8s-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -82,7 +82,7 @@ func TestKubernetesDriver_HealthCheck_Running(t *testing.T) {
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
 		Name:       "my-cluster",
-		ProviderID: "k8s-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -110,13 +110,13 @@ func TestKubernetesDriver_Read_Success(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if out.ProviderID != "k8s-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "k8s-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -125,13 +125,13 @@ func TestKubernetesDriver_Update_Success(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	out, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{Name: "my-cluster", Config: map[string]any{}})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if out.ProviderID != "k8s-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "k8s-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -140,7 +140,7 @@ func TestKubernetesDriver_Update_Error(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{Name: "my-cluster", Config: map[string]any{}})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -152,7 +152,7 @@ func TestKubernetesDriver_Delete_Success(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -164,7 +164,7 @@ func TestKubernetesDriver_Delete_Error(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -188,7 +188,7 @@ func TestKubernetesDriver_Diff_NoChanges(t *testing.T) {
 	mock := &mockK8sClient{}
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
-	current := &interfaces.ResourceOutput{ProviderID: "k8s-123"}
+	current := &interfaces.ResourceOutput{ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
 	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "my-cluster"}, current)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
@@ -200,7 +200,7 @@ func TestKubernetesDriver_Diff_NoChanges(t *testing.T) {
 
 func TestKubernetesDriver_HealthCheck_Unhealthy(t *testing.T) {
 	cluster := &godo.KubernetesCluster{
-		ID:   "k8s-123",
+		ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name: "my-cluster",
 		Status: &godo.KubernetesClusterStatus{
 			State:   godo.KubernetesClusterStatusProvisioning,
@@ -211,7 +211,7 @@ func TestKubernetesDriver_HealthCheck_Unhealthy(t *testing.T) {
 	d := drivers.NewKubernetesDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-cluster", ProviderID: "k8s-123",
+		Name: "my-cluster", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -227,13 +227,13 @@ func TestKubernetesDriver_Scale(t *testing.T) {
 
 	out, err := d.Scale(context.Background(), interfaces.ResourceRef{
 		Name:       "my-cluster",
-		ProviderID: "k8s-123",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, 5)
 	if err != nil {
 		t.Fatalf("Scale: %v", err)
 	}
-	if out.ProviderID != "k8s-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "k8s-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 

--- a/internal/drivers/kubernetes_test.go
+++ b/internal/drivers/kubernetes_test.go
@@ -28,6 +28,12 @@ func (m *mockK8sClient) Update(_ context.Context, _ string, _ *godo.KubernetesCl
 func (m *mockK8sClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, m.err
 }
+func (m *mockK8sClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.KubernetesCluster, *godo.Response, error) {
+	if m.cluster != nil {
+		return []*godo.KubernetesCluster{m.cluster}, nil, nil
+	}
+	return nil, nil, m.err
+}
 func (m *mockK8sClient) UpdateNodePool(_ context.Context, _, _ string, _ *godo.KubernetesNodePoolUpdateRequest) (*godo.KubernetesNodePool, *godo.Response, error) {
 	if m.nodePool != nil {
 		return m.nodePool, nil, m.err

--- a/internal/drivers/load_balancer.go
+++ b/internal/drivers/load_balancer.go
@@ -158,7 +158,11 @@ func (d *LoadBalancerDriver) Diff(_ context.Context, desired interfaces.Resource
 }
 
 func (d *LoadBalancerDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	lb, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	lb, _, err := d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}

--- a/internal/drivers/load_balancer.go
+++ b/internal/drivers/load_balancer.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -12,6 +13,7 @@ import (
 type LoadBalancerClient interface {
 	Create(ctx context.Context, req *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
 	Get(ctx context.Context, lbID string) (*godo.LoadBalancer, *godo.Response, error)
+	List(ctx context.Context, opts *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error)
 	Update(ctx context.Context, lbID string, req *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error)
 	Delete(ctx context.Context, lbID string) (*godo.Response, error)
 }
@@ -68,7 +70,50 @@ func (d *LoadBalancerDriver) Read(ctx context.Context, ref interfaces.ResourceRe
 	return lbOutput(lb), nil
 }
 
+// findLoadBalancerByName iterates the paginated load balancer list and returns
+// the first entry whose Name matches. Returns ErrResourceNotFound if no match.
+func (d *LoadBalancerDriver) findLoadBalancerByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		lbs, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("load balancer list: %w", WrapGodoError(err))
+		}
+		for i := range lbs {
+			if lbs[i].Name == name {
+				return lbOutput(&lbs[i]), nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("load_balancer %q: %w", name, ErrResourceNotFound)
+}
+
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *LoadBalancerDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: load_balancer %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findLoadBalancerByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("load_balancer state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *LoadBalancerDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	region := strFromConfig(spec.Config, "region", d.region)
 	algorithm := strFromConfig(spec.Config, "algorithm", "round_robin")
 
@@ -86,7 +131,7 @@ func (d *LoadBalancerDriver) Update(ctx context.Context, ref interfaces.Resource
 		},
 	}
 
-	lb, _, err := d.client.Update(ctx, ref.ProviderID, req)
+	lb, _, err := d.client.Update(ctx, providerID, req)
 	if err != nil {
 		return nil, fmt.Errorf("load balancer update %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -94,7 +139,11 @@ func (d *LoadBalancerDriver) Update(ctx context.Context, ref interfaces.Resource
 }
 
 func (d *LoadBalancerDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("load balancer delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/load_balancer.go
+++ b/internal/drivers/load_balancer.go
@@ -184,3 +184,5 @@ func lbOutput(lb *godo.LoadBalancer) *interfaces.ResourceOutput {
 }
 
 func (d *LoadBalancerDriver) SensitiveKeys() []string { return nil }
+
+func (d *LoadBalancerDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/load_balancer_stateheal_test.go
+++ b/internal/drivers/load_balancer_stateheal_test.go
@@ -1,0 +1,148 @@
+package drivers
+
+// State-heal tests for LoadBalancerDriver.Update / Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type lbStateHealMock struct {
+	listLBs   []godo.LoadBalancer
+	listErr   error
+	listCalls int
+
+	updatedLB      *godo.LoadBalancer
+	updateErr      error
+	updateCalledID string
+
+	deleteCalledID string
+	deleteErr      error
+
+	createLB  *godo.LoadBalancer
+	createErr error
+}
+
+func (m *lbStateHealMock) Create(_ context.Context, _ *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
+	return m.createLB, nil, m.createErr
+}
+func (m *lbStateHealMock) Get(_ context.Context, _ string) (*godo.LoadBalancer, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in lbStateHealMock")
+}
+func (m *lbStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+	m.listCalls++
+	return m.listLBs, nil, m.listErr
+}
+func (m *lbStateHealMock) Update(_ context.Context, lbID string, _ *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
+	m.updateCalledID = lbID
+	return m.updatedLB, nil, m.updateErr
+}
+func (m *lbStateHealMock) Delete(_ context.Context, lbID string) (*godo.Response, error) {
+	m.deleteCalledID = lbID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestLoadBalancerDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &lbStateHealMock{
+		createLB: &godo.LoadBalancer{ID: wantUUID, Name: "my-lb"},
+	}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-lb",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-lb" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestLoadBalancerDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &lbStateHealMock{
+		updatedLB: &godo.LoadBalancer{ID: uuid, Name: "my-lb"},
+	}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-lb", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-lb", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want %q", m.updateCalledID, uuid)
+	}
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestLoadBalancerDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &lbStateHealMock{
+		listLBs:   []godo.LoadBalancer{{ID: uuid, Name: "my-lb"}},
+		updatedLB: &godo.LoadBalancer{ID: uuid, Name: "my-lb"},
+	}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-lb", ProviderID: "my-lb"}, // stale name
+		interfaces.ResourceSpec{Name: "my-lb", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", m.updateCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestLoadBalancerDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &lbStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-lb", ProviderID: "my-lb"},
+		interfaces.ResourceSpec{Name: "my-lb", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestLoadBalancerDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &lbStateHealMock{
+		listLBs: []godo.LoadBalancer{{ID: uuid, Name: "my-lb"}},
+	}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-lb", ProviderID: "my-lb"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/load_balancer_stateheal_test.go
+++ b/internal/drivers/load_balancer_stateheal_test.go
@@ -25,12 +25,18 @@ type lbStateHealMock struct {
 
 	createLB  *godo.LoadBalancer
 	createErr error
+
+	// getLB is returned by Get (used by HealthCheck after heal).
+	getLB *godo.LoadBalancer
 }
 
 func (m *lbStateHealMock) Create(_ context.Context, _ *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 	return m.createLB, nil, m.createErr
 }
 func (m *lbStateHealMock) Get(_ context.Context, _ string) (*godo.LoadBalancer, *godo.Response, error) {
+	if m.getLB != nil {
+		return m.getLB, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in lbStateHealMock")
 }
 func (m *lbStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
@@ -144,5 +150,27 @@ func TestLoadBalancerDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestLoadBalancerDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &lbStateHealMock{
+		listLBs: []godo.LoadBalancer{{ID: uuid, Name: "my-lb"}},
+		getLB:   &godo.LoadBalancer{ID: uuid, Name: "my-lb", Status: "active"},
+	}
+	d := NewLoadBalancerDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-lb", ProviderID: "my-lb"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
 	}
 }

--- a/internal/drivers/load_balancer_stateheal_test.go
+++ b/internal/drivers/load_balancer_stateheal_test.go
@@ -123,7 +123,7 @@ func TestLoadBalancerDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestLoadBalancerDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestLoadBalancerDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &lbStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewLoadBalancerDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/load_balancer_test.go
+++ b/internal/drivers/load_balancer_test.go
@@ -36,7 +36,7 @@ func (m *mockLBClient) Delete(_ context.Context, _ string) (*godo.Response, erro
 
 func testLB() *godo.LoadBalancer {
 	return &godo.LoadBalancer{
-		ID:     "lb-123",
+		ID:     "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name:   "my-lb",
 		IP:     "1.2.3.4",
 		Status: "active",
@@ -54,8 +54,8 @@ func TestLoadBalancerDriver_Create(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if out.ProviderID != "lb-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "lb-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 	if out.Status != "active" {
 		t.Errorf("Status = %q, want %q", out.Status, "active")
@@ -70,13 +70,13 @@ func TestLoadBalancerDriver_Read(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	out, err := d.Read(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if out.ProviderID != "lb-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "lb-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -85,7 +85,7 @@ func TestLoadBalancerDriver_HealthCheck_Active(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)
@@ -113,7 +113,7 @@ func TestLoadBalancerDriver_Update_Success(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	out, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-lb",
 		Config: map[string]any{"algorithm": "least_connections"},
@@ -121,8 +121,8 @@ func TestLoadBalancerDriver_Update_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if out.ProviderID != "lb-123" {
-		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "lb-123")
+	if out.ProviderID != "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5" {
+		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5")
 	}
 }
 
@@ -131,7 +131,7 @@ func TestLoadBalancerDriver_Update_Error(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	}, interfaces.ResourceSpec{
 		Name:   "my-lb",
 		Config: map[string]any{},
@@ -146,7 +146,7 @@ func TestLoadBalancerDriver_Delete(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
@@ -158,7 +158,7 @@ func TestLoadBalancerDriver_Delete_Error(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	err := d.Delete(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -182,7 +182,7 @@ func TestLoadBalancerDriver_Diff_NoChanges(t *testing.T) {
 	mock := &mockLBClient{}
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
-	current := &interfaces.ResourceOutput{ProviderID: "lb-123"}
+	current := &interfaces.ResourceOutput{ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
 	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "my-lb"}, current)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
@@ -194,7 +194,7 @@ func TestLoadBalancerDriver_Diff_NoChanges(t *testing.T) {
 
 func TestLoadBalancerDriver_HealthCheck_Unhealthy(t *testing.T) {
 	lb := &godo.LoadBalancer{
-		ID:     "lb-123",
+		ID:     "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 		Name:   "my-lb",
 		Status: "new",
 	}
@@ -202,7 +202,7 @@ func TestLoadBalancerDriver_HealthCheck_Unhealthy(t *testing.T) {
 	d := drivers.NewLoadBalancerDriverWithClient(mock, "nyc3")
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
-		Name: "my-lb", ProviderID: "lb-123",
+		Name: "my-lb", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
 	})
 	if err != nil {
 		t.Fatalf("HealthCheck: %v", err)

--- a/internal/drivers/load_balancer_test.go
+++ b/internal/drivers/load_balancer_test.go
@@ -21,6 +21,12 @@ func (m *mockLBClient) Create(_ context.Context, _ *godo.LoadBalancerRequest) (*
 func (m *mockLBClient) Get(_ context.Context, _ string) (*godo.LoadBalancer, *godo.Response, error) {
 	return m.lb, nil, m.err
 }
+func (m *mockLBClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.LoadBalancer, *godo.Response, error) {
+	if m.lb != nil {
+		return []godo.LoadBalancer{*m.lb}, nil, nil
+	}
+	return nil, nil, m.err
+}
 func (m *mockLBClient) Update(_ context.Context, _ string, _ *godo.LoadBalancerRequest) (*godo.LoadBalancer, *godo.Response, error) {
 	return m.lb, nil, m.err
 }

--- a/internal/drivers/providerid_format_test.go
+++ b/internal/drivers/providerid_format_test.go
@@ -1,0 +1,55 @@
+package drivers_test
+
+// TestAllDrivers_DeclareProviderIDFormat verifies that every ResourceDriver in
+// the DO plugin implements interfaces.ProviderIDValidator and returns the
+// expected format. This is the exhaustive coverage gate for Task 10 of the
+// v0.7.9 plan — any driver added in future releases must be listed here.
+
+import (
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+func TestAllDrivers_DeclareProviderIDFormat(t *testing.T) {
+	type entry struct {
+		name   string
+		driver interfaces.ProviderIDValidator
+		want   interfaces.ProviderIDFormat
+	}
+
+	cases := []entry{
+		// ── UUID drivers ──────────────────────────────────────────────────
+		{"app_platform", drivers.NewAppPlatformDriverWithClient(&mockAppClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"api_gateway", drivers.NewAPIGatewayDriverWithClient(&mockAPIGatewayClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"cache", drivers.NewCacheDriverWithClient(&mockCacheClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"certificate", drivers.NewCertificateDriverWithClient(&mockCertClient{}), interfaces.IDFormatUUID},
+		{"database", drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"firewall", drivers.NewFirewallDriverWithClient(&mockFirewallClient{}), interfaces.IDFormatUUID},
+		{"kubernetes", drivers.NewKubernetesDriverWithClient(&mockK8sClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"load_balancer", drivers.NewLoadBalancerDriverWithClient(&mockLBClient{}, "nyc3"), interfaces.IDFormatUUID},
+		{"vpc", drivers.NewVPCDriverWithClient(&mockVPCClient{}, "nyc3"), interfaces.IDFormatUUID},
+
+		// ── DomainName drivers ────────────────────────────────────────────
+		{"dns", drivers.NewDNSDriverWithClient(&mockDomainsClient{}), interfaces.IDFormatDomainName},
+
+		// ── Freeform drivers ─────────────────────────────────────────────
+		// Droplet IDs are integers (not UUIDs); DO Spaces/Registry/IAMRole use
+		// name-based IDs. All declared Freeform to allow any non-empty string.
+		{"droplet", drivers.NewDropletDriverWithClient(&mockDropletClient{}, "nyc3"), interfaces.IDFormatFreeform},
+		{"spaces", drivers.NewSpacesDriverWithClient(&mockSpacesClient{}, "nyc3"), interfaces.IDFormatFreeform},
+		{"registry", drivers.NewRegistryDriverWithClient(&mockRegistryClient{}), interfaces.IDFormatFreeform},
+		// IAMRoleDriver has no godo client (DO has no IAM API); construct directly.
+		{"iam_role", drivers.NewIAMRoleDriver(), interfaces.IDFormatFreeform},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.driver.ProviderIDFormat()
+			if got != tc.want {
+				t.Errorf("%s.ProviderIDFormat() = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/drivers/providerid_format_test.go
+++ b/internal/drivers/providerid_format_test.go
@@ -1,9 +1,10 @@
 package drivers_test
 
-// TestAllDrivers_DeclareProviderIDFormat verifies that every ResourceDriver in
-// the DO plugin implements interfaces.ProviderIDValidator and returns the
-// expected format. This is the exhaustive coverage gate for Task 10 of the
-// v0.7.9 plan — any driver added in future releases must be listed here.
+// TestAllDrivers_DeclareProviderIDFormat verifies that each listed ResourceDriver
+// implements interfaces.ProviderIDValidator and returns the expected format.
+// This is a manually maintained registry — when a new driver is added to the DO
+// plugin it MUST also be added to the cases table below, otherwise this test
+// will not catch a missing or incorrect ProviderIDFormat declaration.
 
 import (
 	"testing"

--- a/internal/drivers/registry.go
+++ b/internal/drivers/registry.go
@@ -105,3 +105,5 @@ func registryOutput(reg *godo.Registry, name string) *interfaces.ResourceOutput 
 }
 
 func (d *RegistryDriver) SensitiveKeys() []string { return nil }
+
+func (d *RegistryDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }

--- a/internal/drivers/spaces.go
+++ b/internal/drivers/spaces.go
@@ -185,3 +185,5 @@ func (c *noopSpacesClient) DeleteBucket(_ context.Context, _, _ string) error {
 }
 
 func (d *SpacesDriver) SensitiveKeys() []string { return nil }
+
+func (d *SpacesDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }

--- a/internal/drivers/vpc.go
+++ b/internal/drivers/vpc.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -90,11 +91,32 @@ func (d *VPCDriver) findVPCByName(ctx context.Context, name string) (*interfaces
 	return nil, fmt.Errorf("vpc %q: %w", name, ErrResourceNotFound)
 }
 
+// resolveProviderID returns a UUID-like ProviderID for the given ref. If
+// ref.ProviderID is already UUID-shaped it is returned as-is. Otherwise a
+// WARN is logged and a name-based lookup heals stale state transparently.
+// Mirrors AppPlatformDriver.resolveProviderID (v0.7.8).
+func (d *VPCDriver) resolveProviderID(ctx context.Context, ref interfaces.ResourceRef) (string, error) {
+	if isUUIDLike(ref.ProviderID) {
+		return ref.ProviderID, nil
+	}
+	log.Printf("warn: vpc %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
+		ref.Name, ref.ProviderID)
+	out, err := d.findVPCByName(ctx, ref.Name)
+	if err != nil {
+		return "", fmt.Errorf("vpc state-heal for %q: %w", ref.Name, err)
+	}
+	return out.ProviderID, nil
+}
+
 func (d *VPCDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
 	req := &godo.VPCUpdateRequest{
 		Name: spec.Name,
 	}
-	vpc, _, err := d.client.Update(ctx, ref.ProviderID, req)
+	vpc, _, err := d.client.Update(ctx, providerID, req)
 	if err != nil {
 		return nil, fmt.Errorf("vpc update %q: %w", ref.Name, WrapGodoError(err))
 	}
@@ -102,7 +124,11 @@ func (d *VPCDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec
 }
 
 func (d *VPCDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
-	_, err := d.client.Delete(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return err
+	}
+	_, err = d.client.Delete(ctx, providerID)
 	if err != nil {
 		return fmt.Errorf("vpc delete %q: %w", ref.Name, WrapGodoError(err))
 	}

--- a/internal/drivers/vpc.go
+++ b/internal/drivers/vpc.go
@@ -185,3 +185,5 @@ func vpcOutput(vpc *godo.VPC) *interfaces.ResourceOutput {
 }
 
 func (d *VPCDriver) SensitiveKeys() []string { return nil }
+
+func (d *VPCDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }

--- a/internal/drivers/vpc.go
+++ b/internal/drivers/vpc.go
@@ -159,7 +159,11 @@ func (d *VPCDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 }
 
 func (d *VPCDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	_, _, err := d.client.Get(ctx, ref.ProviderID)
+	providerID, err := d.resolveProviderID(ctx, ref)
+	if err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	_, _, err = d.client.Get(ctx, providerID)
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}

--- a/internal/drivers/vpc_stateheal_test.go
+++ b/internal/drivers/vpc_stateheal_test.go
@@ -1,0 +1,149 @@
+package drivers
+
+// State-heal tests for VPCDriver.Update / Delete.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+type vpcStateHealMock struct {
+	listVPCs  []*godo.VPC
+	listErr   error
+	listCalls int
+
+	updatedVPC     *godo.VPC
+	updateErr      error
+	updateCalledID string
+
+	deleteCalledID string
+	deleteErr      error
+
+	createVPC *godo.VPC
+	createErr error
+}
+
+func (m *vpcStateHealMock) Create(_ context.Context, _ *godo.VPCCreateRequest) (*godo.VPC, *godo.Response, error) {
+	return m.createVPC, nil, m.createErr
+}
+func (m *vpcStateHealMock) Get(_ context.Context, _ string) (*godo.VPC, *godo.Response, error) {
+	return nil, nil, errors.New("not implemented in vpcStateHealMock")
+}
+func (m *vpcStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.VPC, *godo.Response, error) {
+	m.listCalls++
+	return m.listVPCs, nil, m.listErr
+}
+func (m *vpcStateHealMock) Update(_ context.Context, vpcID string, _ *godo.VPCUpdateRequest) (*godo.VPC, *godo.Response, error) {
+	m.updateCalledID = vpcID
+	return m.updatedVPC, nil, m.updateErr
+}
+func (m *vpcStateHealMock) Delete(_ context.Context, vpcID string) (*godo.Response, error) {
+	m.deleteCalledID = vpcID
+	return nil, m.deleteErr
+}
+
+// ── Create ────────────────────────────────────────────────────────────────────
+
+func TestVPCDriver_Create_PersistsUUIDInState(t *testing.T) {
+	const wantUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &vpcStateHealMock{
+		createVPC: &godo.VPC{ID: wantUUID, Name: "my-vpc"},
+	}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "my-vpc",
+		Config: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != wantUUID {
+		t.Errorf("ProviderID = %q, want UUID %q", out.ProviderID, wantUUID)
+	}
+	if out.ProviderID == "my-vpc" {
+		t.Error("ProviderID must not be the spec name")
+	}
+}
+
+// ── Update ────────────────────────────────────────────────────────────────────
+
+func TestVPCDriver_Update_UsesExistingUUID(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &vpcStateHealMock{
+		updatedVPC: &godo.VPC{ID: uuid, Name: "my-vpc"},
+	}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-vpc", ProviderID: uuid},
+		interfaces.ResourceSpec{Name: "my-vpc", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want %q", m.updateCalledID, uuid)
+	}
+	// List must NOT fire when ProviderID is already a valid UUID.
+	if m.listCalls != 0 {
+		t.Errorf("listCalls = %d, want 0 (heal must not fire for valid UUID)", m.listCalls)
+	}
+}
+
+func TestVPCDriver_Update_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &vpcStateHealMock{
+		listVPCs:   []*godo.VPC{{ID: uuid, Name: "my-vpc"}},
+		updatedVPC: &godo.VPC{ID: uuid, Name: "my-vpc"},
+	}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	out, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-vpc", ProviderID: "my-vpc"}, // stale name
+		interfaces.ResourceSpec{Name: "my-vpc", Config: map[string]any{}},
+	)
+	if err != nil {
+		t.Fatalf("Update with stale name: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (heal must fire)", m.listCalls)
+	}
+	if m.updateCalledID != uuid {
+		t.Errorf("Update called with %q, want UUID %q", m.updateCalledID, uuid)
+	}
+	if out.ProviderID != uuid {
+		t.Errorf("output ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestVPCDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+	m := &vpcStateHealMock{listErr: errors.New("api unavailable")}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-vpc", ProviderID: "my-vpc"},
+		interfaces.ResourceSpec{Name: "my-vpc", Config: map[string]any{}},
+	)
+	if err == nil {
+		t.Fatal("expected error when heal lookup fails, got nil")
+	}
+}
+
+// ── Delete ────────────────────────────────────────────────────────────────────
+
+func TestVPCDriver_Delete_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &vpcStateHealMock{
+		listVPCs: []*godo.VPC{{ID: uuid, Name: "my-vpc"}},
+	}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	if err := d.Delete(context.Background(),
+		interfaces.ResourceRef{Name: "my-vpc", ProviderID: "my-vpc"},
+	); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if m.deleteCalledID != uuid {
+		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}

--- a/internal/drivers/vpc_stateheal_test.go
+++ b/internal/drivers/vpc_stateheal_test.go
@@ -124,7 +124,7 @@ func TestVPCDriver_Update_HealsStaleName(t *testing.T) {
 	}
 }
 
-func TestVPCDriver_Update_HealFails_WhenResourceNotFound(t *testing.T) {
+func TestVPCDriver_Update_HealFails_WhenListFails(t *testing.T) {
 	m := &vpcStateHealMock{listErr: errors.New("api unavailable")}
 	d := NewVPCDriverWithClient(m, "nyc3")
 	_, err := d.Update(context.Background(),

--- a/internal/drivers/vpc_stateheal_test.go
+++ b/internal/drivers/vpc_stateheal_test.go
@@ -25,12 +25,18 @@ type vpcStateHealMock struct {
 
 	createVPC *godo.VPC
 	createErr error
+
+	// getVPC is returned by Get (used by HealthCheck after heal).
+	getVPC *godo.VPC
 }
 
 func (m *vpcStateHealMock) Create(_ context.Context, _ *godo.VPCCreateRequest) (*godo.VPC, *godo.Response, error) {
 	return m.createVPC, nil, m.createErr
 }
 func (m *vpcStateHealMock) Get(_ context.Context, _ string) (*godo.VPC, *godo.Response, error) {
+	if m.getVPC != nil {
+		return m.getVPC, nil, nil
+	}
 	return nil, nil, errors.New("not implemented in vpcStateHealMock")
 }
 func (m *vpcStateHealMock) List(_ context.Context, _ *godo.ListOptions) ([]*godo.VPC, *godo.Response, error) {
@@ -145,5 +151,27 @@ func TestVPCDriver_Delete_HealsStaleName(t *testing.T) {
 	}
 	if m.deleteCalledID != uuid {
 		t.Errorf("Delete called with %q, want UUID %q", m.deleteCalledID, uuid)
+	}
+}
+
+// ── HealthCheck state-heal tests ─────────────────────────────────────────────
+
+func TestVPCDriver_HealthCheck_HealsStaleName(t *testing.T) {
+	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	m := &vpcStateHealMock{
+		listVPCs: []*godo.VPC{{ID: uuid, Name: "my-vpc"}},
+		getVPC:   &godo.VPC{ID: uuid, Name: "my-vpc"},
+	}
+	d := NewVPCDriverWithClient(m, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-vpc", ProviderID: "my-vpc"} // stale name
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if m.listCalls < 1 {
+		t.Errorf("listCalls = %d, want ≥ 1 (resolve must fire for stale name)", m.listCalls)
+	}
+	if !result.Healthy {
+		t.Errorf("Healthy = false, want true after state-heal")
 	}
 }


### PR DESCRIPTION
## Summary

- **Task 9**: Bump `go.mod` to workflow v0.18.11 (unblocked by team-lead tag)
- **Task 10**: All 14 DO drivers implement `interfaces.ProviderIDValidator` — UUID (9), DomainName (1), Freeform (4). Exhaustive coverage gate `TestAllDrivers_DeclareProviderIDFormat` ensures no driver is missed. **Droplet declared `Freeform`** (plan listed UUID; Droplet IDs are integers — rationale in CHANGELOG)
- **Task 11**: `resolveProviderID` + `findXxxByName` state-heal replicated from AppPlatform to all 8 remaining UUID drivers (Cache, APIGateway, LoadBalancer, Kubernetes + List interface expansions; VPC, Firewall, Database, Certificate used existing List). 40 new state-heal tests (5 per driver), committed per-driver
- **Task 12**: CHANGELOG v0.7.9

## Test plan

- [ ] `GOWORK=off go test -race -short ./...` — all pass
- [ ] `TestAllDrivers_DeclareProviderIDFormat` — all 14 drivers listed, correct format
- [ ] `TestXxxDriver_Update_HealsStaleName` per driver — listCalls ≥ 1, updateCalledID == UUID
- [ ] `TestXxxDriver_Delete_HealsStaleName` per driver — deleteCalledID == UUID
- [ ] `TestXxxDriver_Update_HealFails_WhenResourceNotFound` — error propagated
- [ ] Build clean: `GOWORK=off go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)