### PR TITLE
Adopt existing DigitalOcean DNS records safely

### DIFF
--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -27,6 +28,12 @@ type DomainsClient interface {
 type DNSDriver struct {
 	client DomainsClient
 }
+
+const (
+	dnsConflictRetryAttempts  = 5
+	dnsConflictRetryBaseDelay = 25 * time.Millisecond
+	dnsConflictRetryMaxDelay  = 200 * time.Millisecond
+)
 
 // NewDNSDriver creates a DNSDriver backed by a real godo client.
 func NewDNSDriver(c *godo.Client) *DNSDriver {
@@ -60,10 +67,25 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 		if !errors.Is(wrapped, interfaces.ErrResourceNotFound) {
 			return nil, fmt.Errorf("dns get domain %q: %w", domain, wrapped)
 		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("dns create domain %q: %w", domain, err)
+		}
 		dom, _, err = d.client.Create(ctx, &godo.DomainCreateRequest{Name: domain})
 		if err != nil {
-			return nil, fmt.Errorf("dns create domain %q: %w", domain, WrapGodoError(err))
+			wrapped = WrapGodoError(err)
+			if !errors.Is(wrapped, interfaces.ErrResourceAlreadyExists) {
+				return nil, fmt.Errorf("dns create domain %q: %w", domain, wrapped)
+			}
+			dom, err = d.getDomainAfterCreateConflict(ctx, domain, wrapped)
+			if err != nil {
+				return nil, err
+			}
 		}
+	} else if err := validateDNSDomainResponse(domain, "get domain", dom); err != nil {
+		return nil, err
+	}
+	if err := validateDNSDomainResponse(domain, "create domain", dom); err != nil {
+		return nil, err
 	}
 
 	if err := d.upsertRecords(ctx, domain, declaredRecords); err != nil {
@@ -77,17 +99,62 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 	return dnsOutput(dom, spec.Name, records), nil
 }
 
+func (d *DNSDriver) getDomainAfterCreateConflict(ctx context.Context, domain string, conflictErr error) (*godo.Domain, error) {
+	var lastRetryable error
+	for attempt := 0; attempt < dnsConflictRetryAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("dns get domain %q after create conflict: %w", domain, err)
+		}
+		dom, _, err := d.client.Get(ctx, domain)
+		if err == nil {
+			if err := validateDNSDomainResponse(domain, "get domain after create conflict", dom); err != nil {
+				return nil, err
+			}
+			return dom, nil
+		}
+		wrapped := WrapGodoError(err)
+		if !errors.Is(wrapped, interfaces.ErrResourceNotFound) && !isRetryableDNSConflictError(wrapped) {
+			return nil, fmt.Errorf("dns get domain %q after create conflict: %w", domain, wrapped)
+		}
+		if isRetryableDNSConflictError(wrapped) {
+			lastRetryable = wrapped
+		} else {
+			lastRetryable = nil
+		}
+		if attempt == dnsConflictRetryAttempts-1 {
+			break
+		}
+		if err := waitDNSConflictRetry(ctx, domain, "domain", domain, attempt); err != nil {
+			return nil, err
+		}
+	}
+	if lastRetryable != nil {
+		return nil, fmt.Errorf("dns get domain %q after create conflict: %w", domain, lastRetryable)
+	}
+	return nil, fmt.Errorf("dns create domain %q: %w", domain, conflictErr)
+}
+
 func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
 	domain := ref.ProviderID
 	dom, _, err := d.client.Get(ctx, domain)
 	if err != nil {
 		return nil, fmt.Errorf("dns read %q: %w", ref.Name, WrapGodoError(err))
 	}
+	if err := validateDNSDomainResponse(domain, "read domain", dom); err != nil {
+		return nil, err
+	}
 	records, err := d.listRecords(ctx, domain)
 	if err != nil {
 		return nil, err
 	}
 	return dnsOutput(dom, ref.Name, records), nil
+}
+
+func validateDNSDomainResponse(domain, op string, dom *godo.Domain) error {
+	if dom == nil || dom.Name == "" {
+		return fmt.Errorf("dns %s %q: API returned empty domain", op, domain)
+	}
+	return nil
 }
 
 func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -109,6 +176,9 @@ func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec
 }
 
 func (d *DNSDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("dns delete %q: %w", ref.Name, err)
+	}
 	_, err := d.client.Delete(ctx, ref.ProviderID)
 	if err != nil {
 		return fmt.Errorf("dns delete %q: %w", ref.Name, WrapGodoError(err))
@@ -129,7 +199,13 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
 	if hasDesiredDomain && !strings.EqualFold(desiredDomain, current.ProviderID) {
-		return &interfaces.DiffResult{NeedsUpdate: true}, nil
+		return &interfaces.DiffResult{
+			NeedsUpdate:  true,
+			NeedsReplace: true,
+			Changes: []interfaces.FieldChange{
+				{Path: "domain", Old: current.ProviderID, New: desiredDomain, ForceNew: true},
+			},
+		}, nil
 	}
 	if len(desiredRecords) == 0 {
 		return &interfaces.DiffResult{NeedsUpdate: false}, nil
@@ -184,11 +260,7 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []
 		return err
 	}
 
-	existingByKey := make(map[string][]godo.DomainRecord)
-	for _, r := range existing {
-		key := dnsDomainRecordUpsertKey(r)
-		existingByKey[key] = append(existingByKey[key], r)
-	}
+	existingByKey := dnsRecordsByUpsertKey(existing)
 
 	seenDeclared := make(map[string]struct{})
 	for _, editReq := range records {
@@ -205,16 +277,117 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []
 			if dnsRecordMatchesRequest(existing, editReq) {
 				continue
 			}
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("dns update record %q %s/%s: %w", domain, editReq.Type, editReq.Name, err)
+			}
 			if _, _, err := d.client.EditRecord(ctx, domain, existing.ID, &editReq); err != nil {
 				return fmt.Errorf("dns update record %q %s/%s: %w", domain, editReq.Type, editReq.Name, WrapGodoError(err))
 			}
 		} else {
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("dns create record %q %s/%s: %w", domain, editReq.Type, editReq.Name, err)
+			}
 			if _, _, err := d.client.CreateRecord(ctx, domain, &editReq); err != nil {
-				return fmt.Errorf("dns create record %q %s/%s: %w", domain, editReq.Type, editReq.Name, WrapGodoError(err))
+				latest, err := d.handleCreateRecordConflict(ctx, domain, editReq, err)
+				if err != nil {
+					return err
+				}
+				existingByKey = dnsRecordsByUpsertKey(latest)
 			}
 		}
 	}
 	return nil
+}
+
+func (d *DNSDriver) handleCreateRecordConflict(ctx context.Context, domain string, editReq godo.DomainRecordEditRequest, createErr error) ([]godo.DomainRecord, error) {
+	wrapped := WrapGodoError(createErr)
+	if !errors.Is(wrapped, interfaces.ErrResourceAlreadyExists) {
+		return nil, fmt.Errorf("dns create record %q %s/%s: %w", domain, editReq.Type, editReq.Name, wrapped)
+	}
+	key := dnsRecordRequestUpsertKey(editReq)
+	for attempt := 0; attempt < dnsConflictRetryAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("dns create record %q %s/%s after create conflict: %w", domain, editReq.Type, editReq.Name, err)
+		}
+		existing, err := d.listRecords(ctx, domain)
+		if err != nil {
+			if isRetryableDNSConflictError(err) && attempt < dnsConflictRetryAttempts-1 {
+				if waitErr := waitDNSConflictRetry(ctx, domain, editReq.Type, editReq.Name, attempt); waitErr != nil {
+					return nil, waitErr
+				}
+				continue
+			}
+			return nil, fmt.Errorf("dns list records %q after create conflict %s/%s: %w", domain, editReq.Type, editReq.Name, err)
+		}
+		if err := validateDNSRecordLiveConflicts([]godo.DomainRecordEditRequest{editReq}, existing); err != nil {
+			return nil, err
+		}
+		for i, record := range existing {
+			if dnsDomainRecordUpsertKey(record) != key {
+				continue
+			}
+			if dnsRecordMatchesRequest(record, editReq) {
+				return existing, nil
+			}
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("dns update record %q %s/%s after create conflict: %w", domain, editReq.Type, editReq.Name, err)
+			}
+			updated, _, err := d.client.EditRecord(ctx, domain, record.ID, &editReq)
+			if err != nil {
+				return nil, fmt.Errorf("dns update record %q %s/%s after create conflict: %w", domain, editReq.Type, editReq.Name, WrapGodoError(err))
+			}
+			if updated != nil {
+				existing[i] = *updated
+			} else {
+				replacement := dnsDomainRecordFromRequest(editReq)
+				replacement.ID = record.ID
+				existing[i] = replacement
+			}
+			return existing, nil
+		}
+		if attempt == dnsConflictRetryAttempts-1 {
+			break
+		}
+		if err := waitDNSConflictRetry(ctx, domain, editReq.Type, editReq.Name, attempt); err != nil {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("dns create record %q %s/%s: %w", domain, editReq.Type, editReq.Name, wrapped)
+}
+
+func dnsRecordsByUpsertKey(records []godo.DomainRecord) map[string][]godo.DomainRecord {
+	out := make(map[string][]godo.DomainRecord)
+	for _, r := range records {
+		key := dnsDomainRecordUpsertKey(r)
+		out[key] = append(out[key], r)
+	}
+	return out
+}
+
+func isRetryableDNSConflictError(err error) bool {
+	return errors.Is(err, interfaces.ErrTransient) || errors.Is(err, interfaces.ErrRateLimited)
+}
+
+func waitDNSConflictRetry(ctx context.Context, domain, recordType, name string, attempt int) error {
+	timer := time.NewTimer(dnsConflictBackoffDelay(attempt))
+	select {
+	case <-ctx.Done():
+		timer.Stop()
+		return fmt.Errorf("dns retry %q %s/%s after create conflict: %w", domain, recordType, name, ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
+func dnsConflictBackoffDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+	delay := dnsConflictRetryBaseDelay << attempt
+	if delay > dnsConflictRetryMaxDelay {
+		return dnsConflictRetryMaxDelay
+	}
+	return delay
 }
 
 func (d *DNSDriver) listRecords(ctx context.Context, domain string) ([]godo.DomainRecord, error) {
@@ -410,6 +583,7 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 		Flags:    flags,
 		Tag:      tag,
 	}
+	req.Tag = dnsCanonicalRecordTag(req.Type, req.Tag)
 	if err := validateDNSRecordRequest(index, req, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
@@ -672,7 +846,7 @@ func dnsRecordRequestsEqual(a, b godo.DomainRecordEditRequest) bool {
 		a.Port == b.Port &&
 		a.Weight == b.Weight &&
 		a.Flags == b.Flags &&
-		a.Tag == b.Tag
+		dnsCanonicalRecordTag(a.Type, a.Tag) == dnsCanonicalRecordTag(b.Type, b.Tag)
 }
 
 func dnsRecordsFromOutput(current *interfaces.ResourceOutput) ([]godo.DomainRecord, error) {
@@ -763,7 +937,7 @@ func dnsDomainRecordFromOutputMap(index int, m map[string]any) (godo.DomainRecor
 		Port:     port,
 		Weight:   weight,
 		Flags:    flags,
-		Tag:      tag,
+		Tag:      dnsCanonicalRecordTag(recordType, tag),
 	}, true, nil
 }
 
@@ -811,7 +985,7 @@ func dnsRecordIdentity(recordType, name, data string, priority, port, weight, fl
 	parts := []string{strings.ToUpper(recordType), dnsCanonicalRecordName(name), dnsCanonicalRecordData(recordType, data)}
 	switch strings.ToUpper(recordType) {
 	case "CAA":
-		parts = append(parts, fmt.Sprint(flags), strings.ToLower(tag))
+		parts = append(parts, fmt.Sprint(flags), dnsCanonicalRecordTag(recordType, tag))
 	case "MX":
 		parts = append(parts, fmt.Sprint(priority))
 	case "SRV":
@@ -829,7 +1003,7 @@ func dnsRecordMatchesRequest(record godo.DomainRecord, req godo.DomainRecordEdit
 		record.Port == req.Port &&
 		record.Weight == req.Weight &&
 		record.Flags == req.Flags &&
-		record.Tag == req.Tag
+		dnsCanonicalRecordTag(record.Type, record.Tag) == dnsCanonicalRecordTag(req.Type, req.Tag)
 }
 
 func dnsCanonicalRecordName(name string) string {
@@ -838,6 +1012,13 @@ func dnsCanonicalRecordName(name string) string {
 
 func dnsRecordDataMatches(recordType, a, b string) bool {
 	return dnsCanonicalRecordData(recordType, a) == dnsCanonicalRecordData(recordType, b)
+}
+
+func dnsCanonicalRecordTag(recordType, tag string) string {
+	if strings.EqualFold(recordType, "CAA") {
+		return strings.ToLower(tag)
+	}
+	return tag
 }
 
 func dnsCanonicalRecordData(recordType, data string) string {
@@ -878,7 +1059,7 @@ func dnsRecordOutputs(records []godo.DomainRecord) []map[string]any {
 			"port":     record.Port,
 			"weight":   record.Weight,
 			"flags":    record.Flags,
-			"tag":      record.Tag,
+			"tag":      dnsCanonicalRecordTag(record.Type, record.Tag),
 		})
 	}
 	return out

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -38,8 +38,9 @@ func NewDNSDriverWithClient(c DomainsClient) *DNSDriver {
 
 // Create creates a domain and any declared DNS records idempotently.
 // Config keys:
-//   domain   string            — the zone name (e.g. "example.com")
-//   records  []map[string]any  — each: {type, name, data, ttl}
+//
+//	domain   string            — the zone name (e.g. "example.com")
+//	records  []map[string]any  — each: {type, name, data, ttl}
 func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	domain := strFromConfig(spec.Config, "domain", spec.Name)
 
@@ -56,7 +57,7 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 		return nil, err
 	}
 
-	return dnsOutput(dom, spec.Name), nil
+	return dnsOutput(dom, spec.Name, nil), nil
 }
 
 func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
@@ -65,7 +66,11 @@ func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*inte
 	if err != nil {
 		return nil, fmt.Errorf("dns read %q: %w", ref.Name, WrapGodoError(err))
 	}
-	return dnsOutput(dom, ref.Name), nil
+	records, _, err := d.client.Records(ctx, domain, nil)
+	if err != nil {
+		return nil, fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
+	}
+	return dnsOutput(dom, ref.Name, records), nil
 }
 
 func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -105,8 +110,8 @@ func (d *DNSDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*
 
 // upsertRecords creates or updates DNS records for a domain.
 func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, config map[string]any) error {
-	records, ok := config["records"].([]any)
-	if !ok {
+	records := declaredDNSRecords(config)
+	if len(records) == 0 {
 		return nil
 	}
 
@@ -115,56 +120,127 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, config map
 		return fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
 	}
 
-	existingByName := make(map[string]godo.DomainRecord)
+	existingByKey := make(map[string][]godo.DomainRecord)
 	for _, r := range existing {
-		key := strings.ToLower(r.Type) + ":" + r.Name
-		existingByName[key] = r
+		key := dnsRecordIdentity(r.Type, r.Name, r.Data)
+		existingByKey[key] = append(existingByKey[key], r)
 	}
 
-	for _, rec := range records {
-		m, _ := rec.(map[string]any)
-		if m == nil {
+	seenDeclared := make(map[string]struct{})
+	for _, editReq := range records {
+		key := dnsRecordIdentity(editReq.Type, editReq.Name, editReq.Data)
+		if _, seen := seenDeclared[key]; seen {
 			continue
 		}
-		rType := strings.ToUpper(strFromConfig(m, "type", "A"))
-		rName := strFromConfig(m, "name", "@")
-		rData := strFromConfig(m, "data", "")
-		rTTL, _ := intFromConfig(m, "ttl", 300)
+		seenDeclared[key] = struct{}{}
 
-		editReq := &godo.DomainRecordEditRequest{
-			Type: rType,
-			Name: rName,
-			Data: rData,
-			TTL:  rTTL,
-		}
-
-		key := strings.ToLower(rType) + ":" + rName
-		if existing, found := existingByName[key]; found {
-			if _, _, err := d.client.EditRecord(ctx, domain, existing.ID, editReq); err != nil {
-				return fmt.Errorf("dns update record %q %s/%s: %w", domain, rType, rName, WrapGodoError(err))
+		candidates := existingByKey[key]
+		if len(candidates) > 0 {
+			existing := candidates[0]
+			existingByKey[key] = candidates[1:]
+			if dnsRecordMatchesRequest(existing, editReq) {
+				continue
+			}
+			if _, _, err := d.client.EditRecord(ctx, domain, existing.ID, &editReq); err != nil {
+				return fmt.Errorf("dns update record %q %s/%s: %w", domain, editReq.Type, editReq.Name, WrapGodoError(err))
 			}
 		} else {
-			if _, _, err := d.client.CreateRecord(ctx, domain, editReq); err != nil {
-				return fmt.Errorf("dns create record %q %s/%s: %w", domain, rType, rName, WrapGodoError(err))
+			if _, _, err := d.client.CreateRecord(ctx, domain, &editReq); err != nil {
+				return fmt.Errorf("dns create record %q %s/%s: %w", domain, editReq.Type, editReq.Name, WrapGodoError(err))
 			}
 		}
 	}
 	return nil
 }
 
-func dnsOutput(dom *godo.Domain, name string) *interfaces.ResourceOutput {
+func declaredDNSRecords(config map[string]any) []godo.DomainRecordEditRequest {
+	raw, ok := config["records"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]godo.DomainRecordEditRequest, 0, len(raw))
+	for _, rec := range raw {
+		m, _ := rec.(map[string]any)
+		if m == nil {
+			continue
+		}
+		out = append(out, dnsRecordEditRequestFromConfig(m))
+	}
+	return out
+}
+
+func dnsRecordEditRequestFromConfig(m map[string]any) godo.DomainRecordEditRequest {
+	ttl, _ := intFromConfig(m, "ttl", 300)
+	priority, _ := intFromConfig(m, "priority", 0)
+	port, _ := intFromConfig(m, "port", 0)
+	weight, _ := intFromConfig(m, "weight", 0)
+	flags, _ := intFromConfig(m, "flags", 0)
+	return godo.DomainRecordEditRequest{
+		Type:     strings.ToUpper(strFromConfig(m, "type", "A")),
+		Name:     strFromConfig(m, "name", "@"),
+		Data:     strFromConfig(m, "data", ""),
+		TTL:      ttl,
+		Priority: priority,
+		Port:     port,
+		Weight:   weight,
+		Flags:    flags,
+		Tag:      strFromConfig(m, "tag", ""),
+	}
+}
+
+func dnsRecordIdentity(recordType, name, data string) string {
+	return strings.ToUpper(recordType) + "\x00" + strings.ToLower(name) + "\x00" + data
+}
+
+func dnsRecordMatchesRequest(record godo.DomainRecord, req godo.DomainRecordEditRequest) bool {
+	return strings.EqualFold(record.Type, req.Type) &&
+		strings.EqualFold(record.Name, req.Name) &&
+		record.Data == req.Data &&
+		record.TTL == req.TTL &&
+		record.Priority == req.Priority &&
+		record.Port == req.Port &&
+		record.Weight == req.Weight &&
+		record.Flags == req.Flags &&
+		record.Tag == req.Tag
+}
+
+func dnsOutput(dom *godo.Domain, name string, records []godo.DomainRecord) *interfaces.ResourceOutput {
+	outputs := map[string]any{
+		"domain": dom.Name,
+		"ttl":    dom.TTL,
+	}
+	if records != nil {
+		outputs["records"] = dnsRecordOutputs(records)
+	}
 	return &interfaces.ResourceOutput{
 		Name:       name,
 		Type:       "infra.dns",
 		ProviderID: dom.Name,
-		Outputs: map[string]any{
-			"domain": dom.Name,
-			"ttl":    dom.TTL,
-		},
-		Status: "active",
+		Outputs:    outputs,
+		Status:     "active",
 	}
+}
+
+func dnsRecordOutputs(records []godo.DomainRecord) []map[string]any {
+	out := make([]map[string]any, 0, len(records))
+	for _, record := range records {
+		out = append(out, map[string]any{
+			"type":     record.Type,
+			"name":     record.Name,
+			"data":     record.Data,
+			"ttl":      record.TTL,
+			"priority": record.Priority,
+			"port":     record.Port,
+			"weight":   record.Weight,
+			"flags":    record.Flags,
+			"tag":      record.Tag,
+		})
+	}
+	return out
 }
 
 func (d *DNSDriver) SensitiveKeys() []string { return nil }
 
-func (d *DNSDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatDomainName }
+func (d *DNSDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatDomainName
+}

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/netip"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -139,11 +140,11 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 	}
 	currentByKey := make(map[string][]godo.DomainRecord)
 	for _, record := range currentRecords {
-		key := dnsRecordIdentity(record.Type, record.Name, record.Data)
+		key := dnsDomainRecordIdentity(record)
 		currentByKey[key] = append(currentByKey[key], record)
 	}
 	for _, desiredRecord := range desiredRecords {
-		key := dnsRecordIdentity(desiredRecord.Type, desiredRecord.Name, desiredRecord.Data)
+		key := dnsRecordRequestIdentity(desiredRecord)
 		candidates := currentByKey[key]
 		if len(candidates) == 0 {
 			return &interfaces.DiffResult{NeedsUpdate: true}, nil
@@ -185,13 +186,13 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []
 
 	existingByKey := make(map[string][]godo.DomainRecord)
 	for _, r := range existing {
-		key := dnsRecordIdentity(r.Type, r.Name, r.Data)
+		key := dnsDomainRecordIdentity(r)
 		existingByKey[key] = append(existingByKey[key], r)
 	}
 
 	seenDeclared := make(map[string]struct{})
 	for _, editReq := range records {
-		key := dnsRecordIdentity(editReq.Type, editReq.Name, editReq.Data)
+		key := dnsRecordRequestIdentity(editReq)
 		if _, seen := seenDeclared[key]; seen {
 			continue
 		}
@@ -244,7 +245,7 @@ func dnsDomainFromConfig(config map[string]any, fallback string) (string, error)
 	if domain == "" {
 		return "", fmt.Errorf("dns domain is required")
 	}
-	if !interfaces.ValidateProviderID(domain, interfaces.IDFormatDomainName) {
+	if !isDigitalOceanManagedDomainName(domain) {
 		return "", fmt.Errorf("dns domain %q is not a valid domain name", domain)
 	}
 	return domain, nil
@@ -262,10 +263,16 @@ func dnsDomainFromConfigIfPresent(config map[string]any) (string, bool, error) {
 	if domain == "" {
 		return "", true, fmt.Errorf("dns domain must not be empty")
 	}
-	if !interfaces.ValidateProviderID(domain, interfaces.IDFormatDomainName) {
+	if !isDigitalOceanManagedDomainName(domain) {
 		return "", true, fmt.Errorf("dns domain %q is not a valid domain name", domain)
 	}
 	return domain, true, nil
+}
+
+func isDigitalOceanManagedDomainName(domain string) bool {
+	return !strings.HasSuffix(domain, ".") &&
+		strings.Contains(domain, ".") &&
+		interfaces.ValidateProviderID(domain, interfaces.IDFormatDomainName)
 }
 
 func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, error) {
@@ -285,7 +292,7 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 		if err != nil {
 			return nil, err
 		}
-		key := dnsRecordIdentity(req.Type, req.Name, req.Data)
+		key := dnsRecordRequestIdentity(req)
 		if existing, exists := seen[key]; exists {
 			if !dnsRecordRequestsEqual(existing, req) {
 				return nil, fmt.Errorf("dns conflicting duplicate DNS record %s/%s data %q", req.Type, req.Name, req.Data)
@@ -370,27 +377,27 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	ttl, err := dnsOptionalIntField(index, m, "ttl", 300, true)
+	ttl, _, err := dnsOptionalIntField(index, m, "ttl", 300, true)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	priority, err := dnsOptionalIntField(index, m, "priority", 0, false)
+	priority, hasPriority, err := dnsOptionalIntField(index, m, "priority", 0, false)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	port, err := dnsOptionalIntField(index, m, "port", 0, false)
+	port, hasPort, err := dnsOptionalIntField(index, m, "port", 0, false)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	weight, err := dnsOptionalIntField(index, m, "weight", 0, false)
+	weight, hasWeight, err := dnsOptionalIntField(index, m, "weight", 0, false)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	flags, err := dnsOptionalIntField(index, m, "flags", 0, false)
+	flags, _, err := dnsOptionalIntField(index, m, "flags", 0, false)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	return godo.DomainRecordEditRequest{
+	req := godo.DomainRecordEditRequest{
 		Type:     recordType,
 		Name:     name,
 		Data:     data,
@@ -400,7 +407,11 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 		Weight:   weight,
 		Flags:    flags,
 		Tag:      tag,
-	}, nil
+	}
+	if err := validateDNSRecordRequest(index, req, hasPriority, hasPort, hasWeight); err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	return req, nil
 }
 
 func dnsOptionalStringField(index int, m map[string]any, key, defaultValue string) (string, error) {
@@ -433,10 +444,10 @@ func dnsRequiredStringField(index int, m map[string]any, key string) (string, er
 	return text, nil
 }
 
-func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue int, positive bool) (int, error) {
+func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue int, positive bool) (int, bool, error) {
 	value, ok := m[key]
 	if !ok {
-		return defaultValue, nil
+		return defaultValue, false, nil
 	}
 	var out int
 	switch typed := value.(type) {
@@ -447,18 +458,81 @@ func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue i
 	case float64:
 		out = int(typed)
 		if typed != float64(out) {
-			return 0, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
+			return 0, true, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
 		}
 	default:
-		return 0, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
+		return 0, true, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
 	}
 	if positive && out <= 0 {
-		return 0, fmt.Errorf("dns records[%d].%s must be positive", index, key)
+		return 0, true, fmt.Errorf("dns records[%d].%s must be positive", index, key)
 	}
 	if !positive && out < 0 {
-		return 0, fmt.Errorf("dns records[%d].%s must be non-negative", index, key)
+		return 0, true, fmt.Errorf("dns records[%d].%s must be non-negative", index, key)
 	}
-	return out, nil
+	return out, true, nil
+}
+
+func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPriority, hasPort, hasWeight bool) error {
+	switch req.Type {
+	case "A":
+		addr, err := netip.ParseAddr(req.Data)
+		if err != nil || !addr.Is4() {
+			return fmt.Errorf("dns records[%d].data must be an IPv4 address", index)
+		}
+	case "AAAA":
+		addr, err := netip.ParseAddr(req.Data)
+		if err != nil || !addr.Is6() {
+			return fmt.Errorf("dns records[%d].data must be an IPv6 address", index)
+		}
+	case "CNAME":
+		if _, err := netip.ParseAddr(req.Data); err == nil {
+			return fmt.Errorf("dns records[%d].data must be a hostname for CNAME records", index)
+		}
+	case "MX":
+		if !hasPriority {
+			return fmt.Errorf("dns records[%d].priority is required for MX records", index)
+		}
+		if err := validateDNSUint16(index, "priority", req.Priority); err != nil {
+			return err
+		}
+	case "SRV":
+		if !hasPriority {
+			return fmt.Errorf("dns records[%d].priority is required for SRV records", index)
+		}
+		if !hasPort {
+			return fmt.Errorf("dns records[%d].port is required for SRV records", index)
+		}
+		if !hasWeight {
+			return fmt.Errorf("dns records[%d].weight is required for SRV records", index)
+		}
+		if err := validateDNSUint16(index, "priority", req.Priority); err != nil {
+			return err
+		}
+		if req.Port <= 0 || req.Port > 65535 {
+			return fmt.Errorf("dns records[%d].port must be between 1 and 65535", index)
+		}
+		if err := validateDNSUint16(index, "weight", req.Weight); err != nil {
+			return err
+		}
+	case "CAA":
+		if req.Tag == "" {
+			return fmt.Errorf("dns records[%d].tag is required for CAA records", index)
+		}
+		if strings.ContainsAny(req.Tag, " \t\r\n") {
+			return fmt.Errorf("dns records[%d].tag must not contain whitespace", index)
+		}
+		if req.Flags < 0 || req.Flags > 255 {
+			return fmt.Errorf("dns records[%d].flags must be between 0 and 255", index)
+		}
+	}
+	return nil
+}
+
+func validateDNSUint16(index int, field string, value int) error {
+	if value < 0 || value > 65535 {
+		return fmt.Errorf("dns records[%d].%s must be between 0 and 65535", index, field)
+	}
+	return nil
 }
 
 func isSupportedDNSRecordType(recordType string) bool {
@@ -531,8 +605,25 @@ func dnsDomainRecordFromRequest(req godo.DomainRecordEditRequest) godo.DomainRec
 	}
 }
 
-func dnsRecordIdentity(recordType, name, data string) string {
-	return strings.ToUpper(recordType) + "\x00" + strings.ToLower(name) + "\x00" + data
+func dnsRecordRequestIdentity(req godo.DomainRecordEditRequest) string {
+	return dnsRecordIdentity(req.Type, req.Name, req.Data, req.Priority, req.Port, req.Weight, req.Flags, req.Tag)
+}
+
+func dnsDomainRecordIdentity(record godo.DomainRecord) string {
+	return dnsRecordIdentity(record.Type, record.Name, record.Data, record.Priority, record.Port, record.Weight, record.Flags, record.Tag)
+}
+
+func dnsRecordIdentity(recordType, name, data string, priority, port, weight, flags int, tag string) string {
+	parts := []string{strings.ToUpper(recordType), strings.ToLower(name), data}
+	switch strings.ToUpper(recordType) {
+	case "CAA":
+		parts = append(parts, fmt.Sprint(flags), strings.ToLower(tag))
+	case "MX":
+		parts = append(parts, fmt.Sprint(priority))
+	case "SRV":
+		parts = append(parts, fmt.Sprint(priority), fmt.Sprint(port), fmt.Sprint(weight))
+	}
+	return strings.Join(parts, "\x00")
 }
 
 func dnsRecordMatchesRequest(record godo.DomainRecord, req godo.DomainRecordEditRequest) bool {

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -47,6 +48,10 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 	// Idempotent: create domain only if it doesn't exist.
 	dom, _, err := d.client.Get(ctx, domain)
 	if err != nil {
+		wrapped := WrapGodoError(err)
+		if !errors.Is(wrapped, interfaces.ErrResourceNotFound) {
+			return nil, fmt.Errorf("dns get domain %q: %w", domain, wrapped)
+		}
 		dom, _, err = d.client.Create(ctx, &godo.DomainCreateRequest{Name: domain})
 		if err != nil {
 			return nil, fmt.Errorf("dns create domain %q: %w", domain, WrapGodoError(err))
@@ -57,7 +62,11 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 		return nil, err
 	}
 
-	return dnsOutput(dom, spec.Name, nil), nil
+	records, err := d.listRecords(ctx, domain)
+	if err != nil {
+		return nil, err
+	}
+	return dnsOutput(dom, spec.Name, records), nil
 }
 
 func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
@@ -75,10 +84,13 @@ func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*inte
 
 func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	domain := strFromConfig(spec.Config, "domain", ref.ProviderID)
+	if ref.ProviderID != "" && !strings.EqualFold(domain, ref.ProviderID) {
+		return nil, fmt.Errorf("dns update %q: cannot change domain from %q to %q", ref.Name, ref.ProviderID, domain)
+	}
 	if err := d.upsertRecords(ctx, domain, spec.Config); err != nil {
 		return nil, err
 	}
-	return d.Read(ctx, ref)
+	return d.Read(ctx, interfaces.ResourceRef{Name: ref.Name, ProviderID: domain})
 }
 
 func (d *DNSDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
@@ -90,8 +102,39 @@ func (d *DNSDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) erro
 }
 
 func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	desiredRecords, err := declaredDNSRecords(desired.Config)
+	if err != nil {
+		return nil, err
+	}
 	if current == nil {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
+	}
+	if desiredDomain := strFromConfig(desired.Config, "domain", ""); desiredDomain != "" && !strings.EqualFold(desiredDomain, current.ProviderID) {
+		return &interfaces.DiffResult{NeedsUpdate: true}, nil
+	}
+	if len(desiredRecords) == 0 {
+		return &interfaces.DiffResult{NeedsUpdate: false}, nil
+	}
+	currentRecords, err := dnsRecordsFromOutput(current)
+	if err != nil {
+		return nil, err
+	}
+	currentByKey := make(map[string][]godo.DomainRecord)
+	for _, record := range currentRecords {
+		key := dnsRecordIdentity(record.Type, record.Name, record.Data)
+		currentByKey[key] = append(currentByKey[key], record)
+	}
+	for _, desiredRecord := range desiredRecords {
+		key := dnsRecordIdentity(desiredRecord.Type, desiredRecord.Name, desiredRecord.Data)
+		candidates := currentByKey[key]
+		if len(candidates) == 0 {
+			return &interfaces.DiffResult{NeedsUpdate: true}, nil
+		}
+		currentRecord := candidates[0]
+		currentByKey[key] = candidates[1:]
+		if !dnsRecordMatchesRequest(currentRecord, desiredRecord) {
+			return &interfaces.DiffResult{NeedsUpdate: true}, nil
+		}
 	}
 	return &interfaces.DiffResult{NeedsUpdate: false}, nil
 }
@@ -184,6 +227,7 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 	}
 	out := make([]godo.DomainRecordEditRequest, 0, len(raw))
 	seen := make(map[string]godo.DomainRecordEditRequest)
+	recordsByName := make(map[string][]godo.DomainRecordEditRequest)
 	for i, rec := range raw {
 		m, ok := rec.(map[string]any)
 		if !ok {
@@ -200,10 +244,23 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 			}
 			continue
 		}
+		if err := validateDNSRecordNameConflict(req, recordsByName[strings.ToLower(req.Name)]); err != nil {
+			return nil, err
+		}
 		seen[key] = req
+		recordsByName[strings.ToLower(req.Name)] = append(recordsByName[strings.ToLower(req.Name)], req)
 		out = append(out, req)
 	}
 	return out, nil
+}
+
+func validateDNSRecordNameConflict(req godo.DomainRecordEditRequest, existing []godo.DomainRecordEditRequest) error {
+	for _, other := range existing {
+		if req.Type == "CNAME" || other.Type == "CNAME" {
+			return fmt.Errorf("dns conflicting DNS record %s/%s conflicts with %s/%s", req.Type, req.Name, other.Type, other.Name)
+		}
+	}
+	return nil
 }
 
 func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRecordEditRequest, error) {
@@ -337,6 +394,55 @@ func dnsRecordRequestsEqual(a, b godo.DomainRecordEditRequest) bool {
 		a.Weight == b.Weight &&
 		a.Flags == b.Flags &&
 		a.Tag == b.Tag
+}
+
+func dnsRecordsFromOutput(current *interfaces.ResourceOutput) ([]godo.DomainRecord, error) {
+	if current.Outputs == nil {
+		return nil, nil
+	}
+	raw, ok := current.Outputs["records"]
+	if !ok || raw == nil {
+		return nil, nil
+	}
+	var maps []map[string]any
+	switch typed := raw.(type) {
+	case []map[string]any:
+		maps = typed
+	case []any:
+		maps = make([]map[string]any, 0, len(typed))
+		for i, item := range typed {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("dns outputs.records[%d] must be an object", i)
+			}
+			maps = append(maps, m)
+		}
+	default:
+		return nil, fmt.Errorf("dns outputs.records must be a list")
+	}
+	records := make([]godo.DomainRecord, 0, len(maps))
+	for i, m := range maps {
+		req, err := dnsRecordEditRequestFromConfig(i, m)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, dnsDomainRecordFromRequest(req))
+	}
+	return records, nil
+}
+
+func dnsDomainRecordFromRequest(req godo.DomainRecordEditRequest) godo.DomainRecord {
+	return godo.DomainRecord{
+		Type:     req.Type,
+		Name:     req.Name,
+		Data:     req.Data,
+		TTL:      req.TTL,
+		Priority: req.Priority,
+		Port:     req.Port,
+		Weight:   req.Weight,
+		Flags:    req.Flags,
+		Tag:      req.Tag,
+	}
 }
 
 func dnsRecordIdentity(recordType, name, data string) string {

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -41,9 +41,16 @@ func NewDNSDriverWithClient(c DomainsClient) *DNSDriver {
 // Config keys:
 //
 //	domain   string            — the zone name (e.g. "example.com")
-//	records  []map[string]any  — each: {type, name, data, ttl}
+//	records  []any|[]map[string]any — each: {type, name, data, ttl}
 func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
-	domain := strFromConfig(spec.Config, "domain", spec.Name)
+	domain, err := dnsDomainFromConfig(spec.Config, spec.Name)
+	if err != nil {
+		return nil, err
+	}
+	declaredRecords, err := declaredDNSRecords(spec.Config)
+	if err != nil {
+		return nil, err
+	}
 
 	// Idempotent: create domain only if it doesn't exist.
 	dom, _, err := d.client.Get(ctx, domain)
@@ -58,7 +65,7 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 		}
 	}
 
-	if err := d.upsertRecords(ctx, domain, spec.Config); err != nil {
+	if err := d.upsertRecords(ctx, domain, declaredRecords); err != nil {
 		return nil, err
 	}
 
@@ -83,11 +90,18 @@ func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*inte
 }
 
 func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
-	domain := strFromConfig(spec.Config, "domain", ref.ProviderID)
+	domain, err := dnsDomainFromConfig(spec.Config, ref.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+	declaredRecords, err := declaredDNSRecords(spec.Config)
+	if err != nil {
+		return nil, err
+	}
 	if ref.ProviderID != "" && !strings.EqualFold(domain, ref.ProviderID) {
 		return nil, fmt.Errorf("dns update %q: cannot change domain from %q to %q", ref.Name, ref.ProviderID, domain)
 	}
-	if err := d.upsertRecords(ctx, domain, spec.Config); err != nil {
+	if err := d.upsertRecords(ctx, domain, declaredRecords); err != nil {
 		return nil, err
 	}
 	return d.Read(ctx, interfaces.ResourceRef{Name: ref.Name, ProviderID: domain})
@@ -102,6 +116,10 @@ func (d *DNSDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) erro
 }
 
 func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	desiredDomain, hasDesiredDomain, err := dnsDomainFromConfigIfPresent(desired.Config)
+	if err != nil {
+		return nil, err
+	}
 	desiredRecords, err := declaredDNSRecords(desired.Config)
 	if err != nil {
 		return nil, err
@@ -109,7 +127,7 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 	if current == nil {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
-	if desiredDomain := strFromConfig(desired.Config, "domain", ""); desiredDomain != "" && !strings.EqualFold(desiredDomain, current.ProviderID) {
+	if hasDesiredDomain && !strings.EqualFold(desiredDomain, current.ProviderID) {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
 	if len(desiredRecords) == 0 {
@@ -152,17 +170,16 @@ func (d *DNSDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*
 }
 
 // upsertRecords creates or updates DNS records for a domain.
-func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, config map[string]any) error {
-	records, err := declaredDNSRecords(config)
-	if err != nil {
-		return err
-	}
+func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []godo.DomainRecordEditRequest) error {
 	if len(records) == 0 {
 		return nil
 	}
 
 	existing, err := d.listRecords(ctx, domain)
 	if err != nil {
+		return err
+	}
+	if err := validateDNSRecordLiveConflicts(records, existing); err != nil {
 		return err
 	}
 
@@ -216,23 +233,54 @@ func (d *DNSDriver) listRecords(ctx context.Context, domain string) ([]godo.Doma
 	return out, nil
 }
 
+func dnsDomainFromConfig(config map[string]any, fallback string) (string, error) {
+	domain, ok, err := dnsDomainFromConfigIfPresent(config)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		domain = fallback
+	}
+	if domain == "" {
+		return "", fmt.Errorf("dns domain is required")
+	}
+	if !interfaces.ValidateProviderID(domain, interfaces.IDFormatDomainName) {
+		return "", fmt.Errorf("dns domain %q is not a valid domain name", domain)
+	}
+	return domain, nil
+}
+
+func dnsDomainFromConfigIfPresent(config map[string]any) (string, bool, error) {
+	value, ok := config["domain"]
+	if !ok {
+		return "", false, nil
+	}
+	domain, ok := value.(string)
+	if !ok {
+		return "", true, fmt.Errorf("dns domain must be a string")
+	}
+	if domain == "" {
+		return "", true, fmt.Errorf("dns domain must not be empty")
+	}
+	if !interfaces.ValidateProviderID(domain, interfaces.IDFormatDomainName) {
+		return "", true, fmt.Errorf("dns domain %q is not a valid domain name", domain)
+	}
+	return domain, true, nil
+}
+
 func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, error) {
 	rawValue, ok := config["records"]
 	if !ok {
 		return nil, nil
 	}
-	raw, ok := rawValue.([]any)
-	if !ok {
-		return nil, fmt.Errorf("dns records must be a list")
+	raw, err := dnsRecordConfigMaps(rawValue)
+	if err != nil {
+		return nil, err
 	}
 	out := make([]godo.DomainRecordEditRequest, 0, len(raw))
 	seen := make(map[string]godo.DomainRecordEditRequest)
 	recordsByName := make(map[string][]godo.DomainRecordEditRequest)
-	for i, rec := range raw {
-		m, ok := rec.(map[string]any)
-		if !ok {
-			return nil, fmt.Errorf("dns records[%d] must be an object", i)
-		}
+	for i, m := range raw {
 		req, err := dnsRecordEditRequestFromConfig(i, m)
 		if err != nil {
 			return nil, err
@@ -254,9 +302,47 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 	return out, nil
 }
 
+func dnsRecordConfigMaps(rawValue any) ([]map[string]any, error) {
+	switch raw := rawValue.(type) {
+	case []map[string]any:
+		return raw, nil
+	case []any:
+		maps := make([]map[string]any, 0, len(raw))
+		for i, rec := range raw {
+			m, ok := rec.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("dns records[%d] must be an object", i)
+			}
+			maps = append(maps, m)
+		}
+		return maps, nil
+	default:
+		return nil, fmt.Errorf("dns records must be a list")
+	}
+}
+
 func validateDNSRecordNameConflict(req godo.DomainRecordEditRequest, existing []godo.DomainRecordEditRequest) error {
 	for _, other := range existing {
 		if req.Type == "CNAME" || other.Type == "CNAME" {
+			return fmt.Errorf("dns conflicting DNS record %s/%s conflicts with %s/%s", req.Type, req.Name, other.Type, other.Name)
+		}
+	}
+	return nil
+}
+
+func validateDNSRecordLiveConflicts(records []godo.DomainRecordEditRequest, existing []godo.DomainRecord) error {
+	existingByName := make(map[string][]godo.DomainRecord)
+	for _, record := range existing {
+		existingByName[strings.ToLower(record.Name)] = append(existingByName[strings.ToLower(record.Name)], record)
+	}
+	for _, req := range records {
+		for _, other := range existingByName[strings.ToLower(req.Name)] {
+			if req.Type != "CNAME" && !strings.EqualFold(other.Type, "CNAME") {
+				continue
+			}
+			if req.Type == "CNAME" && strings.EqualFold(other.Type, "CNAME") && other.Data == req.Data {
+				continue
+			}
 			return fmt.Errorf("dns conflicting DNS record %s/%s conflicts with %s/%s", req.Type, req.Name, other.Type, other.Name)
 		}
 	}

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -66,9 +66,9 @@ func (d *DNSDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*inte
 	if err != nil {
 		return nil, fmt.Errorf("dns read %q: %w", ref.Name, WrapGodoError(err))
 	}
-	records, _, err := d.client.Records(ctx, domain, nil)
+	records, err := d.listRecords(ctx, domain)
 	if err != nil {
-		return nil, fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
+		return nil, err
 	}
 	return dnsOutput(dom, ref.Name, records), nil
 }
@@ -110,14 +110,17 @@ func (d *DNSDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*
 
 // upsertRecords creates or updates DNS records for a domain.
 func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, config map[string]any) error {
-	records := declaredDNSRecords(config)
+	records, err := declaredDNSRecords(config)
+	if err != nil {
+		return err
+	}
 	if len(records) == 0 {
 		return nil
 	}
 
-	existing, _, err := d.client.Records(ctx, domain, nil)
+	existing, err := d.listRecords(ctx, domain)
 	if err != nil {
-		return fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
+		return err
 	}
 
 	existingByKey := make(map[string][]godo.DomainRecord)
@@ -153,39 +156,187 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, config map
 	return nil
 }
 
-func declaredDNSRecords(config map[string]any) []godo.DomainRecordEditRequest {
-	raw, ok := config["records"].([]any)
-	if !ok {
-		return nil
-	}
-	out := make([]godo.DomainRecordEditRequest, 0, len(raw))
-	for _, rec := range raw {
-		m, _ := rec.(map[string]any)
-		if m == nil {
-			continue
+func (d *DNSDriver) listRecords(ctx context.Context, domain string) ([]godo.DomainRecord, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	var out []godo.DomainRecord
+	for {
+		records, resp, err := d.client.Records(ctx, domain, opts)
+		if err != nil {
+			return nil, fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
 		}
-		out = append(out, dnsRecordEditRequestFromConfig(m))
+		out = append(out, records...)
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
 	}
-	return out
+	return out, nil
 }
 
-func dnsRecordEditRequestFromConfig(m map[string]any) godo.DomainRecordEditRequest {
-	ttl, _ := intFromConfig(m, "ttl", 300)
-	priority, _ := intFromConfig(m, "priority", 0)
-	port, _ := intFromConfig(m, "port", 0)
-	weight, _ := intFromConfig(m, "weight", 0)
-	flags, _ := intFromConfig(m, "flags", 0)
+func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, error) {
+	rawValue, ok := config["records"]
+	if !ok {
+		return nil, nil
+	}
+	raw, ok := rawValue.([]any)
+	if !ok {
+		return nil, fmt.Errorf("dns records must be a list")
+	}
+	out := make([]godo.DomainRecordEditRequest, 0, len(raw))
+	seen := make(map[string]godo.DomainRecordEditRequest)
+	for i, rec := range raw {
+		m, ok := rec.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("dns records[%d] must be an object", i)
+		}
+		req, err := dnsRecordEditRequestFromConfig(i, m)
+		if err != nil {
+			return nil, err
+		}
+		key := dnsRecordIdentity(req.Type, req.Name, req.Data)
+		if existing, exists := seen[key]; exists {
+			if !dnsRecordRequestsEqual(existing, req) {
+				return nil, fmt.Errorf("dns conflicting duplicate DNS record %s/%s data %q", req.Type, req.Name, req.Data)
+			}
+			continue
+		}
+		seen[key] = req
+		out = append(out, req)
+	}
+	return out, nil
+}
+
+func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRecordEditRequest, error) {
+	recordType, err := dnsOptionalStringField(index, m, "type", "A")
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	recordType = strings.ToUpper(recordType)
+	if !isSupportedDNSRecordType(recordType) {
+		return godo.DomainRecordEditRequest{}, fmt.Errorf("dns records[%d].type %q is not supported", index, recordType)
+	}
+	name, err := dnsOptionalStringField(index, m, "name", "@")
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	data, err := dnsRequiredStringField(index, m, "data")
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	tag, err := dnsOptionalStringField(index, m, "tag", "")
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	ttl, err := dnsOptionalIntField(index, m, "ttl", 300, true)
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	priority, err := dnsOptionalIntField(index, m, "priority", 0, false)
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	port, err := dnsOptionalIntField(index, m, "port", 0, false)
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	weight, err := dnsOptionalIntField(index, m, "weight", 0, false)
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
+	flags, err := dnsOptionalIntField(index, m, "flags", 0, false)
+	if err != nil {
+		return godo.DomainRecordEditRequest{}, err
+	}
 	return godo.DomainRecordEditRequest{
-		Type:     strings.ToUpper(strFromConfig(m, "type", "A")),
-		Name:     strFromConfig(m, "name", "@"),
-		Data:     strFromConfig(m, "data", ""),
+		Type:     recordType,
+		Name:     name,
+		Data:     data,
 		TTL:      ttl,
 		Priority: priority,
 		Port:     port,
 		Weight:   weight,
 		Flags:    flags,
-		Tag:      strFromConfig(m, "tag", ""),
+		Tag:      tag,
+	}, nil
+}
+
+func dnsOptionalStringField(index int, m map[string]any, key, defaultValue string) (string, error) {
+	value, ok := m[key]
+	if !ok {
+		return defaultValue, nil
 	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("dns records[%d].%s must be a string", index, key)
+	}
+	if text == "" && defaultValue != "" {
+		return "", fmt.Errorf("dns records[%d].%s must not be empty", index, key)
+	}
+	return text, nil
+}
+
+func dnsRequiredStringField(index int, m map[string]any, key string) (string, error) {
+	value, ok := m[key]
+	if !ok {
+		return "", fmt.Errorf("dns records[%d].%s is required", index, key)
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("dns records[%d].%s must be a string", index, key)
+	}
+	if text == "" {
+		return "", fmt.Errorf("dns records[%d].%s is required", index, key)
+	}
+	return text, nil
+}
+
+func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue int, positive bool) (int, error) {
+	value, ok := m[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	var out int
+	switch typed := value.(type) {
+	case int:
+		out = typed
+	case int64:
+		out = int(typed)
+	case float64:
+		out = int(typed)
+		if typed != float64(out) {
+			return 0, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
+		}
+	default:
+		return 0, fmt.Errorf("dns records[%d].%s must be an integer", index, key)
+	}
+	if positive && out <= 0 {
+		return 0, fmt.Errorf("dns records[%d].%s must be positive", index, key)
+	}
+	if !positive && out < 0 {
+		return 0, fmt.Errorf("dns records[%d].%s must be non-negative", index, key)
+	}
+	return out, nil
+}
+
+func isSupportedDNSRecordType(recordType string) bool {
+	switch recordType {
+	case "A", "AAAA", "CAA", "CNAME", "MX", "NS", "SRV", "TXT":
+		return true
+	default:
+		return false
+	}
+}
+
+func dnsRecordRequestsEqual(a, b godo.DomainRecordEditRequest) bool {
+	return strings.EqualFold(a.Type, b.Type) &&
+		strings.EqualFold(a.Name, b.Name) &&
+		a.Data == b.Data &&
+		a.TTL == b.TTL &&
+		a.Priority == b.Priority &&
+		a.Port == b.Port &&
+		a.Weight == b.Weight &&
+		a.Flags == b.Flags &&
+		a.Tag == b.Tag
 }
 
 func dnsRecordIdentity(recordType, name, data string) string {

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -186,13 +186,13 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []
 
 	existingByKey := make(map[string][]godo.DomainRecord)
 	for _, r := range existing {
-		key := dnsDomainRecordIdentity(r)
+		key := dnsDomainRecordUpsertKey(r)
 		existingByKey[key] = append(existingByKey[key], r)
 	}
 
 	seenDeclared := make(map[string]struct{})
 	for _, editReq := range records {
-		key := dnsRecordRequestIdentity(editReq)
+		key := dnsRecordRequestUpsertKey(editReq)
 		if _, seen := seenDeclared[key]; seen {
 			continue
 		}
@@ -348,7 +348,7 @@ func validateDNSRecordLiveConflicts(records []godo.DomainRecordEditRequest, exis
 			if req.Type != "CNAME" && !strings.EqualFold(other.Type, "CNAME") {
 				continue
 			}
-			if req.Type == "CNAME" && strings.EqualFold(other.Type, "CNAME") && dnsRecordDataMatches(other.Type, other.Data, req.Data) {
+			if req.Type == "CNAME" && strings.EqualFold(other.Type, "CNAME") {
 				continue
 			}
 			return fmt.Errorf("dns conflicting DNS record %s/%s conflicts with %s/%s", req.Type, req.Name, other.Type, other.Name)
@@ -374,6 +374,7 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
+	_, hasTag := m["tag"]
 	tag, err := dnsOptionalStringField(index, m, "tag", "")
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
@@ -394,7 +395,7 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
-	flags, _, err := dnsOptionalIntField(index, m, "flags", 0, false)
+	flags, hasFlags, err := dnsOptionalIntField(index, m, "flags", 0, false)
 	if err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
@@ -409,7 +410,7 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 		Flags:    flags,
 		Tag:      tag,
 	}
-	if err := validateDNSRecordRequest(index, req, hasPriority, hasPort, hasWeight); err != nil {
+	if err := validateDNSRecordRequest(index, req, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
 		return godo.DomainRecordEditRequest{}, err
 	}
 	return req, nil
@@ -473,7 +474,7 @@ func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue i
 	return out, true, nil
 }
 
-func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPriority, hasPort, hasWeight bool) error {
+func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPriority, hasPort, hasWeight, hasFlags, hasTag bool) error {
 	if !isValidDNSRecordName(req.Name) {
 		return fmt.Errorf("dns records[%d].name must be a valid DNS record name", index)
 	}
@@ -482,20 +483,32 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 	}
 	switch req.Type {
 	case "A":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
 		addr, err := netip.ParseAddr(req.Data)
 		if err != nil || !addr.Is4() {
 			return fmt.Errorf("dns records[%d].data must be an IPv4 address", index)
 		}
 	case "AAAA":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
 		addr, err := netip.ParseAddr(req.Data)
 		if err != nil || !addr.Is6() {
 			return fmt.Errorf("dns records[%d].data must be an IPv6 address", index)
 		}
 	case "CNAME":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
 		if !isValidDNSHostnameValue(req.Data) {
 			return fmt.Errorf("dns records[%d].data must be a hostname for CNAME records", index)
 		}
 	case "MX":
+		if err := rejectDNSRecordFields(index, req.Type, false, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
 		if !hasPriority {
 			return fmt.Errorf("dns records[%d].priority is required for MX records", index)
 		}
@@ -506,10 +519,16 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 			return fmt.Errorf("dns records[%d].data must be a hostname for MX records", index)
 		}
 	case "NS":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
 		if !isValidDNSHostnameValue(req.Data) {
 			return fmt.Errorf("dns records[%d].data must be a hostname for NS records", index)
 		}
 	case "SRV":
+		if err := rejectDNSRecordFields(index, req.Type, false, false, false, hasFlags, hasTag); err != nil {
+			return err
+		}
 		if !hasPriority {
 			return fmt.Errorf("dns records[%d].priority is required for SRV records", index)
 		}
@@ -532,14 +551,45 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 			return fmt.Errorf("dns records[%d].data must be a hostname for SRV records", index)
 		}
 	case "CAA":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, false, false); err != nil {
+			return err
+		}
 		if req.Tag == "" {
 			return fmt.Errorf("dns records[%d].tag is required for CAA records", index)
 		}
 		if strings.ContainsAny(req.Tag, " \t\r\n") {
 			return fmt.Errorf("dns records[%d].tag must not contain whitespace", index)
 		}
+		switch strings.ToLower(req.Tag) {
+		case "issue", "issuewild", "iodef":
+		default:
+			return fmt.Errorf("dns records[%d].tag must be one of issue, issuewild, iodef", index)
+		}
 		if req.Flags < 0 || req.Flags > 255 {
 			return fmt.Errorf("dns records[%d].flags must be between 0 and 255", index)
+		}
+	case "TXT":
+		if err := rejectDNSRecordFields(index, req.Type, hasPriority, hasPort, hasWeight, hasFlags, hasTag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rejectDNSRecordFields(index int, recordType string, hasPriority, hasPort, hasWeight, hasFlags, hasTag bool) error {
+	fields := []struct {
+		name string
+		has  bool
+	}{
+		{name: "priority", has: hasPriority},
+		{name: "port", has: hasPort},
+		{name: "weight", has: hasWeight},
+		{name: "flags", has: hasFlags},
+		{name: "tag", has: hasTag},
+	}
+	for _, field := range fields {
+		if field.has {
+			return fmt.Errorf("dns records[%d].%s is not valid for %s records", index, field.name, recordType)
 		}
 	}
 	return nil
@@ -651,13 +701,70 @@ func dnsRecordsFromOutput(current *interfaces.ResourceOutput) ([]godo.DomainReco
 	}
 	records := make([]godo.DomainRecord, 0, len(maps))
 	for i, m := range maps {
-		req, err := dnsRecordEditRequestFromConfig(i, m)
+		record, ok, err := dnsDomainRecordFromOutputMap(i, m)
 		if err != nil {
 			return nil, err
 		}
-		records = append(records, dnsDomainRecordFromRequest(req))
+		if !ok {
+			continue
+		}
+		records = append(records, record)
 	}
 	return records, nil
+}
+
+func dnsDomainRecordFromOutputMap(index int, m map[string]any) (godo.DomainRecord, bool, error) {
+	recordType, err := dnsOptionalStringField(index, m, "type", "")
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	recordType = strings.ToUpper(recordType)
+	if !isSupportedDNSRecordType(recordType) {
+		return godo.DomainRecord{}, false, nil
+	}
+	name, err := dnsOptionalStringField(index, m, "name", "@")
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	data, err := dnsOptionalStringField(index, m, "data", "")
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	tag, err := dnsOptionalStringField(index, m, "tag", "")
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	ttl, _, err := dnsOptionalIntField(index, m, "ttl", 0, false)
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	priority, _, err := dnsOptionalIntField(index, m, "priority", 0, false)
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	port, _, err := dnsOptionalIntField(index, m, "port", 0, false)
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	weight, _, err := dnsOptionalIntField(index, m, "weight", 0, false)
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	flags, _, err := dnsOptionalIntField(index, m, "flags", 0, false)
+	if err != nil {
+		return godo.DomainRecord{}, false, err
+	}
+	return godo.DomainRecord{
+		Type:     recordType,
+		Name:     name,
+		Data:     data,
+		TTL:      ttl,
+		Priority: priority,
+		Port:     port,
+		Weight:   weight,
+		Flags:    flags,
+		Tag:      tag,
+	}, true, nil
 }
 
 func dnsDomainRecordFromRequest(req godo.DomainRecordEditRequest) godo.DomainRecord {
@@ -680,6 +787,24 @@ func dnsRecordRequestIdentity(req godo.DomainRecordEditRequest) string {
 
 func dnsDomainRecordIdentity(record godo.DomainRecord) string {
 	return dnsRecordIdentity(record.Type, record.Name, record.Data, record.Priority, record.Port, record.Weight, record.Flags, record.Tag)
+}
+
+func dnsRecordRequestUpsertKey(req godo.DomainRecordEditRequest) string {
+	if strings.EqualFold(req.Type, "CNAME") {
+		return dnsRecordNameTypeKey(req.Type, req.Name)
+	}
+	return dnsRecordRequestIdentity(req)
+}
+
+func dnsDomainRecordUpsertKey(record godo.DomainRecord) string {
+	if strings.EqualFold(record.Type, "CNAME") {
+		return dnsRecordNameTypeKey(record.Type, record.Name)
+	}
+	return dnsDomainRecordIdentity(record)
+}
+
+func dnsRecordNameTypeKey(recordType, name string) string {
+	return strings.ToUpper(recordType) + "\x00" + dnsCanonicalRecordName(name)
 }
 
 func dnsRecordIdentity(recordType, name, data string, priority, port, weight, flags int, tag string) string {

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -299,11 +299,12 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 			}
 			continue
 		}
-		if err := validateDNSRecordNameConflict(req, recordsByName[strings.ToLower(req.Name)]); err != nil {
+		nameKey := dnsCanonicalRecordName(req.Name)
+		if err := validateDNSRecordNameConflict(req, recordsByName[nameKey]); err != nil {
 			return nil, err
 		}
 		seen[key] = req
-		recordsByName[strings.ToLower(req.Name)] = append(recordsByName[strings.ToLower(req.Name)], req)
+		recordsByName[nameKey] = append(recordsByName[nameKey], req)
 		out = append(out, req)
 	}
 	return out, nil
@@ -340,14 +341,14 @@ func validateDNSRecordNameConflict(req godo.DomainRecordEditRequest, existing []
 func validateDNSRecordLiveConflicts(records []godo.DomainRecordEditRequest, existing []godo.DomainRecord) error {
 	existingByName := make(map[string][]godo.DomainRecord)
 	for _, record := range existing {
-		existingByName[strings.ToLower(record.Name)] = append(existingByName[strings.ToLower(record.Name)], record)
+		existingByName[dnsCanonicalRecordName(record.Name)] = append(existingByName[dnsCanonicalRecordName(record.Name)], record)
 	}
 	for _, req := range records {
-		for _, other := range existingByName[strings.ToLower(req.Name)] {
+		for _, other := range existingByName[dnsCanonicalRecordName(req.Name)] {
 			if req.Type != "CNAME" && !strings.EqualFold(other.Type, "CNAME") {
 				continue
 			}
-			if req.Type == "CNAME" && strings.EqualFold(other.Type, "CNAME") && other.Data == req.Data {
+			if req.Type == "CNAME" && strings.EqualFold(other.Type, "CNAME") && dnsRecordDataMatches(other.Type, other.Data, req.Data) {
 				continue
 			}
 			return fmt.Errorf("dns conflicting DNS record %s/%s conflicts with %s/%s", req.Type, req.Name, other.Type, other.Name)
@@ -473,6 +474,12 @@ func dnsOptionalIntField(index int, m map[string]any, key string, defaultValue i
 }
 
 func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPriority, hasPort, hasWeight bool) error {
+	if !isValidDNSRecordName(req.Name) {
+		return fmt.Errorf("dns records[%d].name must be a valid DNS record name", index)
+	}
+	if req.Type == "CNAME" && req.Name == "@" {
+		return fmt.Errorf("dns records[%d].name CNAME records cannot be declared at the zone apex", index)
+	}
 	switch req.Type {
 	case "A":
 		addr, err := netip.ParseAddr(req.Data)
@@ -485,7 +492,7 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 			return fmt.Errorf("dns records[%d].data must be an IPv6 address", index)
 		}
 	case "CNAME":
-		if _, err := netip.ParseAddr(req.Data); err == nil {
+		if !isValidDNSHostnameValue(req.Data) {
 			return fmt.Errorf("dns records[%d].data must be a hostname for CNAME records", index)
 		}
 	case "MX":
@@ -494,6 +501,13 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 		}
 		if err := validateDNSUint16(index, "priority", req.Priority); err != nil {
 			return err
+		}
+		if !isValidDNSHostnameValue(req.Data) {
+			return fmt.Errorf("dns records[%d].data must be a hostname for MX records", index)
+		}
+	case "NS":
+		if !isValidDNSHostnameValue(req.Data) {
+			return fmt.Errorf("dns records[%d].data must be a hostname for NS records", index)
 		}
 	case "SRV":
 		if !hasPriority {
@@ -514,6 +528,9 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 		if err := validateDNSUint16(index, "weight", req.Weight); err != nil {
 			return err
 		}
+		if !isValidDNSHostnameValue(req.Data) {
+			return fmt.Errorf("dns records[%d].data must be a hostname for SRV records", index)
+		}
 	case "CAA":
 		if req.Tag == "" {
 			return fmt.Errorf("dns records[%d].tag is required for CAA records", index)
@@ -526,6 +543,58 @@ func validateDNSRecordRequest(index int, req godo.DomainRecordEditRequest, hasPr
 		}
 	}
 	return nil
+}
+
+func isValidDNSRecordName(name string) bool {
+	if name == "@" {
+		return true
+	}
+	return isValidDNSName(name, true, true)
+}
+
+func isValidDNSHostnameValue(host string) bool {
+	if _, err := netip.ParseAddr(host); err == nil {
+		return false
+	}
+	return isValidDNSName(host, false, false)
+}
+
+func isValidDNSName(name string, allowWildcard, allowUnderscore bool) bool {
+	if name == "" || strings.ContainsAny(name, " \t\r\n") {
+		return false
+	}
+	if len(name) > 253 {
+		return false
+	}
+	trimmed := strings.TrimSuffix(name, ".")
+	if trimmed == "" || strings.Contains(trimmed, "..") {
+		return false
+	}
+	labels := strings.Split(trimmed, ".")
+	for i, label := range labels {
+		if label == "" || len(label) > 63 {
+			return false
+		}
+		if label == "*" {
+			if !allowWildcard || i != 0 {
+				return false
+			}
+			continue
+		}
+		if label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for j, r := range label {
+			if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-' {
+				continue
+			}
+			if allowUnderscore && r == '_' && j == 0 && len(label) > 1 {
+				continue
+			}
+			return false
+		}
+	}
+	return true
 }
 
 func validateDNSUint16(index int, field string, value int) error {
@@ -547,7 +616,7 @@ func isSupportedDNSRecordType(recordType string) bool {
 func dnsRecordRequestsEqual(a, b godo.DomainRecordEditRequest) bool {
 	return strings.EqualFold(a.Type, b.Type) &&
 		strings.EqualFold(a.Name, b.Name) &&
-		a.Data == b.Data &&
+		dnsRecordDataMatches(a.Type, a.Data, b.Data) &&
 		a.TTL == b.TTL &&
 		a.Priority == b.Priority &&
 		a.Port == b.Port &&
@@ -614,7 +683,7 @@ func dnsDomainRecordIdentity(record godo.DomainRecord) string {
 }
 
 func dnsRecordIdentity(recordType, name, data string, priority, port, weight, flags int, tag string) string {
-	parts := []string{strings.ToUpper(recordType), strings.ToLower(name), data}
+	parts := []string{strings.ToUpper(recordType), dnsCanonicalRecordName(name), dnsCanonicalRecordData(recordType, data)}
 	switch strings.ToUpper(recordType) {
 	case "CAA":
 		parts = append(parts, fmt.Sprint(flags), strings.ToLower(tag))
@@ -628,14 +697,31 @@ func dnsRecordIdentity(recordType, name, data string, priority, port, weight, fl
 
 func dnsRecordMatchesRequest(record godo.DomainRecord, req godo.DomainRecordEditRequest) bool {
 	return strings.EqualFold(record.Type, req.Type) &&
-		strings.EqualFold(record.Name, req.Name) &&
-		record.Data == req.Data &&
+		dnsCanonicalRecordName(record.Name) == dnsCanonicalRecordName(req.Name) &&
+		dnsRecordDataMatches(record.Type, record.Data, req.Data) &&
 		record.TTL == req.TTL &&
 		record.Priority == req.Priority &&
 		record.Port == req.Port &&
 		record.Weight == req.Weight &&
 		record.Flags == req.Flags &&
 		record.Tag == req.Tag
+}
+
+func dnsCanonicalRecordName(name string) string {
+	return strings.ToLower(strings.TrimSuffix(name, "."))
+}
+
+func dnsRecordDataMatches(recordType, a, b string) bool {
+	return dnsCanonicalRecordData(recordType, a) == dnsCanonicalRecordData(recordType, b)
+}
+
+func dnsCanonicalRecordData(recordType, data string) string {
+	switch strings.ToUpper(recordType) {
+	case "CNAME", "MX", "NS", "SRV":
+		return strings.ToLower(strings.TrimSuffix(data, "."))
+	default:
+		return data
+	}
 }
 
 func dnsOutput(dom *godo.Domain, name string, records []godo.DomainRecord) *interfaces.ResourceOutput {

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -14,19 +14,30 @@ import (
 )
 
 type mockDomainsClient struct {
-	domain          *godo.Domain
-	expectedDomain  string
-	getErr          error
-	createErr       error
-	createdDomains  []string
-	records         []godo.DomainRecord
-	recordPages     [][]godo.DomainRecord
-	recordListCalls []recordListCall
-	createdRecords  []createdRecord
-	editedRecords   []editedRecord
-	createRecordErr error
-	editRecordErr   error
-	err             error
+	domain                      *godo.Domain
+	expectedDomain              string
+	getErr                      error
+	getErrs                     []error
+	createErr                   error
+	afterCreateErr              func()
+	createdDomains              []string
+	records                     []godo.DomainRecord
+	recordPages                 [][]godo.DomainRecord
+	recordListErrs              []error
+	afterRecords                func()
+	recordListCalls             []recordListCall
+	events                      []string
+	attemptedRecords            []createdRecord
+	attemptedEdits              []editedRecord
+	createdRecords              []createdRecord
+	editedRecords               []editedRecord
+	createRecordErr             error
+	createRecordErrs            []error
+	afterCreateRecordErr        func()
+	recordsAfterCreateRecordErr []godo.DomainRecord
+	recordsAfterRecordListCall  int
+	editRecordErr               error
+	err                         error
 }
 
 type recordListCall struct {
@@ -46,19 +57,35 @@ type editedRecord struct {
 	req    godo.DomainRecordEditRequest
 }
 
-func (m *mockDomainsClient) Create(_ context.Context, req *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
+func (m *mockDomainsClient) Create(ctx context.Context, req *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if err := m.checkDomain(req.Name); err != nil {
 		return nil, nil, err
 	}
 	m.createdDomains = append(m.createdDomains, req.Name)
 	if m.createErr != nil {
+		if m.afterCreateErr != nil {
+			m.afterCreateErr()
+		}
 		return nil, nil, m.createErr
 	}
 	return m.domain, nil, m.err
 }
-func (m *mockDomainsClient) Get(_ context.Context, domain string) (*godo.Domain, *godo.Response, error) {
+func (m *mockDomainsClient) Get(ctx context.Context, domain string) (*godo.Domain, *godo.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
+	}
+	if len(m.getErrs) > 0 {
+		err := m.getErrs[0]
+		m.getErrs = m.getErrs[1:]
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	if m.getErr != nil {
 		return nil, nil, m.getErr
@@ -71,11 +98,35 @@ func (m *mockDomainsClient) Delete(_ context.Context, domain string) (*godo.Resp
 	}
 	return nil, m.err
 }
-func (m *mockDomainsClient) CreateRecord(_ context.Context, domain string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+func (m *mockDomainsClient) CreateRecord(ctx context.Context, domain string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
 	}
+	m.events = append(m.events, "create_record")
+	m.attemptedRecords = append(m.attemptedRecords, createdRecord{domain: domain, req: *req})
+	if len(m.createRecordErrs) > 0 {
+		err := m.createRecordErrs[0]
+		m.createRecordErrs = m.createRecordErrs[1:]
+		if err != nil {
+			if m.recordsAfterCreateRecordErr != nil && m.recordsAfterRecordListCall == 0 {
+				m.records = append([]godo.DomainRecord(nil), m.recordsAfterCreateRecordErr...)
+			}
+			if m.afterCreateRecordErr != nil {
+				m.afterCreateRecordErr()
+			}
+			return nil, nil, err
+		}
+	}
 	if m.createRecordErr != nil {
+		if m.recordsAfterCreateRecordErr != nil && m.recordsAfterRecordListCall == 0 {
+			m.records = append([]godo.DomainRecord(nil), m.recordsAfterCreateRecordErr...)
+		}
+		if m.afterCreateRecordErr != nil {
+			m.afterCreateRecordErr()
+		}
 		return nil, nil, m.createRecordErr
 	}
 	if m.err != nil {
@@ -87,7 +138,11 @@ func (m *mockDomainsClient) CreateRecord(_ context.Context, domain string, req *
 	m.records = append(m.records, record)
 	return &record, nil, m.err
 }
-func (m *mockDomainsClient) EditRecord(_ context.Context, domain string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+func (m *mockDomainsClient) EditRecord(ctx context.Context, domain string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	m.attemptedEdits = append(m.attemptedEdits, editedRecord{domain: domain, id: id, req: *req})
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
 	}
@@ -105,7 +160,10 @@ func (m *mockDomainsClient) EditRecord(_ context.Context, domain string, id int,
 func (m *mockDomainsClient) DeleteRecord(_ context.Context, _ string, _ int) (*godo.Response, error) {
 	return nil, m.err
 }
-func (m *mockDomainsClient) Records(_ context.Context, domain string, opts *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+func (m *mockDomainsClient) Records(ctx context.Context, domain string, opts *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
 	}
@@ -118,6 +176,17 @@ func (m *mockDomainsClient) Records(_ context.Context, domain string, opts *godo
 		perPage = opts.PerPage
 	}
 	m.recordListCalls = append(m.recordListCalls, recordListCall{domain: domain, page: page, perPage: perPage})
+	m.events = append(m.events, "records")
+	if m.recordsAfterCreateRecordErr != nil && m.recordsAfterRecordListCall > 0 && len(m.recordListCalls) >= m.recordsAfterRecordListCall {
+		m.records = append([]godo.DomainRecord(nil), m.recordsAfterCreateRecordErr...)
+	}
+	if len(m.recordListErrs) > 0 {
+		err := m.recordListErrs[0]
+		m.recordListErrs = m.recordListErrs[1:]
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	if m.err != nil {
 		return nil, nil, m.err
 	}
@@ -125,7 +194,13 @@ func (m *mockDomainsClient) Records(_ context.Context, domain string, opts *godo
 		if page < 1 || page > len(m.recordPages) {
 			return nil, &godo.Response{Links: &godo.Links{Pages: &godo.Pages{}}}, nil
 		}
+		if m.afterRecords != nil {
+			m.afterRecords()
+		}
 		return append([]godo.DomainRecord(nil), m.recordPages[page-1]...), recordPageResponse(domain, page, len(m.recordPages)), nil
+	}
+	if m.afterRecords != nil {
+		m.afterRecords()
 	}
 	return append([]godo.DomainRecord(nil), m.records...), recordPageResponse(domain, page, 1), nil
 }
@@ -385,6 +460,637 @@ func TestDNSDriver_Create_IdempotentExistingDomain(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Create_RejectsEmptyExistingDomainResponse(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected empty domain response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "API returned empty domain") {
+		t.Fatalf("error = %q, want empty domain response", err)
+	}
+}
+
+func TestDNSDriver_Create_RejectsEmptyCreatedDomainResponse(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+		getErr:         godoStatusErr(http.StatusNotFound),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected empty created domain response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "API returned empty domain") {
+		t.Fatalf("error = %q, want empty domain response", err)
+	}
+}
+
+func TestDNSDriver_Create_AdoptsDomainAfterCreateConflict(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		getErrs:        []error{godoStatusErr(http.StatusNotFound), godoStatusErr(http.StatusNotFound), nil},
+		createErr:      godoStatusErr(http.StatusConflict),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != "example.com" {
+		t.Fatalf("ProviderID = %q, want example.com", out.ProviderID)
+	}
+	if len(mock.createdDomains) != 1 {
+		t.Fatalf("created domains = %v, want one attempted create", mock.createdDomains)
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+}
+
+func TestDNSDriver_Create_DomainConflictHonorsCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		getErrs:        []error{godoStatusErr(http.StatusNotFound)},
+		createErr:      godoStatusErr(http.StatusConflict),
+		afterCreateErr: cancel,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Create(ctx, interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.createdDomains) != 1 {
+		t.Fatalf("created domains = %v, want one attempted create", mock.createdDomains)
+	}
+}
+
+func TestDNSDriver_Create_DomainConflictRejectsEmptyPostConflictDomain(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+		getErrs:        []error{godoStatusErr(http.StatusNotFound), nil},
+		createErr:      godoStatusErr(http.StatusConflict),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected empty domain response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "API returned empty domain") {
+		t.Fatalf("error = %q, want empty domain response", err)
+	}
+}
+
+func TestDNSDriver_Create_RetriesTransientGetAfterDomainConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{name: "transient", code: http.StatusInternalServerError},
+		{name: "rate limited", code: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+				getErrs:        []error{godoStatusErr(http.StatusNotFound), godoStatusErr(tt.code), nil},
+				createErr:      godoStatusErr(http.StatusConflict),
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+				Name:   "example-dns",
+				Config: map[string]any{"domain": "example.com"},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if out.ProviderID != "example.com" {
+				t.Fatalf("ProviderID = %q, want example.com", out.ProviderID)
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Create_DomainConflictReturnsExhaustedRetryableGetError(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		getErrs: []error{
+			godoStatusErr(http.StatusNotFound),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+		},
+		createErr: godoStatusErr(http.StatusConflict),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected exhausted rate-limit error, got nil")
+	}
+	if !errors.Is(err, interfaces.ErrRateLimited) {
+		t.Fatalf("error = %v, want ErrRateLimited", err)
+	}
+	if errors.Is(err, interfaces.ErrResourceAlreadyExists) {
+		t.Fatalf("error = %v, should not be classified as ErrResourceAlreadyExists", err)
+	}
+}
+
+func TestDNSDriver_Create_DomainConflictReturnsOriginalConflictAfterRepeatedNotFound(t *testing.T) {
+	tests := []struct {
+		name    string
+		getErrs []error
+	}{
+		{
+			name: "only not found",
+			getErrs: []error{
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+			},
+		},
+		{
+			name: "retryable followed by not found",
+			getErrs: []error{
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusTooManyRequests),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+				godoStatusErr(http.StatusNotFound),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+				getErrs:        tt.getErrs,
+				createErr:      godoStatusErr(http.StatusConflict),
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+				Name:   "example-dns",
+				Config: map[string]any{"domain": "example.com"},
+			})
+			if err == nil {
+				t.Fatal("expected exhausted conflict error, got nil")
+			}
+			if !errors.Is(err, interfaces.ErrResourceAlreadyExists) {
+				t.Fatalf("error = %v, want ErrResourceAlreadyExists", err)
+			}
+			if errors.Is(err, interfaces.ErrResourceNotFound) {
+				t.Fatalf("error = %v, should not be classified as ErrResourceNotFound", err)
+			}
+			if errors.Is(err, interfaces.ErrRateLimited) || errors.Is(err, interfaces.ErrTransient) {
+				t.Fatalf("error = %v, should not retain stale retryable classification", err)
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Create_AdoptsRecordAfterCreateConflict(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+		recordsAfterRecordListCall:  3,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.events) < 3 || mock.events[0] != "records" || mock.events[1] != "create_record" || mock.events[2] != "records" {
+		t.Fatalf("events = %v, want records before create_record before post-conflict records", mock.events)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0 after conflict adoption", len(mock.createdRecords))
+	}
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if got := records[0]["data"]; got != "1.2.3.4" {
+		t.Fatalf("record data = %v, want 1.2.3.4", got)
+	}
+}
+
+func TestDNSDriver_Create_RecordConflictHonorsCanceledContextBeforeRelist(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockDomainsClient{
+		domain:               testDomain(),
+		expectedDomain:       "example.com",
+		createRecordErrs:     []error{godoStatusErr(http.StatusConflict)},
+		afterCreateRecordErr: cancel,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Create(ctx, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.recordListCalls) != 1 {
+		t.Fatalf("record list calls = %d, want only initial pre-create list", len(mock.recordListCalls))
+	}
+}
+
+func TestDNSDriver_Create_RetriesRetryableRecordListAfterCreateConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{name: "transient", code: http.StatusInternalServerError},
+		{name: "rate limited", code: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:                      testDomain(),
+				expectedDomain:              "example.com",
+				createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+				recordListErrs:              []error{nil, godoStatusErr(tt.code), nil},
+				recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+				recordsAfterRecordListCall:  3,
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain": "example.com",
+					"records": []any{
+						map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Create: %v", err)
+			}
+			if len(mock.recordListCalls) < 3 {
+				t.Fatalf("record list calls = %d, want at least 3", len(mock.recordListCalls))
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Update_RecordConflictHonorsCanceledContextBeforeRelist(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockDomainsClient{
+		domain:               testDomain(),
+		expectedDomain:       "example.com",
+		createRecordErrs:     []error{godoStatusErr(http.StatusConflict)},
+		afterCreateRecordErr: cancel,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Update(ctx, interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.recordListCalls) != 1 {
+		t.Fatalf("record list calls = %d, want only initial pre-create list", len(mock.recordListCalls))
+	}
+}
+
+func TestDNSDriver_Update_RecordConflictHonorsCanceledContextBeforeEdit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	recordListCallsBeforeCancel := 0
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300}},
+		recordsAfterRecordListCall:  2,
+	}
+	mock.afterRecords = func() {
+		if len(mock.recordListCalls) >= 2 {
+			recordListCallsBeforeCancel = len(mock.recordListCalls)
+			cancel()
+		}
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Update(ctx, interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.attemptedEdits) != 0 {
+		t.Fatalf("attempted edits = %d, want 0 because driver should guard before EditRecord", len(mock.attemptedEdits))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if recordListCallsBeforeCancel < 2 {
+		t.Fatalf("record list calls before cancel = %d, want post-conflict relist", recordListCallsBeforeCancel)
+	}
+}
+
+func TestDNSDriver_Update_NormalEditHonorsCanceledContextBeforeEdit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300},
+		},
+	}
+	mock.afterRecords = cancel
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Update(ctx, interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.attemptedEdits) != 0 {
+		t.Fatalf("attempted edits = %d, want 0 because driver should guard before EditRecord", len(mock.attemptedEdits))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+}
+
+func TestDNSDriver_Create_RecordConflictHonorsCanceledContextBeforeEdit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	recordListCallsBeforeCancel := 0
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300}},
+		recordsAfterRecordListCall:  2,
+	}
+	mock.afterRecords = func() {
+		if len(mock.recordListCalls) >= 2 {
+			recordListCallsBeforeCancel = len(mock.recordListCalls)
+			cancel()
+		}
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+	defer cancel()
+
+	_, err := d.Create(ctx, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected canceled context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.attemptedEdits) != 0 {
+		t.Fatalf("attempted edits = %d, want 0 because driver should guard before EditRecord", len(mock.attemptedEdits))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if recordListCallsBeforeCancel < 2 {
+		t.Fatalf("record list calls before cancel = %d, want post-conflict relist", recordListCallsBeforeCancel)
+	}
+}
+
+func TestDNSDriver_Update_RetriesRetryableRecordListAfterCreateConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{name: "transient", code: http.StatusInternalServerError},
+		{name: "rate limited", code: http.StatusTooManyRequests},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:                      testDomain(),
+				expectedDomain:              "example.com",
+				createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+				recordListErrs:              []error{nil, godoStatusErr(tt.code), nil},
+				recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+				recordsAfterRecordListCall:  3,
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain": "example.com",
+					"records": []any{
+						map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if len(mock.recordListCalls) < 3 {
+				t.Fatalf("record list calls = %d, want at least 3", len(mock.recordListCalls))
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Update_ReturnsExhaustedRetryableRecordListErrorAfterCreateConflict(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:           testDomain(),
+		expectedDomain:   "example.com",
+		createRecordErrs: []error{godoStatusErr(http.StatusConflict)},
+		recordListErrs: []error{
+			nil,
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+			godoStatusErr(http.StatusTooManyRequests),
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected exhausted rate-limit error, got nil")
+	}
+	if !errors.Is(err, interfaces.ErrRateLimited) {
+		t.Fatalf("error = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestDNSDriver_Update_RecordConflictRelistValidatesNameConflicts(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300}},
+		recordsAfterRecordListCall:  2,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "www", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected live conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "conflicting DNS record") {
+		t.Fatalf("error = %q, want conflicting DNS record", err)
+	}
+}
+
 func TestDNSDriver_Create_AcceptsRecordMapSliceConfig(t *testing.T) {
 	mock := &mockDomainsClient{
 		domain:         testDomain(),
@@ -437,6 +1143,61 @@ func TestDNSDriver_Create_AcceptsDistinctCAARecordsWithSameData(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Create_CanonicalizesCAARecordTags(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "Issue", "flags": 0},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].req.Tag; got != "issue" {
+		t.Fatalf("created CAA tag = %q, want issue", got)
+	}
+}
+
+func TestDNSDriver_Create_DeduplicatesCAARecordsWithCanonicalTags(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "Issue", "flags": 0},
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issue", "flags": 0},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].req.Tag; got != "issue" {
+		t.Fatalf("created CAA tag = %q, want issue", got)
+	}
+}
+
 func TestDNSDriver_Read_Success(t *testing.T) {
 	mock := &mockDomainsClient{domain: testDomain()}
 	d := drivers.NewDNSDriverWithClient(mock)
@@ -449,6 +1210,23 @@ func TestDNSDriver_Read_Success(t *testing.T) {
 	}
 	if out.ProviderID != "example.com" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "example.com")
+	}
+}
+
+func TestDNSDriver_Read_RejectsEmptyDomainResponse(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	})
+	if err == nil {
+		t.Fatal("expected empty domain response error, got nil")
+	}
+	if !strings.Contains(err.Error(), "API returned empty domain") {
+		t.Fatalf("error = %q, want empty domain response", err)
 	}
 }
 
@@ -500,6 +1278,34 @@ func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
 		if got := records[0][key]; got != wantValue {
 			t.Errorf("records[0][%q] = %#v, want %#v", key, got, wantValue)
 		}
+	}
+}
+
+func TestDNSDriver_Read_CanonicalizesCAARecordTagOutputs(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CAA", Name: "@", Data: "letsencrypt.org", TTL: 300, Flags: 0, Tag: "Issue"},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if got := records[0]["tag"]; got != "issue" {
+		t.Fatalf("CAA output tag = %v, want issue", got)
 	}
 }
 
@@ -671,6 +1477,177 @@ func TestDNSDriver_Update_SkipsIdenticalRecord(t *testing.T) {
 	}
 	if len(mock.editedRecords) != 0 {
 		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+}
+
+func TestDNSDriver_Update_SkipsIdenticalCAARecordWithCanonicalTag(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CAA", Name: "@", Data: "letsencrypt.org", TTL: 300, Flags: 0, Tag: "issue"},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "ttl": 300, "flags": 0, "tag": "Issue"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+}
+
+func TestDNSDriver_Update_CanonicalizesCAARecordTagOnEdit(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CAA", Name: "@", Data: "letsencrypt.org", TTL: 300, Flags: 0, Tag: "issue"},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "ttl": 600, "flags": 0, "tag": "Issue"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.editedRecords) != 1 {
+		t.Fatalf("edited records = %d, want 1", len(mock.editedRecords))
+	}
+	if got := mock.editedRecords[0].req.Tag; got != "issue" {
+		t.Fatalf("edited CAA tag = %q, want issue", got)
+	}
+}
+
+func TestDNSDriver_Update_AdoptsRecordAfterCreateConflict(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+		recordsAfterRecordListCall:  3,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0 after create conflict adoption", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.recordListCalls) < 2 {
+		t.Fatalf("record list calls = %d, want at least 2", len(mock.recordListCalls))
+	}
+}
+
+func TestDNSDriver_Update_RecordConflictRefreshesExistingForLaterRecords(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}, {ID: 11, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300}},
+		recordsAfterRecordListCall:  2,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want only the first record create attempt", len(mock.attemptedRecords))
+	}
+	if len(mock.editedRecords) != 1 {
+		t.Fatalf("edited records = %d, want second record edited from refreshed conflict relist", len(mock.editedRecords))
+	}
+	if got := mock.editedRecords[0].req.Data; got != "new.example.com" {
+		t.Fatalf("edited record data = %q, want new.example.com", got)
+	}
+}
+
+func TestDNSDriver_Update_EditsRecordAfterCreateConflictWithDifferentCNAME(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:                      testDomain(),
+		expectedDomain:              "example.com",
+		createRecordErrs:            []error{godoStatusErr(http.StatusConflict)},
+		recordsAfterCreateRecordErr: []godo.DomainRecord{{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300}},
+		recordsAfterRecordListCall:  3,
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.attemptedRecords) != 1 {
+		t.Fatalf("attempted records = %d, want 1", len(mock.attemptedRecords))
+	}
+	if len(mock.editedRecords) != 1 {
+		t.Fatalf("edited records = %d, want 1", len(mock.editedRecords))
+	}
+	if got := mock.editedRecords[0].req.Data; got != "new.example.com" {
+		t.Fatalf("edited record data = %q, want new.example.com", got)
 	}
 }
 
@@ -1537,7 +2514,7 @@ func TestDNSDriver_Diff_NilCurrent(t *testing.T) {
 	mock := &mockDomainsClient{}
 	d := drivers.NewDNSDriverWithClient(mock)
 
-	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "example-dns"}, nil)
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "example.com"}, nil)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
 	}
@@ -1551,7 +2528,7 @@ func TestDNSDriver_Diff_NoChanges(t *testing.T) {
 	d := drivers.NewDNSDriverWithClient(mock)
 
 	current := &interfaces.ResourceOutput{ProviderID: "example.com"}
-	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "example-dns"}, current)
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{Name: "example.com"}, current)
 	if err != nil {
 		t.Fatalf("Diff: %v", err)
 	}
@@ -1585,6 +2562,47 @@ func TestDNSDriver_Diff_DetectsMissingDeclaredRecord(t *testing.T) {
 	}
 	if !result.NeedsUpdate {
 		t.Fatal("expected NeedsUpdate=true for missing declared record")
+	}
+}
+
+func TestDNSDriver_Diff_DomainChangeRequiresReplacement(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "new.example.com"},
+	}, &interfaces.ResourceOutput{ProviderID: "old.example.com"})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsReplace {
+		t.Fatal("expected NeedsReplace=true for domain change")
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true when replacement is required")
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(result.Changes))
+	}
+	if result.Changes[0].Path != "domain" || !result.Changes[0].ForceNew {
+		t.Fatalf("change = %#v, want force-new domain change", result.Changes[0])
+	}
+}
+
+func TestDNSDriver_Diff_LogicalNameDoesNotForceDomainReplacement(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{},
+	}, &interfaces.ResourceOutput{ProviderID: "example.com"})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsReplace || result.NeedsUpdate {
+		t.Fatalf("expected no replacement/update from logical name alone, got %#v", result)
 	}
 }
 
@@ -1645,6 +2663,34 @@ func TestDNSDriver_Diff_NoChangesForMatchingDeclaredRecords(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Diff_NoChangesForMatchingCAARecordWithCanonicalTag(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	current := &interfaces.ResourceOutput{
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"type": "CAA", "name": "@", "data": "letsencrypt.org", "ttl": 300, "flags": 0, "tag": "issue"},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "ttl": 300, "flags": 0, "tag": "Issue"},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate || result.NeedsReplace {
+		t.Fatalf("expected no diff, got %#v", result)
+	}
+}
+
 func TestDNSDriver_Diff_IgnoresSOAInCurrentOutputs(t *testing.T) {
 	mock := &mockDomainsClient{}
 	d := drivers.NewDNSDriverWithClient(mock)
@@ -1679,7 +2725,7 @@ func TestDNSDriver_Diff_ValidatesDesiredRecords(t *testing.T) {
 	d := drivers.NewDNSDriverWithClient(mock)
 
 	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
-		Name: "example-dns",
+		Name: "example.com",
 		Config: map[string]any{
 			"records": []any{
 				map[string]any{"type": "CNAME", "name": "www", "data": "one.example.com"},

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -3,6 +3,7 @@ package drivers_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
@@ -11,40 +12,159 @@ import (
 )
 
 type mockDomainsClient struct {
-	domain         *godo.Domain
-	records        []godo.DomainRecord
-	createdRecords []godo.DomainRecordEditRequest
-	editedRecords  []editedRecord
-	err            error
+	domain          *godo.Domain
+	expectedDomain  string
+	records         []godo.DomainRecord
+	recordPages     [][]godo.DomainRecord
+	recordListCalls []recordListCall
+	createdRecords  []createdRecord
+	editedRecords   []editedRecord
+	err             error
+}
+
+type recordListCall struct {
+	domain  string
+	page    int
+	perPage int
+}
+
+type createdRecord struct {
+	domain string
+	req    godo.DomainRecordEditRequest
 }
 
 type editedRecord struct {
-	id  int
-	req godo.DomainRecordEditRequest
+	domain string
+	id     int
+	req    godo.DomainRecordEditRequest
 }
 
-func (m *mockDomainsClient) Create(_ context.Context, _ *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
+func (m *mockDomainsClient) Create(_ context.Context, req *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
+	if err := m.checkDomain(req.Name); err != nil {
+		return nil, nil, err
+	}
 	return m.domain, nil, m.err
 }
-func (m *mockDomainsClient) Get(_ context.Context, _ string) (*godo.Domain, *godo.Response, error) {
+func (m *mockDomainsClient) Get(_ context.Context, domain string) (*godo.Domain, *godo.Response, error) {
+	if err := m.checkDomain(domain); err != nil {
+		return nil, nil, err
+	}
 	return m.domain, nil, m.err
 }
-func (m *mockDomainsClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
+func (m *mockDomainsClient) Delete(_ context.Context, domain string) (*godo.Response, error) {
+	if err := m.checkDomain(domain); err != nil {
+		return nil, err
+	}
 	return nil, m.err
 }
-func (m *mockDomainsClient) CreateRecord(_ context.Context, _ string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
-	m.createdRecords = append(m.createdRecords, *req)
-	return &godo.DomainRecord{ID: 1}, nil, m.err
+func (m *mockDomainsClient) CreateRecord(_ context.Context, domain string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	if err := m.checkDomain(domain); err != nil {
+		return nil, nil, err
+	}
+	id := len(m.allRecords()) + 1
+	record := domainRecordFromEditRequest(id, req)
+	m.createdRecords = append(m.createdRecords, createdRecord{domain: domain, req: *req})
+	m.records = append(m.records, record)
+	return &record, nil, m.err
 }
-func (m *mockDomainsClient) EditRecord(_ context.Context, _ string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
-	m.editedRecords = append(m.editedRecords, editedRecord{id: id, req: *req})
-	return &godo.DomainRecord{ID: 1}, nil, m.err
+func (m *mockDomainsClient) EditRecord(_ context.Context, domain string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	if err := m.checkDomain(domain); err != nil {
+		return nil, nil, err
+	}
+	record := domainRecordFromEditRequest(id, req)
+	m.editedRecords = append(m.editedRecords, editedRecord{domain: domain, id: id, req: *req})
+	m.replaceRecord(record)
+	return &record, nil, m.err
 }
 func (m *mockDomainsClient) DeleteRecord(_ context.Context, _ string, _ int) (*godo.Response, error) {
 	return nil, m.err
 }
-func (m *mockDomainsClient) Records(_ context.Context, _ string, _ *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
-	return m.records, nil, m.err
+func (m *mockDomainsClient) Records(_ context.Context, domain string, opts *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+	if err := m.checkDomain(domain); err != nil {
+		return nil, nil, err
+	}
+	page := 1
+	perPage := 0
+	if opts != nil {
+		if opts.Page > 0 {
+			page = opts.Page
+		}
+		perPage = opts.PerPage
+	}
+	m.recordListCalls = append(m.recordListCalls, recordListCall{domain: domain, page: page, perPage: perPage})
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	if len(m.recordPages) > 0 {
+		if page < 1 || page > len(m.recordPages) {
+			return nil, &godo.Response{Links: &godo.Links{Pages: &godo.Pages{}}}, nil
+		}
+		return append([]godo.DomainRecord(nil), m.recordPages[page-1]...), recordPageResponse(domain, page, len(m.recordPages)), nil
+	}
+	return append([]godo.DomainRecord(nil), m.records...), recordPageResponse(domain, page, 1), nil
+}
+
+func (m *mockDomainsClient) checkDomain(domain string) error {
+	if m.expectedDomain != "" && domain != m.expectedDomain {
+		return fmt.Errorf("domain = %q, want %q", domain, m.expectedDomain)
+	}
+	return nil
+}
+
+func (m *mockDomainsClient) allRecords() []godo.DomainRecord {
+	if len(m.recordPages) == 0 {
+		return m.records
+	}
+	var records []godo.DomainRecord
+	for _, page := range m.recordPages {
+		records = append(records, page...)
+	}
+	return records
+}
+
+func (m *mockDomainsClient) replaceRecord(record godo.DomainRecord) {
+	if len(m.recordPages) == 0 {
+		for i := range m.records {
+			if m.records[i].ID == record.ID {
+				m.records[i] = record
+				return
+			}
+		}
+		m.records = append(m.records, record)
+		return
+	}
+	for pageIndex := range m.recordPages {
+		for recordIndex := range m.recordPages[pageIndex] {
+			if m.recordPages[pageIndex][recordIndex].ID == record.ID {
+				m.recordPages[pageIndex][recordIndex] = record
+				return
+			}
+		}
+	}
+	m.recordPages[len(m.recordPages)-1] = append(m.recordPages[len(m.recordPages)-1], record)
+}
+
+func domainRecordFromEditRequest(id int, req *godo.DomainRecordEditRequest) godo.DomainRecord {
+	return godo.DomainRecord{
+		ID:       id,
+		Type:     req.Type,
+		Name:     req.Name,
+		Data:     req.Data,
+		TTL:      req.TTL,
+		Priority: req.Priority,
+		Port:     req.Port,
+		Weight:   req.Weight,
+		Flags:    req.Flags,
+		Tag:      req.Tag,
+	}
+}
+
+func recordPageResponse(domain string, page, pageCount int) *godo.Response {
+	pages := &godo.Pages{}
+	if page < pageCount {
+		pages.Next = fmt.Sprintf("https://api.digitalocean.com/v2/domains/%s/records?page=%d", domain, page+1)
+	}
+	return &godo.Response{Links: &godo.Links{Pages: pages}}
 }
 
 func testDomain() *godo.Domain {
@@ -123,7 +243,8 @@ func TestDNSDriver_Read_Success(t *testing.T) {
 
 func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
 	mock := &mockDomainsClient{
-		domain: testDomain(),
+		domain:         testDomain(),
+		expectedDomain: "example.com",
 		records: []godo.DomainRecord{
 			{
 				ID:       10,
@@ -169,6 +290,45 @@ func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
 	for key, wantValue := range want {
 		if got := records[0][key]; got != wantValue {
 			t.Errorf("records[0][%q] = %#v, want %#v", key, got, wantValue)
+		}
+	}
+}
+
+func TestDNSDriver_Read_IncludesRecordsFromAllPages(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		recordPages: [][]godo.DomainRecord{
+			{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+			{{ID: 11, Type: "TXT", Name: "@", Data: "page-two", TTL: 300}},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records) = %d, want 2", len(records))
+	}
+	if got := records[1]["data"]; got != "page-two" {
+		t.Errorf("second record data = %v, want page-two", got)
+	}
+	if len(mock.recordListCalls) != 2 {
+		t.Fatalf("record list calls = %d, want 2", len(mock.recordListCalls))
+	}
+	for i, call := range mock.recordListCalls {
+		wantPage := i + 1
+		if call.domain != "example.com" || call.page != wantPage {
+			t.Errorf("record list call %d = domain %q page %d, want example.com page %d", i, call.domain, call.page, wantPage)
 		}
 	}
 }
@@ -272,8 +432,190 @@ func TestDNSDriver_Update_CreatesDistinctRecordWithSameTypeAndName(t *testing.T)
 	if len(mock.createdRecords) != 1 {
 		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
 	}
-	if got := mock.createdRecords[0].Data; got != "google-site-verification=new" {
+	if got := mock.createdRecords[0].req.Data; got != "google-site-verification=new" {
 		t.Errorf("created record data = %q, want google-site-verification=new", got)
+	}
+}
+
+func TestDNSDriver_Update_DoesNotDuplicateMatchingRecordOnSecondPage(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		recordPages: [][]godo.DomainRecord{
+			{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+			{{ID: 11, Type: "TXT", Name: "@", Data: "page-two", TTL: 300}},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "page-two", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.recordListCalls) < 2 {
+		t.Fatalf("record list calls = %d, want at least 2", len(mock.recordListCalls))
+	}
+	if got := mock.recordListCalls[1].page; got != 2 {
+		t.Errorf("second record list page = %d, want 2", got)
+	}
+}
+
+func TestDNSDriver_Update_ReturnsOutputWithCreatedRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if got := records[0]["data"]; got != "1.2.3.4" {
+		t.Errorf("created output data = %v, want 1.2.3.4", got)
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].domain; got != "example.com" {
+		t.Errorf("created record domain = %q, want example.com", got)
+	}
+}
+
+func TestDNSDriver_Update_RejectsConflictingDuplicateDeclarations(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "same", "ttl": 300},
+				map[string]any{"type": "TXT", "name": "@", "data": "same", "ttl": 600},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected conflicting duplicate error, got nil")
+	}
+	if !strings.Contains(err.Error(), "conflicting duplicate DNS record") {
+		t.Fatalf("error = %q, want conflicting duplicate DNS record", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+}
+
+func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		record  any
+		wantErr string
+	}{
+		{
+			name:    "non map entry",
+			record:  "not-a-record",
+			wantErr: "records[0] must be an object",
+		},
+		{
+			name:    "invalid type field type",
+			record:  map[string]any{"type": 42, "name": "@", "data": "1.2.3.4"},
+			wantErr: `records[0].type must be a string`,
+		},
+		{
+			name:    "unsupported record type",
+			record:  map[string]any{"type": "BOGUS", "name": "@", "data": "1.2.3.4"},
+			wantErr: `records[0].type "BOGUS" is not supported`,
+		},
+		{
+			name:    "invalid name field type",
+			record:  map[string]any{"type": "A", "name": 42, "data": "1.2.3.4"},
+			wantErr: `records[0].name must be a string`,
+		},
+		{
+			name:    "missing data",
+			record:  map[string]any{"type": "A", "name": "@"},
+			wantErr: `records[0].data is required`,
+		},
+		{
+			name:    "invalid ttl type",
+			record:  map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": "300"},
+			wantErr: `records[0].ttl must be an integer`,
+		},
+		{
+			name:    "negative priority",
+			record:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com", "priority": -1},
+			wantErr: `records[0].priority must be non-negative`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain":  "example.com",
+					"records": []any{tt.record},
+				},
+			})
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
+			}
+			if len(mock.createdRecords) != 0 {
+				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+			}
+		})
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -466,8 +466,6 @@ func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
 				Priority: 20,
 				Port:     5060,
 				Weight:   30,
-				Flags:    1,
-				Tag:      "issue",
 			},
 		},
 	}
@@ -495,8 +493,8 @@ func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
 		"priority": 20,
 		"port":     5060,
 		"weight":   30,
-		"flags":    1,
-		"tag":      "issue",
+		"flags":    0,
+		"tag":      "",
 	}
 	for key, wantValue := range want {
 		if got := records[0][key]; got != wantValue {
@@ -641,8 +639,6 @@ func TestDNSDriver_Update_SkipsIdenticalRecord(t *testing.T) {
 				Priority: 20,
 				Port:     5060,
 				Weight:   30,
-				Flags:    1,
-				Tag:      "issue",
 			},
 		},
 	}
@@ -663,8 +659,6 @@ func TestDNSDriver_Update_SkipsIdenticalRecord(t *testing.T) {
 					"priority": 20,
 					"port":     5060,
 					"weight":   30,
-					"flags":    1,
-					"tag":      "issue",
 				},
 			},
 		},
@@ -992,6 +986,11 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			wantErr: `records[0].type "BOGUS" is not supported`,
 		},
 		{
+			name:    "SOA desired record unsupported",
+			record:  map[string]any{"type": "SOA", "name": "@", "data": "ns1.digitalocean.com hostmaster.example.com 1 10800 3600 604800 1800"},
+			wantErr: `records[0].type "SOA" is not supported`,
+		},
+		{
 			name:    "invalid name field type",
 			record:  map[string]any{"type": "A", "name": 42, "data": "1.2.3.4"},
 			wantErr: `records[0].name must be a string`,
@@ -1027,14 +1026,34 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			wantErr: `records[0].data must be an IPv4 address`,
 		},
 		{
+			name:    "A rejects priority",
+			record:  map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "priority": 10},
+			wantErr: `records[0].priority is not valid for A records`,
+		},
+		{
+			name:    "A rejects CAA tag",
+			record:  map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "tag": "issue"},
+			wantErr: `records[0].tag is not valid for A records`,
+		},
+		{
 			name:    "AAAA data must be IPv6",
 			record:  map[string]any{"type": "AAAA", "name": "@", "data": "192.0.2.10"},
 			wantErr: `records[0].data must be an IPv6 address`,
 		},
 		{
+			name:    "CNAME rejects SRV port",
+			record:  map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com", "port": 443},
+			wantErr: `records[0].port is not valid for CNAME records`,
+		},
+		{
 			name:    "MX priority required",
 			record:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com"},
 			wantErr: `records[0].priority is required for MX records`,
+		},
+		{
+			name:    "MX rejects port",
+			record:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com", "priority": 10, "port": 25},
+			wantErr: `records[0].port is not valid for MX records`,
 		},
 		{
 			name:    "MX data must be hostname",
@@ -1045,6 +1064,11 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			name:    "NS data must be hostname",
 			record:  map[string]any{"type": "NS", "name": "@", "data": "ns_1.example.com"},
 			wantErr: `records[0].data must be a hostname for NS records`,
+		},
+		{
+			name:    "TXT rejects weight",
+			record:  map[string]any{"type": "TXT", "name": "@", "data": "hello", "weight": 5},
+			wantErr: `records[0].weight is not valid for TXT records`,
 		},
 		{
 			name:    "SRV port required",
@@ -1062,9 +1086,19 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			wantErr: `records[0].tag is required for CAA records`,
 		},
 		{
+			name:    "CAA tag allow-list",
+			record:  map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "accounturi", "flags": 0},
+			wantErr: `records[0].tag must be one of issue, issuewild, iodef`,
+		},
+		{
 			name:    "CAA flags range",
 			record:  map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issue", "flags": 256},
 			wantErr: `records[0].flags must be between 0 and 255`,
+		},
+		{
+			name:    "CAA rejects priority",
+			record:  map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issue", "flags": 0, "priority": 1},
+			wantErr: `records[0].priority is not valid for CAA records`,
 		},
 	}
 
@@ -1272,6 +1306,43 @@ func TestDNSDriver_Update_PreservesTXTCaseSensitiveIdentity(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Update_EditsExistingCNAMEWhenTargetChanges(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "old.example.com", TTL: 300},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "new.example.com", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 1 {
+		t.Fatalf("edited records = %d, want 1", len(mock.editedRecords))
+	}
+	if mock.editedRecords[0].id != 10 {
+		t.Fatalf("edited record ID = %d, want 10", mock.editedRecords[0].id)
+	}
+	if got := mock.editedRecords[0].req.Data; got != "new.example.com" {
+		t.Fatalf("edited CNAME data = %q, want new.example.com", got)
+	}
+}
+
 func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *testing.T) {
 	mock := &mockDomainsClient{
 		domain: testDomain(),
@@ -1285,8 +1356,6 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 				Priority: 20,
 				Port:     5060,
 				Weight:   10,
-				Flags:    1,
-				Tag:      "issue",
 			},
 		},
 	}
@@ -1307,8 +1376,6 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 					"priority": 20,
 					"port":     5060,
 					"weight":   10,
-					"flags":    1,
-					"tag":      "issue",
 				},
 			},
 		},
@@ -1329,7 +1396,7 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 	if req.TTL != 600 || req.Weight != 10 {
 		t.Errorf("edited request TTL/Weight = %d/%d, want 600/10", req.TTL, req.Weight)
 	}
-	if req.Priority != 20 || req.Port != 5060 || req.Flags != 1 || req.Tag != "issue" {
+	if req.Priority != 20 || req.Port != 5060 {
 		t.Errorf("edited request = %+v, want supported fields preserved", req)
 	}
 }
@@ -1529,7 +1596,7 @@ func TestDNSDriver_Diff_DetectsChangedDeclaredRecordFields(t *testing.T) {
 		ProviderID: "example.com",
 		Outputs: map[string]any{
 			"records": []map[string]any{
-				{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 300, "priority": 20, "port": 5060, "weight": 10, "flags": 1, "tag": "issue"},
+				{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 300, "priority": 20, "port": 5060, "weight": 10},
 			},
 		},
 	}
@@ -1537,7 +1604,7 @@ func TestDNSDriver_Diff_DetectsChangedDeclaredRecordFields(t *testing.T) {
 		Name: "example-dns",
 		Config: map[string]any{
 			"records": []any{
-				map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 600, "priority": 20, "port": 5060, "weight": 10, "flags": 1, "tag": "issue"},
+				map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 600, "priority": 20, "port": 5060, "weight": 10},
 			},
 		},
 	}, current)
@@ -1575,6 +1642,35 @@ func TestDNSDriver_Diff_NoChangesForMatchingDeclaredRecords(t *testing.T) {
 	}
 	if result.NeedsUpdate {
 		t.Fatal("expected NeedsUpdate=false when declared record exists and matches")
+	}
+}
+
+func TestDNSDriver_Diff_IgnoresSOAInCurrentOutputs(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	current := &interfaces.ResourceOutput{
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"type": "SOA", "name": "@", "data": "ns1.digitalocean.com hostmaster.example.com 1 10800 3600 604800 1800", "ttl": 1800},
+				{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=false when declared record matches and current has provider-owned SOA")
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -274,6 +274,68 @@ func TestDNSDriver_Create_DoesNotCreateOnTransientGetError(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Create_ValidatesRecordsBeforeCreatingDomain(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		getErr: godoStatusErr(http.StatusNotFound),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected record validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "records[0].data is required") {
+		t.Fatalf("error = %q, want records[0].data is required", err)
+	}
+	if len(mock.createdDomains) != 0 {
+		t.Fatalf("created domains = %v, want none", mock.createdDomains)
+	}
+}
+
+func TestDNSDriver_Create_RejectsMalformedDomainBeforeAPICalls(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain any
+	}{
+		{name: "non string", domain: 42},
+		{name: "empty string", domain: ""},
+		{name: "invalid domain name", domain: "not a domain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{domain: testDomain()}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+				Name:   "example.com",
+				Config: map[string]any{"domain": tt.domain},
+			})
+			if err == nil {
+				t.Fatal("expected domain validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), "dns domain") {
+				t.Fatalf("error = %q, want dns domain validation error", err)
+			}
+			if len(mock.createdDomains) != 0 {
+				t.Fatalf("created domains = %v, want none", mock.createdDomains)
+			}
+			if len(mock.recordListCalls) != 0 {
+				t.Fatalf("record list calls = %d, want 0", len(mock.recordListCalls))
+			}
+		})
+	}
+}
+
 func TestDNSDriver_Create_IdempotentExistingDomain(t *testing.T) {
 	// When Get succeeds (domain exists), Create should not error.
 	mock := &mockDomainsClient{domain: testDomain()}
@@ -288,6 +350,33 @@ func TestDNSDriver_Create_IdempotentExistingDomain(t *testing.T) {
 	}
 	if out.ProviderID != "example.com" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "example.com")
+	}
+}
+
+func TestDNSDriver_Create_AcceptsRecordMapSliceConfig(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []map[string]any{
+				{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].req.Data; got != "1.2.3.4" {
+		t.Errorf("created record data = %q, want 1.2.3.4", got)
 	}
 }
 
@@ -439,6 +528,46 @@ func TestDNSDriver_Update_RejectsDomainReplacement(t *testing.T) {
 	}
 	if len(mock.createdRecords) != 0 {
 		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+}
+
+func TestDNSDriver_Update_RejectsMalformedDomainConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain any
+	}{
+		{name: "non string", domain: 42},
+		{name: "empty string", domain: ""},
+		{name: "invalid domain name", domain: "not a domain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name:   "example-dns",
+				Config: map[string]any{"domain": tt.domain},
+			})
+			if err == nil {
+				t.Fatal("expected domain validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), "dns domain") {
+				t.Fatalf("error = %q, want dns domain validation error", err)
+			}
+			if len(mock.recordListCalls) != 0 {
+				t.Fatalf("record list calls = %d, want 0", len(mock.recordListCalls))
+			}
+			if len(mock.createdRecords) != 0 {
+				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+			}
+		})
 	}
 }
 
@@ -719,6 +848,68 @@ func TestDNSDriver_Update_AllowsMultiValueTXTRecords(t *testing.T) {
 	}
 	if len(mock.createdRecords) != 2 {
 		t.Fatalf("created records = %d, want 2", len(mock.createdRecords))
+	}
+}
+
+func TestDNSDriver_Update_RejectsConflictsWithExistingLiveRecordsBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []godo.DomainRecord
+		records  []any
+	}{
+		{
+			name: "desired A conflicts with existing CNAME",
+			existing: []godo.DomainRecord{
+				{ID: 10, Type: "CNAME", Name: "www", Data: "target.example.com", TTL: 300},
+			},
+			records: []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "safe-to-create"},
+				map[string]any{"type": "A", "name": "www", "data": "1.2.3.4"},
+			},
+		},
+		{
+			name: "desired CNAME conflicts with existing A",
+			existing: []godo.DomainRecord{
+				{ID: 10, Type: "A", Name: "www", Data: "1.2.3.4", TTL: 300},
+			},
+			records: []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "safe-to-create"},
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+				records:        tt.existing,
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain":  "example.com",
+					"records": tt.records,
+				},
+			})
+			if err == nil {
+				t.Fatal("expected live DNS conflict error, got nil")
+			}
+			if !strings.Contains(err.Error(), "conflicting DNS record") {
+				t.Fatalf("error = %q, want conflicting DNS record", err)
+			}
+			if len(mock.createdRecords) != 0 {
+				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+			}
+			if len(mock.editedRecords) != 0 {
+				t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+			}
+		})
 	}
 }
 
@@ -1068,6 +1259,35 @@ func TestDNSDriver_Diff_ValidatesDesiredRecords(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "conflicting DNS record") {
 		t.Fatalf("error = %q, want conflicting DNS record", err)
+	}
+}
+
+func TestDNSDriver_Diff_RejectsMalformedDomainConfig(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain any
+	}{
+		{name: "non string", domain: 42},
+		{name: "empty string", domain: ""},
+		{name: "invalid domain name", domain: "not a domain"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+				Name:   "example-dns",
+				Config: map[string]any{"domain": tt.domain},
+			}, &interfaces.ResourceOutput{ProviderID: "example.com"})
+			if err == nil {
+				t.Fatal("expected domain validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), "dns domain") {
+				t.Fatalf("error = %q, want dns domain validation error", err)
+			}
+		})
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -309,6 +309,8 @@ func TestDNSDriver_Create_RejectsMalformedDomainBeforeAPICalls(t *testing.T) {
 		{name: "non string", domain: 42},
 		{name: "empty string", domain: ""},
 		{name: "invalid domain name", domain: "not a domain"},
+		{name: "single label", domain: "example"},
+		{name: "trailing dot fqdn", domain: "example.com."},
 	}
 
 	for _, tt := range tests {
@@ -377,6 +379,31 @@ func TestDNSDriver_Create_AcceptsRecordMapSliceConfig(t *testing.T) {
 	}
 	if got := mock.createdRecords[0].req.Data; got != "1.2.3.4" {
 		t.Errorf("created record data = %q, want 1.2.3.4", got)
+	}
+}
+
+func TestDNSDriver_Create_AcceptsDistinctCAARecordsWithSameData(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issue", "flags": 0},
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issuewild", "flags": 0},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(mock.createdRecords) != 2 {
+		t.Fatalf("created records = %d, want 2", len(mock.createdRecords))
 	}
 }
 
@@ -954,6 +981,36 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			record:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com", "priority": -1},
 			wantErr: `records[0].priority must be non-negative`,
 		},
+		{
+			name:    "A data must be IPv4",
+			record:  map[string]any{"type": "A", "name": "@", "data": "2001:db8::1"},
+			wantErr: `records[0].data must be an IPv4 address`,
+		},
+		{
+			name:    "AAAA data must be IPv6",
+			record:  map[string]any{"type": "AAAA", "name": "@", "data": "192.0.2.10"},
+			wantErr: `records[0].data must be an IPv6 address`,
+		},
+		{
+			name:    "MX priority required",
+			record:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com"},
+			wantErr: `records[0].priority is required for MX records`,
+		},
+		{
+			name:    "SRV port required",
+			record:  map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "priority": 10, "weight": 5},
+			wantErr: `records[0].port is required for SRV records`,
+		},
+		{
+			name:    "CAA tag required",
+			record:  map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "flags": 0},
+			wantErr: `records[0].tag is required for CAA records`,
+		},
+		{
+			name:    "CAA flags range",
+			record:  map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "tag": "issue", "flags": 256},
+			wantErr: `records[0].flags must be between 0 and 255`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -983,6 +1040,41 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
 			}
 		})
+	}
+}
+
+func TestDNSDriver_Update_CreatesDistinctCAAWhenIdentityFieldsDiffer(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CAA", Name: "@", Data: "letsencrypt.org", TTL: 300, Tag: "issue", Flags: 0},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CAA", "name": "@", "data": "letsencrypt.org", "ttl": 300, "tag": "issuewild", "flags": 0},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].req.Tag; got != "issuewild" {
+		t.Errorf("created CAA tag = %q, want issuewild", got)
 	}
 }
 
@@ -1020,7 +1112,7 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 					"ttl":      600,
 					"priority": 20,
 					"port":     5060,
-					"weight":   30,
+					"weight":   10,
 					"flags":    1,
 					"tag":      "issue",
 				},
@@ -1040,11 +1132,62 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 		t.Errorf("edited ID = %d, want 10", got)
 	}
 	req := mock.editedRecords[0].req
-	if req.TTL != 600 || req.Weight != 30 {
-		t.Errorf("edited request TTL/Weight = %d/%d, want 600/30", req.TTL, req.Weight)
+	if req.TTL != 600 || req.Weight != 10 {
+		t.Errorf("edited request TTL/Weight = %d/%d, want 600/10", req.TTL, req.Weight)
 	}
 	if req.Priority != 20 || req.Port != 5060 || req.Flags != 1 || req.Tag != "issue" {
 		t.Errorf("edited request = %+v, want supported fields preserved", req)
+	}
+}
+
+func TestDNSDriver_Update_CreatesDistinctSRVWhenIdentityFieldsDiffer(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{
+				ID:       10,
+				Type:     "SRV",
+				Name:     "_sip._tcp",
+				Data:     "sip.example.com",
+				TTL:      300,
+				Priority: 20,
+				Port:     5060,
+				Weight:   10,
+			},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{
+					"type":     "SRV",
+					"name":     "_sip._tcp",
+					"data":     "sip.example.com",
+					"ttl":      300,
+					"priority": 20,
+					"port":     5060,
+					"weight":   30,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].req.Weight; got != 30 {
+		t.Errorf("created SRV weight = %d, want 30", got)
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -11,9 +11,16 @@ import (
 )
 
 type mockDomainsClient struct {
-	domain  *godo.Domain
-	records []godo.DomainRecord
-	err     error
+	domain         *godo.Domain
+	records        []godo.DomainRecord
+	createdRecords []godo.DomainRecordEditRequest
+	editedRecords  []editedRecord
+	err            error
+}
+
+type editedRecord struct {
+	id  int
+	req godo.DomainRecordEditRequest
 }
 
 func (m *mockDomainsClient) Create(_ context.Context, _ *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
@@ -25,10 +32,12 @@ func (m *mockDomainsClient) Get(_ context.Context, _ string) (*godo.Domain, *god
 func (m *mockDomainsClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, m.err
 }
-func (m *mockDomainsClient) CreateRecord(_ context.Context, _ string, _ *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+func (m *mockDomainsClient) CreateRecord(_ context.Context, _ string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	m.createdRecords = append(m.createdRecords, *req)
 	return &godo.DomainRecord{ID: 1}, nil, m.err
 }
-func (m *mockDomainsClient) EditRecord(_ context.Context, _ string, _ int, _ *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+func (m *mockDomainsClient) EditRecord(_ context.Context, _ string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	m.editedRecords = append(m.editedRecords, editedRecord{id: id, req: *req})
 	return &godo.DomainRecord{ID: 1}, nil, m.err
 }
 func (m *mockDomainsClient) DeleteRecord(_ context.Context, _ string, _ int) (*godo.Response, error) {
@@ -112,6 +121,58 @@ func TestDNSDriver_Read_Success(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Read_IncludesExistingDomainRecords(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{
+				ID:       10,
+				Type:     "SRV",
+				Name:     "_sip._tcp",
+				Data:     "sip.example.com",
+				TTL:      600,
+				Priority: 20,
+				Port:     5060,
+				Weight:   30,
+				Flags:    1,
+				Tag:      "issue",
+			},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	want := map[string]any{
+		"type":     "SRV",
+		"name":     "_sip._tcp",
+		"data":     "sip.example.com",
+		"ttl":      600,
+		"priority": 20,
+		"port":     5060,
+		"weight":   30,
+		"flags":    1,
+		"tag":      "issue",
+	}
+	for key, wantValue := range want {
+		if got := records[0][key]; got != wantValue {
+			t.Errorf("records[0][%q] = %#v, want %#v", key, got, wantValue)
+		}
+	}
+}
+
 func TestDNSDriver_Update_Success(t *testing.T) {
 	mock := &mockDomainsClient{domain: testDomain()}
 	d := drivers.NewDNSDriverWithClient(mock)
@@ -127,6 +188,154 @@ func TestDNSDriver_Update_Success(t *testing.T) {
 	}
 	if out.ProviderID != "example.com" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "example.com")
+	}
+}
+
+func TestDNSDriver_Update_SkipsIdenticalRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{
+				ID:       10,
+				Type:     "SRV",
+				Name:     "_sip._tcp",
+				Data:     "sip.example.com",
+				TTL:      600,
+				Priority: 20,
+				Port:     5060,
+				Weight:   30,
+				Flags:    1,
+				Tag:      "issue",
+			},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{
+					"type":     "SRV",
+					"name":     "_sip._tcp",
+					"data":     "sip.example.com",
+					"ttl":      600,
+					"priority": 20,
+					"port":     5060,
+					"weight":   30,
+					"flags":    1,
+					"tag":      "issue",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+}
+
+func TestDNSDriver_Update_CreatesDistinctRecordWithSameTypeAndName(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "TXT", Name: "@", Data: "google-site-verification=old", TTL: 300},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "google-site-verification=new", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+	}
+	if got := mock.createdRecords[0].Data; got != "google-site-verification=new" {
+		t.Errorf("created record data = %q, want google-site-verification=new", got)
+	}
+}
+
+func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{
+				ID:       10,
+				Type:     "SRV",
+				Name:     "_sip._tcp",
+				Data:     "sip.example.com",
+				TTL:      300,
+				Priority: 20,
+				Port:     5060,
+				Weight:   10,
+				Flags:    1,
+				Tag:      "issue",
+			},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{
+					"type":     "SRV",
+					"name":     "_sip._tcp",
+					"data":     "sip.example.com",
+					"ttl":      600,
+					"priority": 20,
+					"port":     5060,
+					"weight":   30,
+					"flags":    1,
+					"tag":      "issue",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+	if len(mock.editedRecords) != 1 {
+		t.Fatalf("edited records = %d, want 1", len(mock.editedRecords))
+	}
+	if got := mock.editedRecords[0].id; got != 10 {
+		t.Errorf("edited ID = %d, want 10", got)
+	}
+	req := mock.editedRecords[0].req
+	if req.TTL != 600 || req.Weight != 30 {
+		t.Errorf("edited request TTL/Weight = %d/%d, want 600/30", req.TTL, req.Weight)
+	}
+	if req.Priority != 20 || req.Port != 5060 || req.Flags != 1 || req.Tag != "issue" {
+		t.Errorf("edited request = %+v, want supported fields preserved", req)
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -301,6 +301,36 @@ func TestDNSDriver_Create_ValidatesRecordsBeforeCreatingDomain(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Create_RejectsApexCNAMEBeforeCreatingDomain(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		getErr: godoStatusErr(http.StatusNotFound),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "@", "data": "target.example.com"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected apex CNAME validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "CNAME records cannot be declared at the zone apex") {
+		t.Fatalf("error = %q, want apex CNAME validation error", err)
+	}
+	if len(mock.createdDomains) != 0 {
+		t.Fatalf("created domains = %v, want none", mock.createdDomains)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+	}
+}
+
 func TestDNSDriver_Create_RejectsMalformedDomainBeforeAPICalls(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -967,6 +997,16 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			wantErr: `records[0].name must be a string`,
 		},
 		{
+			name:    "name with whitespace",
+			record:  map[string]any{"type": "A", "name": "bad label", "data": "1.2.3.4"},
+			wantErr: `records[0].name must be a valid DNS record name`,
+		},
+		{
+			name:    "name with bad label",
+			record:  map[string]any{"type": "A", "name": "-bad", "data": "1.2.3.4"},
+			wantErr: `records[0].name must be a valid DNS record name`,
+		},
+		{
 			name:    "missing data",
 			record:  map[string]any{"type": "A", "name": "@"},
 			wantErr: `records[0].data is required`,
@@ -997,9 +1037,24 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 			wantErr: `records[0].priority is required for MX records`,
 		},
 		{
+			name:    "MX data must be hostname",
+			record:  map[string]any{"type": "MX", "name": "@", "data": "mail label.example.com", "priority": 10},
+			wantErr: `records[0].data must be a hostname for MX records`,
+		},
+		{
+			name:    "NS data must be hostname",
+			record:  map[string]any{"type": "NS", "name": "@", "data": "ns_1.example.com"},
+			wantErr: `records[0].data must be a hostname for NS records`,
+		},
+		{
 			name:    "SRV port required",
 			record:  map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "priority": 10, "weight": 5},
 			wantErr: `records[0].port is required for SRV records`,
+		},
+		{
+			name:    "SRV data must be hostname",
+			record:  map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip_example.com", "priority": 10, "port": 5060, "weight": 5},
+			wantErr: `records[0].data must be a hostname for SRV records`,
 		},
 		{
 			name:    "CAA tag required",
@@ -1043,6 +1098,56 @@ func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Update_AllowsValidRecordNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		record map[string]any
+	}{
+		{
+			name:   "apex",
+			record: map[string]any{"type": "A", "name": "@", "data": "1.2.3.4"},
+		},
+		{
+			name:   "wildcard",
+			record: map[string]any{"type": "A", "name": "*.preview", "data": "1.2.3.4"},
+		},
+		{
+			name:   "underscore service labels",
+			record: map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "priority": 10, "port": 5060, "weight": 5},
+		},
+		{
+			name:   "fqdn",
+			record: map[string]any{"type": "CNAME", "name": "WWW.Example.com.", "data": "Target.Example.com."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain":  "example.com",
+					"records": []any{tt.record},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if len(mock.createdRecords) != 1 {
+				t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
+			}
+		})
+	}
+}
+
 func TestDNSDriver_Update_CreatesDistinctCAAWhenIdentityFieldsDiffer(t *testing.T) {
 	mock := &mockDomainsClient{
 		domain:         testDomain(),
@@ -1075,6 +1180,95 @@ func TestDNSDriver_Update_CreatesDistinctCAAWhenIdentityFieldsDiffer(t *testing.
 	}
 	if got := mock.createdRecords[0].req.Tag; got != "issuewild" {
 		t.Errorf("created CAA tag = %q, want issuewild", got)
+	}
+}
+
+func TestDNSDriver_Update_MatchesHostnameValuedRecordsCanonically(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing godo.DomainRecord
+		desired  map[string]any
+	}{
+		{
+			name:     "CNAME",
+			existing: godo.DomainRecord{ID: 10, Type: "CNAME", Name: "www", Data: "Target.Example.com.", TTL: 300},
+			desired:  map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com", "ttl": 300},
+		},
+		{
+			name:     "MX",
+			existing: godo.DomainRecord{ID: 10, Type: "MX", Name: "@", Data: "Mail.Example.com.", TTL: 300, Priority: 10},
+			desired:  map[string]any{"type": "MX", "name": "@", "data": "mail.example.com", "ttl": 300, "priority": 10},
+		},
+		{
+			name:     "NS",
+			existing: godo.DomainRecord{ID: 10, Type: "NS", Name: "@", Data: "NS1.Example.com.", TTL: 300},
+			desired:  map[string]any{"type": "NS", "name": "@", "data": "ns1.example.com", "ttl": 300},
+		},
+		{
+			name:     "SRV",
+			existing: godo.DomainRecord{ID: 10, Type: "SRV", Name: "_sip._tcp", Data: "SIP.Example.com.", TTL: 300, Priority: 10, Port: 5060, Weight: 5},
+			desired:  map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 300, "priority": 10, "port": 5060, "weight": 5},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:  testDomain(),
+				records: []godo.DomainRecord{tt.existing},
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain":  "example.com",
+					"records": []any{tt.desired},
+				},
+			})
+			if err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if len(mock.createdRecords) != 0 {
+				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+			}
+			if len(mock.editedRecords) != 0 {
+				t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Update_PreservesTXTCaseSensitiveIdentity(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "TXT", Name: "@", Data: "Token=ABC", TTL: 300},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "token=abc", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.editedRecords) != 0 {
+		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+	if len(mock.createdRecords) != 1 {
+		t.Fatalf("created records = %d, want 1", len(mock.createdRecords))
 	}
 }
 

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -2,7 +2,9 @@ package drivers_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -14,11 +16,16 @@ import (
 type mockDomainsClient struct {
 	domain          *godo.Domain
 	expectedDomain  string
+	getErr          error
+	createErr       error
+	createdDomains  []string
 	records         []godo.DomainRecord
 	recordPages     [][]godo.DomainRecord
 	recordListCalls []recordListCall
 	createdRecords  []createdRecord
 	editedRecords   []editedRecord
+	createRecordErr error
+	editRecordErr   error
 	err             error
 }
 
@@ -43,11 +50,18 @@ func (m *mockDomainsClient) Create(_ context.Context, req *godo.DomainCreateRequ
 	if err := m.checkDomain(req.Name); err != nil {
 		return nil, nil, err
 	}
+	m.createdDomains = append(m.createdDomains, req.Name)
+	if m.createErr != nil {
+		return nil, nil, m.createErr
+	}
 	return m.domain, nil, m.err
 }
 func (m *mockDomainsClient) Get(_ context.Context, domain string) (*godo.Domain, *godo.Response, error) {
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
+	}
+	if m.getErr != nil {
+		return nil, nil, m.getErr
 	}
 	return m.domain, nil, m.err
 }
@@ -61,6 +75,12 @@ func (m *mockDomainsClient) CreateRecord(_ context.Context, domain string, req *
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
 	}
+	if m.createRecordErr != nil {
+		return nil, nil, m.createRecordErr
+	}
+	if m.err != nil {
+		return nil, nil, m.err
+	}
 	id := len(m.allRecords()) + 1
 	record := domainRecordFromEditRequest(id, req)
 	m.createdRecords = append(m.createdRecords, createdRecord{domain: domain, req: *req})
@@ -70,6 +90,12 @@ func (m *mockDomainsClient) CreateRecord(_ context.Context, domain string, req *
 func (m *mockDomainsClient) EditRecord(_ context.Context, domain string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
 	if err := m.checkDomain(domain); err != nil {
 		return nil, nil, err
+	}
+	if m.editRecordErr != nil {
+		return nil, nil, m.editRecordErr
+	}
+	if m.err != nil {
+		return nil, nil, m.err
 	}
 	record := domainRecordFromEditRequest(id, req)
 	m.editedRecords = append(m.editedRecords, editedRecord{domain: domain, id: id, req: *req})
@@ -174,6 +200,13 @@ func testDomain() *godo.Domain {
 	}
 }
 
+func godoStatusErr(code int) error {
+	return &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: code},
+		Message:  http.StatusText(code),
+	}
+}
+
 func TestDNSDriver_Create(t *testing.T) {
 	mock := &mockDomainsClient{domain: testDomain()}
 	d := drivers.NewDNSDriverWithClient(mock)
@@ -193,6 +226,16 @@ func TestDNSDriver_Create(t *testing.T) {
 	if out.ProviderID != "example.com" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "example.com")
 	}
+	records, ok := out.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("Outputs[records] = %T, want []map[string]any", out.Outputs["records"])
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	if got := records[0]["data"]; got != "1.2.3.4" {
+		t.Errorf("created output record data = %v, want 1.2.3.4", got)
+	}
 }
 
 func TestDNSDriver_Create_Error(t *testing.T) {
@@ -206,6 +249,28 @@ func TestDNSDriver_Create_Error(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestDNSDriver_Create_DoesNotCreateOnTransientGetError(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain: testDomain(),
+		getErr: godoStatusErr(http.StatusInternalServerError),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "example-dns",
+		Config: map[string]any{"domain": "example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected transient get error, got nil")
+	}
+	if !errors.Is(err, interfaces.ErrTransient) {
+		t.Fatalf("error = %v, want ErrTransient", err)
+	}
+	if len(mock.createdDomains) != 0 {
+		t.Fatalf("created domains = %v, want none", mock.createdDomains)
 	}
 }
 
@@ -348,6 +413,32 @@ func TestDNSDriver_Update_Success(t *testing.T) {
 	}
 	if out.ProviderID != "example.com" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "example.com")
+	}
+}
+
+func TestDNSDriver_Update_RejectsDomainReplacement(t *testing.T) {
+	mock := &mockDomainsClient{domain: testDomain()}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "old.example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "new.example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected domain replacement error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot change domain") {
+		t.Fatalf("error = %q, want cannot change domain", err)
+	}
+	if len(mock.createdRecords) != 0 {
+		t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
 	}
 }
 
@@ -546,6 +637,91 @@ func TestDNSDriver_Update_RejectsConflictingDuplicateDeclarations(t *testing.T) 
 	}
 }
 
+func TestDNSDriver_Update_RejectsKnownDNSConflicts(t *testing.T) {
+	tests := []struct {
+		name    string
+		records []any
+	}{
+		{
+			name: "two CNAMEs at same name",
+			records: []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "one.example.com"},
+				map[string]any{"type": "CNAME", "name": "www", "data": "two.example.com"},
+			},
+		},
+		{
+			name: "CNAME conflicts with A",
+			records: []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com"},
+				map[string]any{"type": "A", "name": "www", "data": "1.2.3.4"},
+			},
+		},
+		{
+			name: "CNAME conflicts with AAAA",
+			records: []any{
+				map[string]any{"type": "AAAA", "name": "www", "data": "2001:db8::1"},
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDomainsClient{
+				domain:         testDomain(),
+				expectedDomain: "example.com",
+			}
+			d := drivers.NewDNSDriverWithClient(mock)
+
+			_, err := d.Update(context.Background(), interfaces.ResourceRef{
+				Name: "example-dns", ProviderID: "example.com",
+			}, interfaces.ResourceSpec{
+				Name: "example-dns",
+				Config: map[string]any{
+					"domain":  "example.com",
+					"records": tt.records,
+				},
+			})
+			if err == nil {
+				t.Fatal("expected DNS conflict error, got nil")
+			}
+			if !strings.Contains(err.Error(), "conflicting DNS record") {
+				t.Fatalf("error = %q, want conflicting DNS record", err)
+			}
+			if len(mock.createdRecords) != 0 {
+				t.Fatalf("created records = %d, want 0", len(mock.createdRecords))
+			}
+		})
+	}
+}
+
+func TestDNSDriver_Update_AllowsMultiValueTXTRecords(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "one"},
+				map[string]any{"type": "TXT", "name": "@", "data": "two"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(mock.createdRecords) != 2 {
+		t.Fatalf("created records = %d, want 2", len(mock.createdRecords))
+	}
+}
+
 func TestDNSDriver_Update_RejectsMalformedRecordConfig(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -681,6 +857,63 @@ func TestDNSDriver_Update_UpdatesConservativelyMatchedRecordWhenFieldsDiffer(t *
 	}
 }
 
+func TestDNSDriver_Update_CreateRecordErrorDoesNotPersistRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:          testDomain(),
+		expectedDomain:  "example.com",
+		createRecordErr: fmt.Errorf("create record failed"),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected create record error, got nil")
+	}
+	if len(mock.records) != 0 {
+		t.Fatalf("persisted records = %+v, want none", mock.records)
+	}
+}
+
+func TestDNSDriver_Update_EditRecordErrorDoesNotPersistRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300},
+		},
+		editRecordErr: fmt.Errorf("edit record failed"),
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 600},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected edit record error, got nil")
+	}
+	if got := mock.records[0].TTL; got != 300 {
+		t.Fatalf("persisted TTL = %d, want original 300", got)
+	}
+}
+
 func TestDNSDriver_Delete_Success(t *testing.T) {
 	mock := &mockDomainsClient{domain: testDomain()}
 	d := drivers.NewDNSDriverWithClient(mock)
@@ -729,6 +962,112 @@ func TestDNSDriver_Diff_NoChanges(t *testing.T) {
 	}
 	if result.NeedsUpdate {
 		t.Errorf("expected NeedsUpdate=false when current exists")
+	}
+}
+
+func TestDNSDriver_Diff_DetectsMissingDeclaredRecord(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	current := &interfaces.ResourceOutput{
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "missing", "ttl": 300},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true for missing declared record")
+	}
+}
+
+func TestDNSDriver_Diff_DetectsChangedDeclaredRecordFields(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	current := &interfaces.ResourceOutput{
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 300, "priority": 20, "port": 5060, "weight": 10, "flags": 1, "tag": "issue"},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "SRV", "name": "_sip._tcp", "data": "sip.example.com", "ttl": 600, "priority": 20, "port": 5060, "weight": 10, "flags": 1, "tag": "issue"},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true for changed record fields")
+	}
+}
+
+func TestDNSDriver_Diff_NoChangesForMatchingDeclaredRecords(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	current := &interfaces.ResourceOutput{
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"type": "TXT", "name": "@", "data": "one", "ttl": 300},
+				{"type": "TXT", "name": "@", "data": "undeclared", "ttl": 300},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "one", "ttl": 300},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=false when declared record exists and matches")
+	}
+}
+
+func TestDNSDriver_Diff_ValidatesDesiredRecords(t *testing.T) {
+	mock := &mockDomainsClient{}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "one.example.com"},
+				map[string]any{"type": "A", "name": "www", "data": "1.2.3.4"},
+			},
+		},
+	}, &interfaces.ResourceOutput{ProviderID: "example.com"})
+	if err == nil {
+		t.Fatal("expected desired record validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "conflicting DNS record") {
+		t.Fatalf("error = %q, want conflicting DNS record", err)
 	}
 }
 

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -164,8 +164,12 @@ func (p *DOProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpec
 				return nil, fmt.Errorf("plan diff %s/%s: %w", spec.Type, spec.Name, err)
 			}
 			if diff != nil && (diff.NeedsUpdate || diff.NeedsReplace) {
+				action := "update"
+				if diff.NeedsReplace {
+					action = "replace"
+				}
 				plan.Actions = append(plan.Actions, interfaces.PlanAction{
-					Action:   "update",
+					Action:   action,
 					Resource: spec,
 					Current:  &cur,
 					Changes:  diff.Changes,
@@ -257,6 +261,20 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 				ProviderID: action.Current.ProviderID,
 			}
 			out, err = d.Update(ctx, ref, action.Resource)
+		case "replace":
+			if action.Current == nil {
+				err = fmt.Errorf("replace action missing current resource state")
+				break
+			}
+			ref := interfaces.ResourceRef{
+				Name:       action.Resource.Name,
+				Type:       action.Resource.Type,
+				ProviderID: action.Current.ProviderID,
+			}
+			if err = d.Delete(ctx, ref); err != nil {
+				break
+			}
+			out, err = d.Create(ctx, action.Resource)
 		default:
 			err = fmt.Errorf("unknown action %q", action.Action)
 		}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -172,6 +172,9 @@ func (p *DOProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpec
 				})
 				continue
 			}
+			if diff != nil {
+				continue
+			}
 		}
 		if configHash(cur.AppliedConfig) != configHash(spec.Config) {
 			plan.Actions = append(plan.Actions, interfaces.PlanAction{

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -138,7 +138,7 @@ func (p *DOProvider) ResolveSizing(resourceType string, size interfaces.Size, hi
 }
 
 // Plan computes the set of actions needed to reach the desired state.
-func (p *DOProvider) Plan(_ context.Context, desired []interfaces.ResourceSpec, current []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
+func (p *DOProvider) Plan(ctx context.Context, desired []interfaces.ResourceSpec, current []interfaces.ResourceState) (*interfaces.IaCPlan, error) {
 	currentByName := make(map[string]interfaces.ResourceState, len(current))
 	for _, r := range current {
 		currentByName[r.Name] = r
@@ -158,6 +158,21 @@ func (p *DOProvider) Plan(_ context.Context, desired []interfaces.ResourceSpec, 
 			})
 			continue
 		}
+		if driver, err := p.ResourceDriver(spec.Type); err == nil {
+			diff, err := driver.Diff(ctx, spec, resourceOutputFromState(cur))
+			if err != nil {
+				return nil, fmt.Errorf("plan diff %s/%s: %w", spec.Type, spec.Name, err)
+			}
+			if diff != nil && (diff.NeedsUpdate || diff.NeedsReplace) {
+				plan.Actions = append(plan.Actions, interfaces.PlanAction{
+					Action:   "update",
+					Resource: spec,
+					Current:  &cur,
+					Changes:  diff.Changes,
+				})
+				continue
+			}
+		}
 		if configHash(cur.AppliedConfig) != configHash(spec.Config) {
 			plan.Actions = append(plan.Actions, interfaces.PlanAction{
 				Action:   "update",
@@ -167,6 +182,15 @@ func (p *DOProvider) Plan(_ context.Context, desired []interfaces.ResourceSpec, 
 		}
 	}
 	return plan, nil
+}
+
+func resourceOutputFromState(state interfaces.ResourceState) *interfaces.ResourceOutput {
+	return &interfaces.ResourceOutput{
+		Name:       state.Name,
+		Type:       state.Type,
+		ProviderID: state.ProviderID,
+		Outputs:    state.Outputs,
+	}
 }
 
 // upsertSupporter is an optional interface for ResourceDrivers that support

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -245,6 +245,97 @@ func TestDOProvider_Plan_UsesDriverDiffForExistingResource(t *testing.T) {
 	}
 }
 
+func TestDOProvider_Plan_KeepsDistinctCurrentStatePerAction(t *testing.T) {
+	desired := []interfaces.ResourceSpec{
+		{
+			Name:   "one-dns",
+			Type:   "infra.dns",
+			Config: map[string]any{"domain": "one.example.com"},
+		},
+		{
+			Name:   "two-dns",
+			Type:   "infra.dns",
+			Config: map[string]any{"domain": "two.example.com"},
+		},
+	}
+	current := []interfaces.ResourceState{
+		{
+			Name:          "one-dns",
+			Type:          "infra.dns",
+			ProviderID:    "one.example.com",
+			AppliedConfig: map[string]any{"domain": "old-one.example.com"},
+		},
+		{
+			Name:          "two-dns",
+			Type:          "infra.dns",
+			ProviderID:    "two.example.com",
+			AppliedConfig: map[string]any{"domain": "old-two.example.com"},
+		},
+	}
+	fake := &planDiffFakeDriver{
+		diffResult: &interfaces.DiffResult{NeedsUpdate: true},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.dns": fake}}
+
+	plan, err := p.Plan(t.Context(), desired, current)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Actions) != 2 {
+		t.Fatalf("plan actions = %d, want 2", len(plan.Actions))
+	}
+	if plan.Actions[0].Current == nil || plan.Actions[0].Current.ProviderID != "one.example.com" {
+		t.Fatalf("first action current = %+v, want one.example.com", plan.Actions[0].Current)
+	}
+	if plan.Actions[1].Current == nil || plan.Actions[1].Current.ProviderID != "two.example.com" {
+		t.Fatalf("second action current = %+v, want two.example.com", plan.Actions[1].Current)
+	}
+}
+
+func TestDOProvider_Plan_KeepsDistinctCurrentStatePerConfigHashAction(t *testing.T) {
+	desired := []interfaces.ResourceSpec{
+		{
+			Name:   "one-dns",
+			Type:   "infra.dns",
+			Config: map[string]any{"domain": "one.example.com"},
+		},
+		{
+			Name:   "two-dns",
+			Type:   "infra.dns",
+			Config: map[string]any{"domain": "two.example.com"},
+		},
+	}
+	current := []interfaces.ResourceState{
+		{
+			Name:          "one-dns",
+			Type:          "infra.dns",
+			ProviderID:    "one.example.com",
+			AppliedConfig: map[string]any{"domain": "old-one.example.com"},
+		},
+		{
+			Name:          "two-dns",
+			Type:          "infra.dns",
+			ProviderID:    "two.example.com",
+			AppliedConfig: map[string]any{"domain": "old-two.example.com"},
+		},
+	}
+	p := &DOProvider{}
+
+	plan, err := p.Plan(t.Context(), desired, current)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Actions) != 2 {
+		t.Fatalf("plan actions = %d, want 2", len(plan.Actions))
+	}
+	if plan.Actions[0].Current == nil || plan.Actions[0].Current.ProviderID != "one.example.com" {
+		t.Fatalf("first action current = %+v, want one.example.com", plan.Actions[0].Current)
+	}
+	if plan.Actions[1].Current == nil || plan.Actions[1].Current.ProviderID != "two.example.com" {
+		t.Fatalf("second action current = %+v, want two.example.com", plan.Actions[1].Current)
+	}
+}
+
 type providerDNSMock struct {
 	domain         *godo.Domain
 	getErrs        []error

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -149,6 +149,95 @@ func TestConfigHash_Empty(t *testing.T) {
 	}
 }
 
+type planDiffFakeDriver struct {
+	diffResult      *interfaces.DiffResult
+	diffCalls       int
+	receivedSpec    interfaces.ResourceSpec
+	receivedCurrent *interfaces.ResourceOutput
+}
+
+func (f *planDiffFakeDriver) Create(_ context.Context, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *planDiffFakeDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *planDiffFakeDriver) Update(_ context.Context, _ interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *planDiffFakeDriver) Delete(_ context.Context, _ interfaces.ResourceRef) error { return nil }
+func (f *planDiffFakeDriver) Diff(_ context.Context, spec interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	f.diffCalls++
+	f.receivedSpec = spec
+	f.receivedCurrent = current
+	return f.diffResult, nil
+}
+func (f *planDiffFakeDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+func (f *planDiffFakeDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *planDiffFakeDriver) SensitiveKeys() []string { return nil }
+
+func TestDOProvider_Plan_UsesDriverDiffForExistingResource(t *testing.T) {
+	spec := interfaces.ResourceSpec{
+		Name: "example-dns",
+		Type: "infra.dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "expected", "ttl": 300},
+			},
+		},
+	}
+	fake := &planDiffFakeDriver{
+		diffResult: &interfaces.DiffResult{
+			NeedsUpdate: true,
+			Changes: []interfaces.FieldChange{
+				{Path: "records[TXT/@/expected]", Old: nil, New: "expected"},
+			},
+		},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.dns": fake}}
+
+	plan, err := p.Plan(t.Context(), []interfaces.ResourceSpec{spec}, []interfaces.ResourceState{
+		{
+			Name:          "example-dns",
+			Type:          "infra.dns",
+			ProviderID:    "example.com",
+			AppliedConfig: spec.Config,
+			Outputs: map[string]any{
+				"records": []map[string]any{
+					{"type": "TXT", "name": "@", "data": "other", "ttl": 300},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if fake.diffCalls != 1 {
+		t.Fatalf("Diff calls = %d, want 1", fake.diffCalls)
+	}
+	if fake.receivedCurrent == nil {
+		t.Fatal("Diff current = nil, want reconstructed ResourceOutput")
+	}
+	if fake.receivedCurrent.ProviderID != "example.com" {
+		t.Errorf("Diff current ProviderID = %q, want example.com", fake.receivedCurrent.ProviderID)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("plan actions = %d, want 1", len(plan.Actions))
+	}
+	action := plan.Actions[0]
+	if action.Action != "update" {
+		t.Fatalf("plan action = %q, want update", action.Action)
+	}
+	if len(action.Changes) != 1 || action.Changes[0].Path != "records[TXT/@/expected]" {
+		t.Fatalf("plan action changes = %+v, want driver changes", action.Changes)
+	}
+}
+
 // ── fake driver for Apply upsert test ─────────────────────────────────────────
 
 // upsertFakeDriver is a minimal ResourceDriver that:

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -238,6 +238,48 @@ func TestDOProvider_Plan_UsesDriverDiffForExistingResource(t *testing.T) {
 	}
 }
 
+func TestDOProvider_Plan_UsesReplaceForDriverNeedsReplace(t *testing.T) {
+	spec := interfaces.ResourceSpec{
+		Name:   "example-vpc",
+		Type:   "infra.vpc",
+		Config: map[string]any{"ip_range": "10.20.0.0/16"},
+	}
+	fake := &planDiffFakeDriver{
+		diffResult: &interfaces.DiffResult{
+			NeedsReplace: true,
+			Changes: []interfaces.FieldChange{
+				{Path: "ip_range", Old: "10.10.0.0/16", New: "10.20.0.0/16", ForceNew: true},
+			},
+		},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.vpc": fake}}
+
+	plan, err := p.Plan(t.Context(), []interfaces.ResourceSpec{spec}, []interfaces.ResourceState{
+		{
+			Name:          "example-vpc",
+			Type:          "infra.vpc",
+			ProviderID:    "vpc-123",
+			AppliedConfig: map[string]any{"ip_range": "10.10.0.0/16"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Actions) != 1 {
+		t.Fatalf("plan actions = %d, want 1", len(plan.Actions))
+	}
+	action := plan.Actions[0]
+	if action.Action != "replace" {
+		t.Fatalf("plan action = %q, want replace", action.Action)
+	}
+	if action.Current == nil || action.Current.ProviderID != "vpc-123" {
+		t.Fatalf("plan current = %+v, want provider ID vpc-123", action.Current)
+	}
+	if len(action.Changes) != 1 || !action.Changes[0].ForceNew {
+		t.Fatalf("plan action changes = %+v, want ForceNew change", action.Changes)
+	}
+}
+
 func TestDOProvider_Plan_TreatsNoopDriverDiffAsAuthoritative(t *testing.T) {
 	spec := interfaces.ResourceSpec{
 		Name: "example-dns",
@@ -280,6 +322,70 @@ func TestDOProvider_Plan_TreatsNoopDriverDiffAsAuthoritative(t *testing.T) {
 	}
 	if len(plan.Actions) != 0 {
 		t.Fatalf("plan actions = %+v, want none from authoritative driver diff", plan.Actions)
+	}
+}
+
+type replaceFakeDriver struct {
+	calls     []string
+	deleteRef interfaces.ResourceRef
+}
+
+func (f *replaceFakeDriver) Create(_ context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.calls = append(f.calls, "create")
+	return &interfaces.ResourceOutput{Name: spec.Name, Type: spec.Type, ProviderID: "new-provider-id"}, nil
+}
+func (f *replaceFakeDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *replaceFakeDriver) Update(_ context.Context, _ interfaces.ResourceRef, _ interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	f.calls = append(f.calls, "update")
+	return nil, nil
+}
+func (f *replaceFakeDriver) Delete(_ context.Context, ref interfaces.ResourceRef) error {
+	f.calls = append(f.calls, "delete")
+	f.deleteRef = ref
+	return nil
+}
+func (f *replaceFakeDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return nil, nil
+}
+func (f *replaceFakeDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+func (f *replaceFakeDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *replaceFakeDriver) SensitiveKeys() []string { return nil }
+
+func TestDOProvider_Apply_ReplaceDeletesThenCreates(t *testing.T) {
+	fake := &replaceFakeDriver{}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.vpc": fake}}
+
+	spec := interfaces.ResourceSpec{Name: "example-vpc", Type: "infra.vpc", Config: map[string]any{"ip_range": "10.20.0.0/16"}}
+	plan := &interfaces.IaCPlan{
+		ID: "plan-replace",
+		Actions: []interfaces.PlanAction{{
+			Action:   "replace",
+			Resource: spec,
+			Current:  &interfaces.ResourceState{Name: "example-vpc", Type: "infra.vpc", ProviderID: "old-provider-id"},
+		}},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply returned errors: %v", result.Errors)
+	}
+	if got, want := strings.Join(fake.calls, ","), "delete,create"; got != want {
+		t.Fatalf("calls = %s, want %s", got, want)
+	}
+	if fake.deleteRef.ProviderID != "old-provider-id" {
+		t.Fatalf("delete ProviderID = %q, want old-provider-id", fake.deleteRef.ProviderID)
+	}
+	if len(result.Resources) != 1 || result.Resources[0].ProviderID != "new-provider-id" {
+		t.Fatalf("result resources = %+v, want new provider ID", result.Resources)
 	}
 }
 

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -238,6 +238,51 @@ func TestDOProvider_Plan_UsesDriverDiffForExistingResource(t *testing.T) {
 	}
 }
 
+func TestDOProvider_Plan_TreatsNoopDriverDiffAsAuthoritative(t *testing.T) {
+	spec := interfaces.ResourceSpec{
+		Name: "example-dns",
+		Type: "infra.dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "expected", "ttl": 300},
+			},
+		},
+	}
+	fake := &planDiffFakeDriver{
+		diffResult: &interfaces.DiffResult{NeedsUpdate: false, NeedsReplace: false},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.dns": fake}}
+
+	plan, err := p.Plan(t.Context(), []interfaces.ResourceSpec{spec}, []interfaces.ResourceState{
+		{
+			Name:       "example-dns",
+			Type:       "infra.dns",
+			ProviderID: "example.com",
+			AppliedConfig: map[string]any{
+				"domain": "example.com",
+				"records": []any{
+					map[string]any{"type": "TXT", "name": "@", "data": "stale", "ttl": 300},
+				},
+			},
+			Outputs: map[string]any{
+				"records": []map[string]any{
+					{"type": "TXT", "name": "@", "data": "expected", "ttl": 300},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if fake.diffCalls != 1 {
+		t.Fatalf("Diff calls = %d, want 1", fake.diffCalls)
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("plan actions = %+v, want none from authoritative driver diff", plan.Actions)
+	}
+}
+
 // ── fake driver for Apply upsert test ─────────────────────────────────────────
 
 // upsertFakeDriver is a minimal ResourceDriver that:

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -3,14 +3,21 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
 	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
 )
 
 // compile-time interface check
 var _ interfaces.IaCProvider = (*DOProvider)(nil)
+
+func providerGodoStatusErr(code int) error {
+	return &godo.ErrorResponse{Response: &http.Response{StatusCode: code, Status: http.StatusText(code)}}
+}
 
 func TestDOProvider_Name(t *testing.T) {
 	p := NewDOProvider()
@@ -235,6 +242,221 @@ func TestDOProvider_Plan_UsesDriverDiffForExistingResource(t *testing.T) {
 	}
 	if len(action.Changes) != 1 || action.Changes[0].Path != "records[TXT/@/expected]" {
 		t.Fatalf("plan action changes = %+v, want driver changes", action.Changes)
+	}
+}
+
+type providerDNSMock struct {
+	domain         *godo.Domain
+	getErrs        []error
+	createErr      error
+	records        []godo.DomainRecord
+	createCalls    int
+	createRecordNs []godo.DomainRecordEditRequest
+}
+
+func (m *providerDNSMock) Create(_ context.Context, req *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
+	m.createCalls++
+	if m.createErr != nil {
+		return nil, nil, m.createErr
+	}
+	return &godo.Domain{Name: req.Name}, nil, nil
+}
+
+func (m *providerDNSMock) Get(_ context.Context, name string) (*godo.Domain, *godo.Response, error) {
+	if len(m.getErrs) > 0 {
+		err := m.getErrs[0]
+		m.getErrs = m.getErrs[1:]
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if m.domain != nil {
+		return m.domain, nil, nil
+	}
+	return &godo.Domain{Name: name}, nil, nil
+}
+
+func (m *providerDNSMock) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+
+func (m *providerDNSMock) CreateRecord(_ context.Context, _ string, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	m.createRecordNs = append(m.createRecordNs, *req)
+	record := godo.DomainRecord{ID: len(m.records) + 1, Type: req.Type, Name: req.Name, Data: req.Data, TTL: req.TTL, Priority: req.Priority, Port: req.Port, Weight: req.Weight, Flags: req.Flags, Tag: req.Tag}
+	m.records = append(m.records, record)
+	return &record, nil, nil
+}
+
+func (m *providerDNSMock) EditRecord(_ context.Context, _ string, id int, req *godo.DomainRecordEditRequest) (*godo.DomainRecord, *godo.Response, error) {
+	record := godo.DomainRecord{ID: id, Type: req.Type, Name: req.Name, Data: req.Data, TTL: req.TTL, Priority: req.Priority, Port: req.Port, Weight: req.Weight, Flags: req.Flags, Tag: req.Tag}
+	for i := range m.records {
+		if m.records[i].ID == id {
+			m.records[i] = record
+			return &record, nil, nil
+		}
+	}
+	m.records = append(m.records, record)
+	return &record, nil, nil
+}
+
+func (m *providerDNSMock) DeleteRecord(_ context.Context, _ string, _ int) (*godo.Response, error) {
+	return nil, nil
+}
+
+func (m *providerDNSMock) Records(_ context.Context, _ string, _ *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
+	return append([]godo.DomainRecord(nil), m.records...), &godo.Response{Links: &godo.Links{Pages: &godo.Pages{}}}, nil
+}
+
+func TestDOProvider_Plan_DNSDriverDiffUsesImportedRecordState(t *testing.T) {
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
+		"infra.dns": drivers.NewDNSDriverWithClient(&providerDNSMock{}),
+	}}
+	spec := interfaces.ResourceSpec{
+		Name: "site-dns",
+		Type: "infra.dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "expected", "ttl": 300},
+			},
+		},
+	}
+
+	plan, err := p.Plan(t.Context(), []interfaces.ResourceSpec{spec}, []interfaces.ResourceState{{
+		Name:          "site-dns",
+		Type:          "infra.dns",
+		ProviderID:    "example.com",
+		AppliedConfig: spec.Config,
+		Outputs: map[string]any{
+			"records": []map[string]any{{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Actions) != 1 || plan.Actions[0].Action != "update" {
+		t.Fatalf("plan actions = %#v, want one DNS update", plan.Actions)
+	}
+}
+
+func TestDOProvider_Plan_DNSDriverDiffNoopsWhenImportedRecordStateMatches(t *testing.T) {
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
+		"infra.dns": drivers.NewDNSDriverWithClient(&providerDNSMock{}),
+	}}
+	spec := interfaces.ResourceSpec{
+		Name: "site-dns",
+		Type: "infra.dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "TXT", "name": "@", "data": "expected", "ttl": 300},
+			},
+		},
+	}
+
+	plan, err := p.Plan(t.Context(), []interfaces.ResourceSpec{spec}, []interfaces.ResourceState{{
+		Name:          "site-dns",
+		Type:          "infra.dns",
+		ProviderID:    "example.com",
+		AppliedConfig: map[string]any{"domain": "something-stale"},
+		Outputs: map[string]any{
+			"records": []map[string]any{{"type": "TXT", "name": "@", "data": "expected", "ttl": 300}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(plan.Actions) != 0 {
+		t.Fatalf("plan actions = %#v, want none from matching imported DNS records", plan.Actions)
+	}
+}
+
+func TestDOProvider_Apply_DNSCreateIsIdempotentForExistingDomain(t *testing.T) {
+	mock := &providerDNSMock{
+		domain:  &godo.Domain{Name: "example.com"},
+		records: []godo.DomainRecord{{ID: 10, Type: "A", Name: "@", Data: "1.2.3.4", TTL: 300}},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
+		"infra.dns": drivers.NewDNSDriverWithClient(mock),
+	}}
+	spec := interfaces.ResourceSpec{
+		Name: "site-dns",
+		Type: "infra.dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"records": []any{
+				map[string]any{"type": "A", "name": "@", "data": "1.2.3.4", "ttl": 300},
+			},
+		},
+	}
+
+	result, err := p.Apply(t.Context(), &interfaces.IaCPlan{ID: "plan-dns", Actions: []interfaces.PlanAction{{Action: "create", Resource: spec}}})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("Apply errors = %#v", result.Errors)
+	}
+	if mock.createCalls != 0 {
+		t.Fatalf("domain create calls = %d, want 0 for existing domain", mock.createCalls)
+	}
+	if len(mock.createRecordNs) != 0 {
+		t.Fatalf("record create calls = %d, want 0 for matching existing record", len(mock.createRecordNs))
+	}
+	if len(result.Resources) != 1 || result.Resources[0].ProviderID != "example.com" {
+		t.Fatalf("resources = %#v, want adopted DNS output", result.Resources)
+	}
+}
+
+func TestDOProvider_Apply_DNSCreateAdoptsDomainAfterCreateConflict(t *testing.T) {
+	mock := &providerDNSMock{
+		domain:    &godo.Domain{Name: "example.com"},
+		getErrs:   []error{providerGodoStatusErr(http.StatusNotFound), nil},
+		createErr: providerGodoStatusErr(http.StatusConflict),
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
+		"infra.dns": drivers.NewDNSDriverWithClient(mock),
+	}}
+	spec := interfaces.ResourceSpec{
+		Name:   "site-dns",
+		Type:   "infra.dns",
+		Config: map[string]any{"domain": "example.com"},
+	}
+
+	result, err := p.Apply(t.Context(), &interfaces.IaCPlan{ID: "plan-dns", Actions: []interfaces.PlanAction{{Action: "create", Resource: spec}}})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) != 0 {
+		t.Fatalf("Apply errors = %#v", result.Errors)
+	}
+	if mock.createCalls != 1 {
+		t.Fatalf("domain create calls = %d, want one conflicted create attempt", mock.createCalls)
+	}
+	if len(result.Resources) != 1 || result.Resources[0].ProviderID != "example.com" {
+		t.Fatalf("resources = %#v, want adopted DNS output", result.Resources)
+	}
+}
+
+func TestDOProvider_Import_DNSIncludesExistingRecords(t *testing.T) {
+	mock := &providerDNSMock{
+		domain:  &godo.Domain{Name: "example.com"},
+		records: []godo.DomainRecord{{ID: 10, Type: "TXT", Name: "@", Data: "imported", TTL: 300}},
+	}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
+		"infra.dns": drivers.NewDNSDriverWithClient(mock),
+	}}
+
+	state, err := p.Import(t.Context(), "example.com", "infra.dns")
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	records, ok := state.Outputs["records"].([]map[string]any)
+	if !ok {
+		t.Fatalf("records output = %T, want []map[string]any", state.Outputs["records"])
+	}
+	if len(records) != 1 || records[0]["data"] != "imported" {
+		t.Fatalf("records = %#v, want imported TXT record", records)
 	}
 }
 


### PR DESCRIPTION
## Summary
- read DigitalOcean DNS records into state/import outputs and reconcile declared records without duplicating existing ones
- handle domain/record create conflicts with bounded relist adoption and context-aware mutation guards
- add DNS validation/canonicalization coverage plus provider-level plan/apply/import tests

## Verification
- GOWORK=off go test ./... -count=1
- git diff --check