### PR TITLE
feat: add provider-executed migration repair

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.18.11
+	github.com/GoCodeAlone/workflow v0.19.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.18.11 h1:mkCFHafJVKd6WCGT+IFcW9l5BGCUSl2PhICKsULeyNg=
-github.com/GoCodeAlone/workflow v0.18.11/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
+github.com/GoCodeAlone/workflow v0.19.0 h1:OFjLqHnyi19nkyAhpuMNVjrDEO4ST8GVCVsZsRFCWgY=
+github.com/GoCodeAlone/workflow v0.19.0/go.mod h1:ypkCqXTwnIPqNjS8h38KZfwzdVsgwgkS1d6Dq0lXyQQ=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -27,6 +27,14 @@ type AppPlatformClient interface {
 	Delete(ctx context.Context, appID string) (*godo.Response, error)
 }
 
+type appPlatformMigrationRepairClient interface {
+	AppPlatformClient
+	ListJobInvocations(ctx context.Context, appID string, opts *godo.ListJobInvocationsOptions) ([]*godo.JobInvocation, *godo.Response, error)
+	GetJobInvocation(ctx context.Context, appID string, jobInvocationID string, opts *godo.GetJobInvocationOptions) (*godo.JobInvocation, *godo.Response, error)
+	GetJobInvocationLogs(ctx context.Context, appID, jobInvocationID string, opts *godo.GetJobInvocationLogsOptions) (*godo.AppLogs, *godo.Response, error)
+	CancelJobInvocation(ctx context.Context, appID, jobInvocationID string, opts *godo.CancelJobInvocationOptions) (*godo.JobInvocation, *godo.Response, error)
+}
+
 // AppPlatformDriver manages DigitalOcean App Platform (infra.container_service).
 type AppPlatformDriver struct {
 	client AppPlatformClient
@@ -422,14 +430,34 @@ func ParseImageRef(imageStr string) (*godo.ImageSourceSpec, error) {
 	if imageStr == "" {
 		return nil, fmt.Errorf("image ref is empty")
 	}
+	if strings.TrimSpace(imageStr) != imageStr || strings.ContainsAny(imageStr, " \t\n\r") {
+		return nil, fmt.Errorf("invalid image ref %q: whitespace is not allowed", imageStr)
+	}
 
 	// Separate tag from the path reference.
-	ref, tag, _ := strings.Cut(imageStr, ":")
+	ref, tag, hasExplicitTag := strings.Cut(imageStr, ":")
+	if hasExplicitTag && tag == "" {
+		return nil, fmt.Errorf("invalid image ref %q: explicit tag is empty", imageStr)
+	}
+	if strings.Contains(tag, ":") {
+		return nil, fmt.Errorf("invalid image ref %q: tag must not contain ':'", imageStr)
+	}
 	if tag == "" {
 		tag = "latest"
 	}
+	if strings.ContainsAny(tag, " \t\n\r") {
+		return nil, fmt.Errorf("invalid image ref %q: tag whitespace is not allowed", imageStr)
+	}
 
 	parts := strings.Split(ref, "/")
+	for _, part := range parts {
+		if part == "" {
+			return nil, fmt.Errorf("invalid image ref %q: empty path segment", imageStr)
+		}
+		if strings.ContainsAny(part, " \t\n\r") {
+			return nil, fmt.Errorf("invalid image ref %q: path whitespace is not allowed", imageStr)
+		}
+	}
 
 	switch {
 	case strings.HasPrefix(ref, "registry.digitalocean.com/"):

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -65,7 +65,10 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 	if liveApp == nil || liveApp.Spec == nil {
 		return nil, fmt.Errorf("app platform migration repair %q: live app spec missing", req.AppResourceName)
 	}
-	repairSpec := cloneAppSpec(liveApp.Spec)
+	repairSpec, err := cloneAppSpec(liveApp.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("app platform migration repair clone live spec %q: %w", req.AppResourceName, err)
+	}
 	repairSpec.Jobs = append(repairSpec.Jobs, job)
 	restore := func(result *interfaces.MigrationRepairResult) (*interfaces.MigrationRepairResult, error) {
 		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
@@ -98,7 +101,19 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 			})
 			return result, fmt.Errorf("app platform migration repair restore %q: live app spec missing", req.AppResourceName)
 		}
-		restoreSpec := cloneAppSpec(liveApp.Spec)
+		restoreSpec, err := cloneAppSpec(liveApp.Spec)
+		if err != nil {
+			if result == nil {
+				result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusFailed}
+			}
+			result.Status = interfaces.MigrationRepairStatusFailed
+			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+				Phase:  "restore",
+				Cause:  "clone live app spec failed",
+				Detail: err.Error(),
+			})
+			return result, fmt.Errorf("app platform migration repair restore clone %q: %w", req.AppResourceName, err)
+		}
 		restoreSpec.Jobs = withoutMigrationRepairJobName(restoreSpec.Jobs, jobName)
 		if len(restoreSpec.Jobs) == len(liveApp.Spec.Jobs) {
 			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
@@ -415,34 +430,39 @@ func formatAppLogs(ctx context.Context, logs *godo.AppLogs) string {
 func fetchMigrationRepairLogURL(ctx context.Context, url string) string {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "log url: " + url
+		return "log unavailable"
 	}
 	resp, err := migrationRepairHTTPClient.Do(req)
 	if err != nil {
-		return "log url: " + url
+		return "log unavailable"
 	}
 	defer resp.Body.Close() //nolint:errcheck // best-effort close for log body fetch
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return "log url: " + url
+		return "log unavailable"
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 	if err != nil {
-		return "log url: " + url
+		return "log unavailable"
 	}
 	if strings.TrimSpace(string(data)) == "" {
-		return "log url: " + url
+		return "log unavailable"
 	}
 	return string(data)
 }
 
-func cloneAppSpec(spec *godo.AppSpec) *godo.AppSpec {
+func cloneAppSpec(spec *godo.AppSpec) (*godo.AppSpec, error) {
 	if spec == nil {
-		return nil
+		return nil, nil
 	}
-	data, _ := json.Marshal(spec)
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshal app spec: %w", err)
+	}
 	var out godo.AppSpec
-	_ = json.Unmarshal(data, &out)
-	return &out
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("unmarshal app spec: %w", err)
+	}
+	return &out, nil
 }
 
 func shellQuote(value string) string {

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -1,0 +1,456 @@
+package drivers
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const migrationRepairJobPrefix = "wfctl-migration-repair"
+const defaultMigrationRepairTimeout = 10 * time.Minute
+
+var _ interfaces.ProviderMigrationRepairer = (*AppPlatformDriver)(nil)
+
+var migrationRepairHTTPClient = http.DefaultClient
+var migrationRepairPollInterval = 2 * time.Second
+
+func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	operationCtx := ctx
+	timeout := defaultMigrationRepairTimeout
+	if req.TimeoutSeconds > 0 {
+		timeout = time.Duration(req.TimeoutSeconds) * time.Second
+	}
+	var cancel context.CancelFunc
+	operationCtx, cancel = context.WithTimeout(ctx, timeout)
+	defer cancel()
+	client, ok := d.client.(appPlatformMigrationRepairClient)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "app platform migration repair: client does not support job invocation APIs")
+	}
+	app, err := d.findAppObjectByName(operationCtx, req.AppResourceName)
+	if err != nil {
+		return nil, err
+	}
+	if app == nil || app.ID == "" || app.Spec == nil {
+		return nil, fmt.Errorf("app platform migration repair %q: app is missing ID or spec", req.AppResourceName)
+	}
+
+	jobName := migrationRepairJobName()
+	job, err := migrationRepairJobSpec(jobName, req)
+	if err != nil {
+		return nil, err
+	}
+	if err := preflightMigrationRepairJobInvocations(operationCtx, client, app.ID); err != nil {
+		return nil, err
+	}
+	liveApp, _, err := client.Get(operationCtx, app.ID)
+	if err != nil {
+		return nil, fmt.Errorf("app platform migration repair read live spec %q: %w", req.AppResourceName, WrapGodoError(err))
+	}
+	if liveApp == nil || liveApp.Spec == nil {
+		return nil, fmt.Errorf("app platform migration repair %q: live app spec missing", req.AppResourceName)
+	}
+	repairSpec := cloneAppSpec(liveApp.Spec)
+	repairSpec.Jobs = append(repairSpec.Jobs, job)
+	restore := func(result *interfaces.MigrationRepairResult) (*interfaces.MigrationRepairResult, error) {
+		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+		defer cancel()
+		// App Platform updates are full-spec writes and godo does not expose a
+		// compare-and-swap token for AppUpdateRequest. Re-read the live spec and
+		// remove only this generated job so unrelated fields are preserved as far
+		// as the provider API allows.
+		liveApp, _, err := client.Get(restoreCtx, app.ID)
+		if err != nil {
+			if result == nil {
+				result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusFailed}
+			}
+			result.Status = interfaces.MigrationRepairStatusFailed
+			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+				Phase:  "restore",
+				Cause:  "read live app spec failed",
+				Detail: err.Error(),
+			})
+			return result, fmt.Errorf("app platform migration repair restore read %q: %w", req.AppResourceName, WrapGodoError(err))
+		}
+		if liveApp == nil || liveApp.Spec == nil {
+			if result == nil {
+				result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusFailed}
+			}
+			result.Status = interfaces.MigrationRepairStatusFailed
+			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+				Phase: "restore",
+				Cause: "live app spec missing",
+			})
+			return result, fmt.Errorf("app platform migration repair restore %q: live app spec missing", req.AppResourceName)
+		}
+		restoreSpec := cloneAppSpec(liveApp.Spec)
+		restoreSpec.Jobs = withoutMigrationRepairJobName(restoreSpec.Jobs, jobName)
+		if len(restoreSpec.Jobs) == len(liveApp.Spec.Jobs) {
+			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+				Phase: "restore",
+				Cause: "generated repair job already absent from live spec",
+			})
+			return result, nil
+		}
+		if _, _, err := client.Update(restoreCtx, app.ID, &godo.AppUpdateRequest{Spec: restoreSpec}); err != nil {
+			if result == nil {
+				result = &interfaces.MigrationRepairResult{Status: interfaces.MigrationRepairStatusFailed}
+			}
+			result.Status = interfaces.MigrationRepairStatusFailed
+			result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+				Phase:  "restore",
+				Cause:  "restore app spec failed",
+				Detail: err.Error(),
+			})
+			return result, fmt.Errorf("app platform migration repair restore %q: %w", req.AppResourceName, WrapGodoError(err))
+		}
+		return result, nil
+	}
+	if _, _, err := client.Update(operationCtx, app.ID, &godo.AppUpdateRequest{Spec: repairSpec}); err != nil {
+		result := &interfaces.MigrationRepairResult{
+			Status: interfaces.MigrationRepairStatusFailed,
+			Diagnostics: []interfaces.Diagnostic{{
+				Phase:  "update",
+				Cause:  "temporary repair job update failed",
+				Detail: err.Error(),
+			}},
+		}
+		restored, restoreErr := restore(result)
+		if restoreErr != nil {
+			return restored, restoreErr
+		}
+		return restored, fmt.Errorf("app platform migration repair update %q: %w", req.AppResourceName, WrapGodoError(err))
+	}
+
+	result := &interfaces.MigrationRepairResult{
+		Status: interfaces.MigrationRepairStatusFailed,
+		Diagnostics: []interfaces.Diagnostic{{
+			Phase: "job_invocation",
+			Cause: "waiting for migration repair job invocation",
+		}},
+	}
+	invocation, err := waitForMigrationRepairInvocation(operationCtx, client, app.ID, jobName, time.Duration(req.TimeoutSeconds)*time.Second)
+	if err != nil {
+		result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{Phase: "job_invocation", Cause: err.Error()})
+		if invocation != nil && invocation.ID != "" {
+			result.ProviderJobID = invocation.ID
+			cancelCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer cancel()
+			if _, _, cancelErr := client.CancelJobInvocation(cancelCtx, app.ID, invocation.ID, &godo.CancelJobInvocationOptions{JobName: jobName}); cancelErr != nil {
+				result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+					ID:     invocation.ID,
+					Phase:  "cancel",
+					Cause:  "cancel job invocation failed",
+					Detail: cancelErr.Error(),
+				})
+			} else {
+				result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+					ID:    invocation.ID,
+					Phase: "cancel",
+					Cause: "job invocation cancellation requested",
+				})
+			}
+		}
+		restored, restoreErr := restore(result)
+		if restoreErr != nil {
+			return restored, restoreErr
+		}
+		if invocation != nil && invocation.ID != "" {
+			restored.Logs = fetchMigrationRepairInvocationLogs(ctx, client, app.ID, invocation.ID, jobName)
+		}
+		return restored, err
+	}
+	result.ProviderJobID = invocation.ID
+	result.Status = migrationRepairStatusFromJobInvocation(invocation.Phase)
+	result.Diagnostics = append(result.Diagnostics, interfaces.Diagnostic{
+		ID:    invocation.DeploymentID,
+		Phase: string(invocation.Phase),
+		Cause: fmt.Sprintf("job %s", invocation.JobName),
+		Detail: fmt.Sprintf("app_id=%s deployment_id=%s job_invocation_id=%s job_name=%s phase=%s",
+			app.ID, invocation.DeploymentID, invocation.ID, invocation.JobName, invocation.Phase),
+	})
+	restored, err := restore(result)
+	if err != nil {
+		return restored, err
+	}
+	restored.Logs = fetchMigrationRepairInvocationLogs(ctx, client, app.ID, invocation.ID, jobName)
+	return restored, nil
+}
+
+func (d *AppPlatformDriver) findAppObjectByName(ctx context.Context, name string) (*godo.App, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		apps, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("app platform list: %w", WrapGodoError(err))
+		}
+		for _, app := range apps {
+			if app != nil && app.Spec != nil && app.Spec.Name == name {
+				return app, nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("app %q: %w", name, ErrResourceNotFound)
+}
+
+func migrationRepairJobSpec(name string, req interfaces.MigrationRepairRequest) (*godo.AppJobSpec, error) {
+	image, err := ParseImageRef(req.JobImage)
+	if err != nil {
+		return nil, fmt.Errorf("app platform migration repair image: %w", err)
+	}
+	return &godo.AppJobSpec{
+		Name:       name,
+		Kind:       godo.AppJobSpecKind_PreDeploy,
+		Image:      image,
+		RunCommand: migrationRepairRunCommand(req),
+		SourceDir:  "",
+		Envs:       migrationRepairEnv(req.Env),
+		Timeout:    migrationRepairTimeout(req.TimeoutSeconds),
+	}, nil
+}
+
+func migrationRepairRunCommand(req interfaces.MigrationRepairRequest) string {
+	parts := []string{
+		"/workflow-migrate repair-dirty",
+		"--source-dir " + shellQuote(req.SourceDir),
+		"--expected-dirty-version " + shellQuote(req.ExpectedDirtyVersion),
+		"--force-version " + shellQuote(req.ForceVersion),
+		"--confirm-force " + shellQuote(req.ConfirmForce),
+	}
+	if req.ThenUp {
+		parts = append(parts, "--then-up")
+	}
+	if req.UpIfClean {
+		parts = append(parts, "--up-if-clean")
+	}
+	return strings.Join(parts, " ")
+}
+
+func migrationRepairEnv(env map[string]string) []*godo.AppVariableDefinition {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make([]*godo.AppVariableDefinition, 0, len(env))
+	for key, value := range env {
+		out = append(out, &godo.AppVariableDefinition{
+			Key:   key,
+			Value: value,
+			Scope: godo.AppVariableScope_RunTime,
+			Type:  godo.AppVariableType_Secret,
+		})
+	}
+	return out
+}
+
+func migrationRepairTimeout(seconds int) string {
+	if seconds <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%ds", seconds)
+}
+
+var errMigrationRepairProviderPoll = errors.New("migration repair provider poll failed")
+
+func withoutMigrationRepairJobName(jobs []*godo.AppJobSpec, name string) []*godo.AppJobSpec {
+	out := make([]*godo.AppJobSpec, 0, len(jobs))
+	for _, job := range jobs {
+		if job != nil && job.Name == name {
+			continue
+		}
+		out = append(out, job)
+	}
+	return out
+}
+
+func migrationRepairJobName() string {
+	var token [6]byte
+	if _, err := rand.Read(token[:]); err == nil {
+		return migrationRepairJobPrefix + "-" + hex.EncodeToString(token[:])
+	}
+	return fmt.Sprintf("%s-%d", migrationRepairJobPrefix, time.Now().UnixNano())
+}
+
+func preflightMigrationRepairJobInvocations(ctx context.Context, client appPlatformMigrationRepairClient, appID string) error {
+	_, _, err := client.ListJobInvocations(ctx, appID, &godo.ListJobInvocationsOptions{Page: 1, PerPage: 1})
+	if err == nil {
+		return nil
+	}
+	if isUnsupportedJobInvocationError(err) {
+		return status.Error(codes.Unimplemented, "app platform migration repair: job invocation APIs are not supported")
+	}
+	return fmt.Errorf("%w: preflight job invocations: %w", errMigrationRepairProviderPoll, WrapGodoError(err))
+}
+
+func waitForMigrationRepairInvocation(ctx context.Context, client appPlatformMigrationRepairClient, appID, jobName string, timeout time.Duration) (*godo.JobInvocation, error) {
+	if timeout <= 0 {
+		timeout = 10 * time.Minute
+	}
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(migrationRepairPollInterval)
+	defer ticker.Stop()
+	var last *godo.JobInvocation
+	for {
+		invocations, err := listMigrationRepairInvocations(ctx, client, appID, jobName)
+		if err != nil {
+			if isUnsupportedJobInvocationError(err) {
+				return last, status.Error(codes.Unimplemented, "app platform migration repair: job invocation APIs are not supported")
+			}
+			return last, fmt.Errorf("%w: list job invocations: %w", errMigrationRepairProviderPoll, WrapGodoError(err))
+		}
+		for _, invocation := range invocations {
+			if invocation == nil || invocation.JobName != jobName {
+				continue
+			}
+			last = invocation
+			switch invocation.Phase {
+			case godo.JOBINVOCATIONPHASE_Succeeded, godo.JOBINVOCATIONPHASE_Failed, godo.JOBINVOCATIONPHASE_Canceled, godo.JOBINVOCATIONPHASE_Skipped:
+				return invocation, nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return last, ctx.Err()
+		case <-deadline.C:
+			return last, fmt.Errorf("timed out waiting for migration repair job %q", jobName)
+		case <-ticker.C:
+		}
+	}
+}
+
+func listMigrationRepairInvocations(ctx context.Context, client appPlatformMigrationRepairClient, appID, jobName string) ([]*godo.JobInvocation, error) {
+	opts := &godo.ListJobInvocationsOptions{
+		JobNames: []string{jobName},
+		Page:     1,
+		PerPage:  20,
+	}
+	var out []*godo.JobInvocation
+	for {
+		invocations, resp, err := client.ListJobInvocations(ctx, appID, opts)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, invocations...)
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			return out, nil
+		}
+		opts.Page++
+	}
+}
+
+func isUnsupportedJobInvocationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var godoErr *godo.ErrorResponse
+	if errors.As(err, &godoErr) && godoErr.Response != nil {
+		return godoErr.Response.StatusCode == http.StatusNotFound || godoErr.Response.StatusCode == http.StatusMethodNotAllowed
+	}
+	type grpcStatusError interface {
+		GRPCStatus() *status.Status
+	}
+	var grpcErr grpcStatusError
+	if errors.As(err, &grpcErr) && grpcErr.GRPCStatus() != nil {
+		return grpcErr.GRPCStatus().Code() == codes.Unimplemented
+	}
+	return false
+}
+
+func fetchMigrationRepairInvocationLogs(ctx context.Context, client appPlatformMigrationRepairClient, appID, invocationID, jobName string) string {
+	logCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+	defer cancel()
+	logs, _, err := client.GetJobInvocationLogs(logCtx, appID, invocationID, &godo.GetJobInvocationLogsOptions{JobName: jobName, TailLines: 200})
+	if err != nil {
+		return ""
+	}
+	return formatAppLogs(logCtx, logs)
+}
+
+func migrationRepairStatusFromJobInvocation(phase godo.JobInvocationPhase) string {
+	switch phase {
+	case godo.JOBINVOCATIONPHASE_Succeeded:
+		return interfaces.MigrationRepairStatusSucceeded
+	case godo.JOBINVOCATIONPHASE_Failed, godo.JOBINVOCATIONPHASE_Canceled, godo.JOBINVOCATIONPHASE_Skipped:
+		return interfaces.MigrationRepairStatusFailed
+	default:
+		return interfaces.MigrationRepairStatusFailed
+	}
+}
+
+func formatAppLogs(ctx context.Context, logs *godo.AppLogs) string {
+	if logs == nil {
+		return ""
+	}
+	var parts []string
+	if logs.LiveURL != "" {
+		parts = append(parts, fetchMigrationRepairLogURL(ctx, logs.LiveURL))
+	}
+	for _, url := range logs.HistoricURLs {
+		if url != "" {
+			parts = append(parts, fetchMigrationRepairLogURL(ctx, url))
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func fetchMigrationRepairLogURL(ctx context.Context, url string) string {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "log url: " + url
+	}
+	resp, err := migrationRepairHTTPClient.Do(req)
+	if err != nil {
+		return "log url: " + url
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close for log body fetch
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return "log url: " + url
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return "log url: " + url
+	}
+	if strings.TrimSpace(string(data)) == "" {
+		return "log url: " + url
+	}
+	return string(data)
+}
+
+func cloneAppSpec(spec *godo.AppSpec) *godo.AppSpec {
+	if spec == nil {
+		return nil
+	}
+	data, _ := json.Marshal(spec)
+	var out godo.AppSpec
+	_ = json.Unmarshal(data, &out)
+	return &out
+}
+
+func shellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	if strings.ContainsAny(value, " \t\n'\"$`\\") {
+		return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+	}
+	return value
+}

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -111,6 +111,23 @@ func TestAppPlatformRepairDirtyMigrationRunsTemporaryPreDeployJobAndRestoresSpec
 	}
 }
 
+func TestFetchMigrationRepairLogURLDoesNotLeakSignedURLOnFailure(t *testing.T) {
+	logServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer logServer.Close()
+
+	logs := formatAppLogs(context.Background(), &godo.AppLogs{
+		HistoricURLs: []string{logServer.URL + "/job-123?token=secret"},
+	})
+	if strings.Contains(logs, "token=secret") || strings.Contains(logs, logServer.URL) {
+		t.Fatalf("logs = %q, want no signed URL leak", logs)
+	}
+	if logs != "log unavailable" {
+		t.Fatalf("logs = %q, want generic placeholder", logs)
+	}
+}
+
 func TestAppPlatformRepairDirtyMigrationRejectsInvalidJobImageBeforeMutation(t *testing.T) {
 	client := &migrationRepairAppClient{
 		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
@@ -895,7 +912,10 @@ func (m *migrationRepairAppClient) Update(_ context.Context, _ string, req *godo
 		}
 		m.bindRepairJobName(req.Spec.Jobs[len(req.Spec.Jobs)-1].Name)
 		if m.externalSpecBeforeRestore != nil {
-			live := cloneAppSpec(m.externalSpecBeforeRestore)
+			live, err := cloneAppSpec(m.externalSpecBeforeRestore)
+			if err != nil {
+				panic(err)
+			}
 			if m.includeRepairJobInLiveSpec {
 				live.Jobs = append(live.Jobs, req.Spec.Jobs[len(req.Spec.Jobs)-1])
 			}

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -1,0 +1,1002 @@
+package drivers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestAppPlatformRepairDirtyMigrationRunsTemporaryPreDeployJobAndRestoresSpec(t *testing.T) {
+	logServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("migration repair log tail"))
+	}))
+	defer logServer.Close()
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID: "app-123",
+			Spec: &godo.AppSpec{
+				Name:   "bmw-staging",
+				Region: "nyc3",
+				Services: []*godo.AppServiceSpec{{
+					Name: "bmw-staging",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+						Registry:     "bmw-registry",
+						Repository:   "buymywishlist",
+						Tag:          "sha",
+					},
+				}},
+			},
+		},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Active},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+		logs: &godo.AppLogs{HistoricURLs: []string{logServer.URL + "/job-123"}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		Env:                  map[string]string{"DATABASE_URL": "postgres://secret"},
+		TimeoutSeconds:       60,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.Status != interfaces.MigrationRepairStatusSucceeded {
+		t.Fatalf("status = %q", result.Status)
+	}
+	if result.ProviderJobID != "job-123" {
+		t.Fatalf("ProviderJobID = %q", result.ProviderJobID)
+	}
+	if len(client.updates) != 2 {
+		t.Fatalf("updates = %d, want temporary update + restore", len(client.updates))
+	}
+	tempSpec := client.updates[0].Spec
+	if len(tempSpec.Jobs) != 1 {
+		t.Fatalf("temporary jobs = %d, want 1", len(tempSpec.Jobs))
+	}
+	job := tempSpec.Jobs[0]
+	if !strings.HasPrefix(job.Name, "wfctl-migration-repair-") {
+		t.Fatalf("job name = %q", job.Name)
+	}
+	if job.Image == nil || job.Image.Repository != "workflow-migrate" || job.Image.Tag != "sha" {
+		t.Fatalf("job image = %+v", job.Image)
+	}
+	for _, want := range []string{
+		"/workflow-migrate repair-dirty",
+		"--source-dir /migrations",
+		"--expected-dirty-version 20260426000005",
+		"--force-version 20260422000001",
+		"--confirm-force FORCE_MIGRATION_METADATA",
+		"--then-up",
+	} {
+		if !strings.Contains(job.RunCommand, want) {
+			t.Fatalf("run command %q missing %q", job.RunCommand, want)
+		}
+	}
+	if len(job.Envs) != 1 || job.Envs[0].Key != "DATABASE_URL" || job.Envs[0].Type != godo.AppVariableType_Secret {
+		t.Fatalf("job envs = %+v", job.Envs)
+	}
+	if len(client.deploymentsCreated) != 0 {
+		t.Fatalf("deploymentsCreated = %v, want no explicit deployment after app update", client.deploymentsCreated)
+	}
+	if restored := client.updates[1].Spec; len(restored.Jobs) != 0 {
+		t.Fatalf("restored jobs = %d, want original jobs restored", len(restored.Jobs))
+	}
+	if len(result.Diagnostics) == 0 || result.Diagnostics[len(result.Diagnostics)-1].ID != "dep-123" {
+		t.Fatalf("diagnostics = %+v", result.Diagnostics)
+	}
+	if detail := result.Diagnostics[len(result.Diagnostics)-1].Detail; !strings.Contains(detail, "app_id=app-123") || !strings.Contains(detail, "job_invocation_id=job-123") {
+		t.Fatalf("terminal diagnostic detail = %q, want provider identifiers", detail)
+	}
+	if !strings.Contains(result.Logs, "migration repair log tail") {
+		t.Fatalf("logs = %q, want fetched log tail", result.Logs)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationRejectsInvalidJobImageBeforeMutation(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "not a valid image reference with spaces",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err == nil {
+		t.Fatal("expected invalid image error")
+	}
+	if len(client.updates) != 0 {
+		t.Fatalf("updates = %d, want no mutation before image validation", len(client.updates))
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationDefaultTimeoutCoversPreflight(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app:                      &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment:               &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		requirePreflightDeadline: true,
+		invocations:              [][]*godo.JobInvocation{{{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded}}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	if _, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	}); err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationCleansUpAfterAmbiguousUpdateError(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app:                 &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment:          &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		updateErrAfterApply: true,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err == nil {
+		t.Fatal("expected update error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusFailed {
+		t.Fatalf("result = %+v, want failed result", result)
+	}
+	if len(client.updates) != 2 {
+		t.Fatalf("updates = %d, want attempted update plus cleanup update", len(client.updates))
+	}
+	if jobs := client.updates[1].Spec.Jobs; len(jobs) != 0 {
+		t.Fatalf("cleanup jobs = %+v, want generated repair job removed", jobs)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationCancelsRunningJobOnPollingErrorAndRestores(t *testing.T) {
+	prevInterval := migrationRepairPollInterval
+	migrationRepairPollInterval = time.Millisecond
+	t.Cleanup(func() { migrationRepairPollInterval = prevInterval })
+	logServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("running job log tail"))
+	}))
+	defer logServer.Close()
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{
+			ID:    "dep-123",
+			Phase: godo.DeploymentPhase_Deploying,
+		},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-running", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Running},
+		}},
+		listInvocationErr: context.DeadlineExceeded,
+		logs:              &godo.AppLogs{HistoricURLs: []string{logServer.URL + "/job-running"}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err == nil {
+		t.Fatal("expected provider polling error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusFailed {
+		t.Fatalf("result = %+v, want failed result", result)
+	}
+	if len(client.cancelledJobs) != 1 || client.cancelledJobs[0] != "job-running" {
+		t.Fatalf("cancelledJobs = %v, want job-running canceled", client.cancelledJobs)
+	}
+	if !strings.Contains(result.Logs, "running job log tail") {
+		t.Fatalf("logs = %q, want failed invocation logs", result.Logs)
+	}
+	if len(client.updates) != 2 {
+		t.Fatalf("updates = %d, want temporary update + restore", len(client.updates))
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationCancelsRunningJobOnRequestTimeoutAndRestores(t *testing.T) {
+	prevInterval := migrationRepairPollInterval
+	migrationRepairPollInterval = time.Millisecond
+	t.Cleanup(func() { migrationRepairPollInterval = prevInterval })
+	client := &migrationRepairAppClient{
+		app:        &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-running", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Running},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusFailed {
+		t.Fatalf("result = %+v, want failed result", result)
+	}
+	if len(client.cancelledJobs) != 1 || client.cancelledJobs[0] != "job-running" {
+		t.Fatalf("cancelledJobs = %v, want job-running canceled", client.cancelledJobs)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationUsesRequestTimeoutForPolling(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app:        &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	start := time.Now()
+
+	result, err := driver.RepairDirtyMigration(ctx, interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if result == nil || result.Status != interfaces.MigrationRepairStatusFailed {
+		t.Fatalf("result = %+v, want failed result", result)
+	}
+	if elapsed := time.Since(start); elapsed > 2500*time.Millisecond {
+		t.Fatalf("repair elapsed %s, want request timeout to bound polling near 1s", elapsed)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationDoesNotPollPreviousActiveDeployment(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID:               "app-123",
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "active-old", Phase: godo.DeploymentPhase_Active},
+		},
+		useActiveDeploymentOnly: true,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err == nil {
+		t.Fatal("expected missing update deployment error")
+	}
+	if result == nil || len(result.Diagnostics) == 0 || !strings.Contains(result.Diagnostics[len(result.Diagnostics)-1].Cause, "timed out waiting for migration repair job") {
+		t.Fatalf("result diagnostics = %+v, want job polling timeout diagnostic", result)
+	}
+	if len(client.listInvocationRequests) < 2 {
+		t.Fatalf("listInvocationRequests = %d, want preflight and polling requests", len(client.listInvocationRequests))
+	}
+	if got := client.listInvocationRequests[1].DeploymentID; got != "" {
+		t.Fatalf("DeploymentID filter = %q, want no binding to previous active deployment", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationPrefersPendingDeploymentOverPreviousInProgress(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID:                   "app-123",
+			Spec:                 &godo.AppSpec{Name: "bmw-staging"},
+			InProgressDeployment: &godo.Deployment{ID: "in-progress-old", Phase: godo.DeploymentPhase_Building},
+		},
+		deployment: &godo.Deployment{ID: "pending-new", Phase: godo.DeploymentPhase_PendingBuild},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-new", JobName: "$repair", DeploymentID: "pending-new", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+		usePendingDeployment: true,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-new" {
+		t.Fatalf("ProviderJobID = %q, want job-new", result.ProviderJobID)
+	}
+	if got := client.listInvocationRequests[1].DeploymentID; got != "" {
+		t.Fatalf("DeploymentID filter = %q, want no deployment binding", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationIgnoresPreExistingPendingDeployment(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID:                "app-123",
+			Spec:              &godo.AppSpec{Name: "bmw-staging"},
+			PendingDeployment: &godo.Deployment{ID: "pending-old", Phase: godo.DeploymentPhase_PendingBuild},
+		},
+		deployment: &godo.Deployment{ID: "in-progress-new", Phase: godo.DeploymentPhase_Building},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-new", JobName: "$repair", DeploymentID: "in-progress-new", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+		listInvocationErr: context.DeadlineExceeded,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-new" {
+		t.Fatalf("ProviderJobID = %q, want job-new", result.ProviderJobID)
+	}
+	if got := client.listInvocationRequests[1].DeploymentID; got != "" {
+		t.Fatalf("DeploymentID filter = %q, want no deployment binding", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationPollsForEventuallyConsistentNewDeployment(t *testing.T) {
+	prevInterval := migrationRepairPollInterval
+	migrationRepairPollInterval = time.Millisecond
+	t.Cleanup(func() { migrationRepairPollInterval = prevInterval })
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{
+			ID:    "dep-eventual",
+			Phase: godo.DeploymentPhase_Deploying,
+		},
+		suppressUpdateDeployment: true,
+		deploymentOnGet:          &godo.Deployment{ID: "dep-eventual", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-eventual", JobName: "$repair", DeploymentID: "dep-eventual", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-eventual" {
+		t.Fatalf("ProviderJobID = %q, want job-eventual", result.ProviderJobID)
+	}
+	if got := client.listInvocationRequests[1].DeploymentID; got != "" {
+		t.Fatalf("DeploymentID filter = %q, want no deployment binding", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationSelectsFastActiveNewDeployment(t *testing.T) {
+	prevInterval := migrationRepairPollInterval
+	migrationRepairPollInterval = time.Millisecond
+	t.Cleanup(func() { migrationRepairPollInterval = prevInterval })
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID:               "app-123",
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "active-old", Phase: godo.DeploymentPhase_Active},
+		},
+		deployment:              &godo.Deployment{ID: "active-new", Phase: godo.DeploymentPhase_Active},
+		useActiveDeploymentOnly: true,
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-active", JobName: "$repair", DeploymentID: "active-new", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-active" {
+		t.Fatalf("ProviderJobID = %q, want job-active", result.ProviderJobID)
+	}
+	if got := client.listInvocationRequests[1].DeploymentID; got != "" {
+		t.Fatalf("DeploymentID filter = %q, want no deployment binding", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationUsesGeneratedJobInvocationDeployment(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app:        &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-generated", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-123" {
+		t.Fatalf("ProviderJobID = %q, want generated job invocation accepted", result.ProviderJobID)
+	}
+	if got := result.Diagnostics[len(result.Diagnostics)-1].ID; got != "dep-generated" {
+		t.Fatalf("diagnostic deployment ID = %q, want invocation deployment", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationRestorePreservesConcurrentSpecChanges(t *testing.T) {
+	concurrentSpec := &godo.AppSpec{
+		Name: "bmw-staging",
+		Services: []*godo.AppServiceSpec{{
+			Name: "bmw-staging",
+			Image: &godo.ImageSourceSpec{
+				RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+				Registry:     "bmw-registry",
+				Repository:   "buymywishlist",
+				Tag:          "new-live-tag",
+			},
+		}},
+	}
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID: "app-123",
+			Spec: &godo.AppSpec{
+				Name: "bmw-staging",
+				Services: []*godo.AppServiceSpec{{
+					Name: "bmw-staging",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+						Registry:     "bmw-registry",
+						Repository:   "buymywishlist",
+						Tag:          "old-live-tag",
+					},
+				}},
+			},
+		},
+		deployment:                 &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations:                [][]*godo.JobInvocation{{{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded}}},
+		externalSpecBeforeRestore:  concurrentSpec,
+		includeRepairJobInLiveSpec: true,
+		expectedRestoredServiceTag: "new-live-tag",
+		expectedRestoredRepairJobs: 0,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	restored := client.updates[len(client.updates)-1].Spec
+	if got := restored.Services[0].Image.Tag; got != "new-live-tag" {
+		t.Fatalf("restored service image tag = %q, want concurrent value new-live-tag", got)
+	}
+	if len(restored.Jobs) != 0 {
+		t.Fatalf("restored jobs = %d, want repair job removed", len(restored.Jobs))
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationFindsInvocationOnLaterPage(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app:        &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{
+			{{ID: "job-other", JobName: "other-job", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded}},
+			{{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded}},
+		},
+		paginateInvocations: true,
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if result.ProviderJobID != "job-123" {
+		t.Fatalf("ProviderJobID = %q, want later page job", result.ProviderJobID)
+	}
+	if len(client.listInvocationRequests) != 3 || client.listInvocationRequests[2].Page != 2 {
+		t.Fatalf("listInvocationRequests = %+v, want second page queried", client.listInvocationRequests)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID: "app-123",
+			Spec: &godo.AppSpec{
+				Name: "bmw-staging",
+				Jobs: []*godo.AppJobSpec{{
+					Name: "wfctl-migration-repair-other",
+					Kind: godo.AppJobSpecKind_PreDeploy,
+				}},
+			},
+		},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	tempSpec := client.updates[0].Spec
+	if len(tempSpec.Jobs) != 2 {
+		t.Fatalf("temporary jobs = %d, want existing repair job plus this repair job", len(tempSpec.Jobs))
+	}
+	if tempSpec.Jobs[0].Name != "wfctl-migration-repair-other" {
+		t.Fatalf("existing repair job was not preserved: %+v", tempSpec.Jobs)
+	}
+	restoredSpec := client.updates[len(client.updates)-1].Spec
+	if len(restoredSpec.Jobs) != 1 || restoredSpec.Jobs[0].Name != "wfctl-migration-repair-other" {
+		t.Fatalf("restored jobs = %+v, want only other repair job preserved", restoredSpec.Jobs)
+	}
+}
+
+func TestWithoutMigrationRepairJobNamePreservesNilJobs(t *testing.T) {
+	jobs := []*godo.AppJobSpec{
+		nil,
+		{Name: "wfctl-migration-repair-current"},
+		{Name: "wfctl-migration-repair-other"},
+	}
+	out := withoutMigrationRepairJobName(jobs, "wfctl-migration-repair-current")
+	if len(out) != 2 || out[0] != nil || out[1].Name != "wfctl-migration-repair-other" {
+		t.Fatalf("jobs = %+v, want nil and unrelated job preserved", out)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationGeneratesUniqueJobNames(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployments: []*godo.Deployment{
+			{ID: "dep-1", Phase: godo.DeploymentPhase_Deploying},
+			{ID: "dep-2", Phase: godo.DeploymentPhase_Deploying},
+		},
+		invocations: [][]*godo.JobInvocation{
+			{{ID: "job-1", JobName: "$repair", DeploymentID: "dep-1", Phase: godo.JOBINVOCATIONPHASE_Succeeded}},
+			{{ID: "job-2", JobName: "$repair", DeploymentID: "dep-2", Phase: godo.JOBINVOCATIONPHASE_Succeeded}},
+		},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+	req := interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	}
+
+	if _, err := driver.RepairDirtyMigration(context.Background(), req); err != nil {
+		t.Fatalf("first RepairDirtyMigration: %v", err)
+	}
+	if _, err := driver.RepairDirtyMigration(context.Background(), req); err != nil {
+		t.Fatalf("second RepairDirtyMigration: %v", err)
+	}
+	first := client.updates[0].Spec.Jobs[0].Name
+	second := client.updates[2].Spec.Jobs[0].Name
+	if first == second {
+		t.Fatalf("job names collided: %q", first)
+	}
+	if len(client.listInvocationRequests) != 4 {
+		t.Fatalf("listInvocationRequests = %d, want 4", len(client.listInvocationRequests))
+	}
+	if client.listInvocationRequests[1].JobNames[0] != first || client.listInvocationRequests[3].JobNames[0] != second {
+		t.Fatalf("listInvocationRequests = %+v, want generated job names %q and %q", client.listInvocationRequests, first, second)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationJobInvocationUnsupportedReturnsUnimplemented(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		deployment: &godo.Deployment{
+			ID:    "dep-123",
+			Phase: godo.DeploymentPhase_Deploying,
+		},
+		preflightErr: &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusMethodNotAllowed},
+			Message:  "method not allowed",
+		},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %s, want %s (err=%v)", status.Code(err), codes.Unimplemented, err)
+	}
+	if len(client.updates) != 0 {
+		t.Fatalf("updates = %d, want unsupported API detected before mutation", len(client.updates))
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationUnsupportedClientReturnsUnimplemented(t *testing.T) {
+	driver := NewAppPlatformDriverWithClient(&migrationRepairBaseAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+	}, "nyc3")
+
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %s, want %s (err=%v)", status.Code(err), codes.Unimplemented, err)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationMissingDeploymentRestoresWithDiagnostic(t *testing.T) {
+	client := &migrationRepairAppClient{
+		app: &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+
+	result, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+		TimeoutSeconds:       1,
+	})
+	if err == nil {
+		t.Fatal("expected missing deployment error")
+	}
+	if result == nil || len(result.Diagnostics) == 0 || !strings.Contains(result.Diagnostics[len(result.Diagnostics)-1].Cause, "timed out waiting for migration repair job") {
+		t.Fatalf("result diagnostics = %+v, want job polling timeout diagnostic", result)
+	}
+	if len(client.updates) != 2 {
+		t.Fatalf("updates = %d, want temporary update + restore", len(client.updates))
+	}
+}
+
+type migrationRepairBaseAppClient struct {
+	app *godo.App
+}
+
+func (m *migrationRepairBaseAppClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return nil, nil, nil
+}
+
+func (m *migrationRepairBaseAppClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return m.app, nil, nil
+}
+
+func (m *migrationRepairBaseAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return []*godo.App{m.app}, &godo.Response{}, nil
+}
+
+func (m *migrationRepairBaseAppClient) Update(_ context.Context, _ string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	m.app.Spec = req.Spec
+	return m.app, nil, nil
+}
+
+func (m *migrationRepairBaseAppClient) CreateDeployment(_ context.Context, _ string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	return nil, nil, nil
+}
+
+func (m *migrationRepairBaseAppClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return nil, nil, nil
+}
+
+func (m *migrationRepairBaseAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+
+type migrationRepairAppClient struct {
+	app                        *godo.App
+	deployment                 *godo.Deployment
+	deployments                []*godo.Deployment
+	deploymentOnGet            *godo.Deployment
+	invocations                [][]*godo.JobInvocation
+	logs                       *godo.AppLogs
+	listInvocationErr          error
+	preflightErr               error
+	requirePreflightDeadline   bool
+	paginateInvocations        bool
+	updateErrAfterApply        bool
+	updates                    []*godo.AppUpdateRequest
+	deploymentsCreated         []string
+	cancelledJobs              []string
+	listInvocationRequests     []*godo.ListJobInvocationsOptions
+	useActiveDeploymentOnly    bool
+	usePendingDeployment       bool
+	suppressUpdateDeployment   bool
+	requireLiveUpdate          bool
+	externalSpecBeforeRestore  *godo.AppSpec
+	includeRepairJobInLiveSpec bool
+	expectedRestoredServiceTag string
+	expectedRestoredRepairJobs int
+}
+
+func (m *migrationRepairAppClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return nil, nil, nil
+}
+
+func (m *migrationRepairAppClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	if m.deploymentOnGet != nil && len(m.updates) > 0 {
+		m.app.InProgressDeployment = m.deploymentOnGet
+	}
+	return m.app, nil, nil
+}
+
+func (m *migrationRepairAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return []*godo.App{m.app}, &godo.Response{}, nil
+}
+
+func (m *migrationRepairAppClient) Update(_ context.Context, _ string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	m.updates = append(m.updates, req)
+	m.app.Spec = req.Spec
+	if len(req.Spec.Jobs) > 0 {
+		deployment := m.nextDeployment()
+		if deployment == nil {
+			return m.app, nil, nil
+		}
+		if m.suppressUpdateDeployment {
+			m.bindRepairJobName(req.Spec.Jobs[len(req.Spec.Jobs)-1].Name)
+			return m.app, nil, nil
+		}
+		if m.useActiveDeploymentOnly {
+			m.app.ActiveDeployment = deployment
+		} else if m.usePendingDeployment {
+			m.app.PendingDeployment = deployment
+		} else {
+			m.app.InProgressDeployment = deployment
+		}
+		m.bindRepairJobName(req.Spec.Jobs[len(req.Spec.Jobs)-1].Name)
+		if m.externalSpecBeforeRestore != nil {
+			live := cloneAppSpec(m.externalSpecBeforeRestore)
+			if m.includeRepairJobInLiveSpec {
+				live.Jobs = append(live.Jobs, req.Spec.Jobs[len(req.Spec.Jobs)-1])
+			}
+			m.app.Spec = live
+		}
+	}
+	if m.updateErrAfterApply && len(m.updates) == 1 {
+		return m.app, nil, context.DeadlineExceeded
+	}
+	return m.app, nil, nil
+}
+
+func (m *migrationRepairAppClient) nextDeployment() *godo.Deployment {
+	if len(m.deployments) > 0 {
+		deployment := m.deployments[0]
+		m.deployments = m.deployments[1:]
+		return deployment
+	}
+	return m.deployment
+}
+
+func (m *migrationRepairAppClient) bindRepairJobName(jobName string) {
+	for _, batch := range m.invocations {
+		bound := false
+		for _, invocation := range batch {
+			if invocation != nil && invocation.JobName == "$repair" {
+				invocation.JobName = jobName
+				bound = true
+			}
+		}
+		if bound {
+			return
+		}
+	}
+}
+
+func (m *migrationRepairAppClient) CreateDeployment(_ context.Context, appID string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	m.deploymentsCreated = append(m.deploymentsCreated, appID)
+	return m.deployment, nil, nil
+}
+
+func (m *migrationRepairAppClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return []*godo.Deployment{m.deployment}, nil, nil
+}
+
+func (m *migrationRepairAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+
+func (m *migrationRepairAppClient) GetDeployment(_ context.Context, _ string, _ string) (*godo.Deployment, *godo.Response, error) {
+	return m.deployment, nil, nil
+}
+
+func (m *migrationRepairAppClient) GetLogs(_ context.Context, _ string, _ string, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return m.logs, nil, nil
+}
+
+func (m *migrationRepairAppClient) ListJobInvocations(ctx context.Context, _ string, opts *godo.ListJobInvocationsOptions) ([]*godo.JobInvocation, *godo.Response, error) {
+	if opts != nil {
+		copied := *opts
+		copied.JobNames = append([]string(nil), opts.JobNames...)
+		m.listInvocationRequests = append(m.listInvocationRequests, &copied)
+	}
+	if opts != nil && len(opts.JobNames) == 0 && opts.DeploymentID == "" && opts.PerPage == 1 {
+		if m.requirePreflightDeadline {
+			if _, ok := ctx.Deadline(); !ok {
+				return nil, nil, context.DeadlineExceeded
+			}
+		}
+		if m.preflightErr != nil {
+			return nil, nil, m.preflightErr
+		}
+		return nil, &godo.Response{}, nil
+	}
+	if len(m.invocations) == 0 {
+		if m.listInvocationErr != nil {
+			return nil, nil, m.listInvocationErr
+		}
+		return nil, nil, nil
+	}
+	if m.paginateInvocations && opts != nil && opts.Page != 1 && opts.Page != 2 {
+		return nil, &godo.Response{}, nil
+	}
+	out := m.invocations[0]
+	m.invocations = m.invocations[1:]
+	resp := &godo.Response{}
+	if m.paginateInvocations && opts != nil && opts.Page == 1 {
+		resp.Links = &godo.Links{Pages: &godo.Pages{Next: "https://api.digitalocean.com/v2/apps/app-123/jobs?page=2"}}
+	}
+	return out, resp, nil
+}
+
+func (m *migrationRepairAppClient) GetJobInvocation(_ context.Context, _ string, _ string, _ *godo.GetJobInvocationOptions) (*godo.JobInvocation, *godo.Response, error) {
+	return nil, nil, nil
+}
+
+func (m *migrationRepairAppClient) GetJobInvocationLogs(_ context.Context, _ string, _ string, _ *godo.GetJobInvocationLogsOptions) (*godo.AppLogs, *godo.Response, error) {
+	return m.logs, nil, nil
+}
+
+func (m *migrationRepairAppClient) CancelJobInvocation(_ context.Context, _ string, jobInvocationID string, _ *godo.CancelJobInvocationOptions) (*godo.JobInvocation, *godo.Response, error) {
+	m.cancelledJobs = append(m.cancelledJobs, jobInvocationID)
+	return &godo.JobInvocation{ID: jobInvocationID, Phase: godo.JOBINVOCATIONPHASE_Canceled}, nil, nil
+}

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -662,6 +662,12 @@ func TestParseImageRef_Malformed(t *testing.T) {
 		"registry.digitalocean.com/onlyone", // DOCR with only one path segment
 		"ghcr.io/onlyone",                   // GHCR with only org, no repo
 		"docker.io/onlyone",                 // docker.io with only one path segment
+		"registry.digitalocean.com/reg/workflow migrate:sha",
+		"registry.digitalocean.com/reg/:sha",
+		"registry.digitalocean.com/reg/app:bad tag",
+		"registry.digitalocean.com/reg/app:bad:tag",
+		"registry.digitalocean.com/reg/app:",
+		"ghcr.io//app:sha",
 	}
 	for _, tc := range cases {
 		_, err := drivers.ParseImageRef(tc)

--- a/internal/grpc_dispatch_test.go
+++ b/internal/grpc_dispatch_test.go
@@ -249,10 +249,12 @@ func TestGRPCDispatch_NilArgs_NoPanic(t *testing.T) {
 		sizingResult:    &interfaces.ProviderSizing{InstanceType: "xs"},
 		bootstrapResult: &interfaces.BootstrapResult{},
 	}
+	repairFake := &fakeRepairProvider{fakeIaCProvider: *fake}
 	provider := &DOProvider{
 		drivers: map[string]interfaces.ResourceDriver{"infra.droplet": stub},
 	}
 	miProvider := &doModuleInstance{provider: fake}
+	miRepairProvider := &doModuleInstance{provider: repairFake}
 	miDrivers := &doModuleInstance{provider: provider}
 
 	cases := []struct {
@@ -273,6 +275,7 @@ func TestGRPCDispatch_NilArgs_NoPanic(t *testing.T) {
 		{miProvider, "IaCProvider.Import"},
 		{miProvider, "IaCProvider.ResolveSizing"},
 		{miProvider, "IaCProvider.BootstrapStateBackend"},
+		{miRepairProvider, "IaCProvider.RepairDirtyMigration"},
 		// Driver methods with nil args → resource_type missing → error (not panic).
 		{miDrivers, "ResourceDriver.Create"},
 		{miDrivers, "ResourceDriver.Read"},
@@ -311,10 +314,12 @@ func TestGRPCDispatch_EmptyArgs_NoPanic(t *testing.T) {
 		sizingResult:    &interfaces.ProviderSizing{InstanceType: "xs"},
 		bootstrapResult: &interfaces.BootstrapResult{},
 	}
+	repairFake := &fakeRepairProvider{fakeIaCProvider: *fake}
 	provider := &DOProvider{
 		drivers: map[string]interfaces.ResourceDriver{"infra.droplet": stub},
 	}
 	miProvider := &doModuleInstance{provider: fake}
+	miRepairProvider := &doModuleInstance{provider: repairFake}
 	miDrivers := &doModuleInstance{provider: provider}
 
 	cases := []struct {
@@ -333,6 +338,7 @@ func TestGRPCDispatch_EmptyArgs_NoPanic(t *testing.T) {
 		{miProvider, "IaCProvider.Import"},
 		{miProvider, "IaCProvider.ResolveSizing"},
 		{miProvider, "IaCProvider.BootstrapStateBackend"},
+		{miRepairProvider, "IaCProvider.RepairDirtyMigration"},
 		{miDrivers, "ResourceDriver.Create"},
 		{miDrivers, "ResourceDriver.Read"},
 		{miDrivers, "ResourceDriver.Update"},

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -29,6 +29,10 @@ func (m *doModuleInstance) Stop(_ context.Context) error  { return nil }
 // InvokeMethod dispatches host calls to the underlying DOProvider and its
 // resource drivers. Method names follow the convention "Interface.MethodName".
 func (m *doModuleInstance) InvokeMethod(method string, args map[string]any) (map[string]any, error) {
+	return m.InvokeMethodContext(context.Background(), method, args)
+}
+
+func (m *doModuleInstance) InvokeMethodContext(ctx context.Context, method string, args map[string]any) (map[string]any, error) {
 	switch method {
 	case "IaCProvider.Initialize":
 		// Already initialised in CreateModule; accept a re-init call as a no-op.
@@ -53,28 +57,31 @@ func (m *doModuleInstance) InvokeMethod(method string, args map[string]any) (map
 		return map[string]any{"capabilities": out}, nil
 
 	case "IaCProvider.Plan":
-		return m.invokeProviderPlan(args)
+		return m.invokeProviderPlan(ctx, args)
 
 	case "IaCProvider.Apply":
-		return m.invokeProviderApply(args)
+		return m.invokeProviderApply(ctx, args)
 
 	case "IaCProvider.Destroy":
-		return m.invokeProviderDestroy(args)
+		return m.invokeProviderDestroy(ctx, args)
 
 	case "IaCProvider.Status":
-		return m.invokeProviderStatus(args)
+		return m.invokeProviderStatus(ctx, args)
 
 	case "IaCProvider.DetectDrift":
-		return m.invokeProviderDetectDrift(args)
+		return m.invokeProviderDetectDrift(ctx, args)
 
 	case "IaCProvider.Import":
-		return m.invokeProviderImport(args)
+		return m.invokeProviderImport(ctx, args)
 
 	case "IaCProvider.ResolveSizing":
 		return m.invokeProviderResolveSizing(args)
 
 	case "IaCProvider.BootstrapStateBackend":
-		return m.invokeProviderBootstrapStateBackend(args)
+		return m.invokeProviderBootstrapStateBackend(ctx, args)
+
+	case "IaCProvider.RepairDirtyMigration":
+		return m.invokeProviderRepairDirtyMigration(ctx, args)
 
 	case "ResourceDriver.Update":
 		return m.invokeDriverUpdate(args)
@@ -111,7 +118,7 @@ func (m *doModuleInstance) InvokeMethod(method string, args map[string]any) (map
 // ── IaCProvider bulk-method helpers ──────────────────────────────────────────
 
 // invokeProviderPlan decodes desired+current and calls IaCProvider.Plan.
-func (m *doModuleInstance) invokeProviderPlan(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderPlan(ctx context.Context, args map[string]any) (map[string]any, error) {
 	var desired []interfaces.ResourceSpec
 	if err := decodeJSONField(args, "desired", &desired); err != nil {
 		return nil, fmt.Errorf("IaCProvider.Plan: %w", err)
@@ -120,7 +127,7 @@ func (m *doModuleInstance) invokeProviderPlan(args map[string]any) (map[string]a
 	if err := decodeJSONField(args, "current", &current); err != nil {
 		return nil, fmt.Errorf("IaCProvider.Plan: %w", err)
 	}
-	plan, err := m.provider.Plan(context.Background(), desired, current)
+	plan, err := m.provider.Plan(ctx, desired, current)
 	if err != nil {
 		return nil, err
 	}
@@ -128,12 +135,12 @@ func (m *doModuleInstance) invokeProviderPlan(args map[string]any) (map[string]a
 }
 
 // invokeProviderApply decodes the plan and calls IaCProvider.Apply.
-func (m *doModuleInstance) invokeProviderApply(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderApply(ctx context.Context, args map[string]any) (map[string]any, error) {
 	var plan interfaces.IaCPlan
 	if err := decodeJSONField(args, "plan", &plan); err != nil {
 		return nil, fmt.Errorf("IaCProvider.Apply: %w", err)
 	}
-	result, err := m.provider.Apply(context.Background(), &plan)
+	result, err := m.provider.Apply(ctx, &plan)
 	if err != nil {
 		return nil, err
 	}
@@ -141,12 +148,12 @@ func (m *doModuleInstance) invokeProviderApply(args map[string]any) (map[string]
 }
 
 // invokeProviderDestroy decodes refs and calls IaCProvider.Destroy.
-func (m *doModuleInstance) invokeProviderDestroy(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderDestroy(ctx context.Context, args map[string]any) (map[string]any, error) {
 	refs, err := refsFromArgs(args)
 	if err != nil {
 		return nil, fmt.Errorf("IaCProvider.Destroy: %w", err)
 	}
-	result, err := m.provider.Destroy(context.Background(), refs)
+	result, err := m.provider.Destroy(ctx, refs)
 	if err != nil {
 		return nil, err
 	}
@@ -154,12 +161,12 @@ func (m *doModuleInstance) invokeProviderDestroy(args map[string]any) (map[strin
 }
 
 // invokeProviderStatus decodes refs and calls IaCProvider.Status.
-func (m *doModuleInstance) invokeProviderStatus(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderStatus(ctx context.Context, args map[string]any) (map[string]any, error) {
 	refs, err := refsFromArgs(args)
 	if err != nil {
 		return nil, fmt.Errorf("IaCProvider.Status: %w", err)
 	}
-	statuses, err := m.provider.Status(context.Background(), refs)
+	statuses, err := m.provider.Status(ctx, refs)
 	if err != nil {
 		return nil, err
 	}
@@ -172,12 +179,12 @@ func (m *doModuleInstance) invokeProviderStatus(args map[string]any) (map[string
 }
 
 // invokeProviderDetectDrift decodes refs and calls IaCProvider.DetectDrift.
-func (m *doModuleInstance) invokeProviderDetectDrift(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderDetectDrift(ctx context.Context, args map[string]any) (map[string]any, error) {
 	refs, err := refsFromArgs(args)
 	if err != nil {
 		return nil, fmt.Errorf("IaCProvider.DetectDrift: %w", err)
 	}
-	drifts, err := m.provider.DetectDrift(context.Background(), refs)
+	drifts, err := m.provider.DetectDrift(ctx, refs)
 	if err != nil {
 		return nil, err
 	}
@@ -190,10 +197,10 @@ func (m *doModuleInstance) invokeProviderDetectDrift(args map[string]any) (map[s
 }
 
 // invokeProviderImport decodes resource_type + provider_id and calls IaCProvider.Import.
-func (m *doModuleInstance) invokeProviderImport(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderImport(ctx context.Context, args map[string]any) (map[string]any, error) {
 	resourceType := stringArg(args, "resource_type")
 	providerID := stringArg(args, "provider_id")
-	state, err := m.provider.Import(context.Background(), providerID, resourceType)
+	state, err := m.provider.Import(ctx, providerID, resourceType)
 	if err != nil {
 		return nil, err
 	}
@@ -220,12 +227,12 @@ func (m *doModuleInstance) invokeProviderResolveSizing(args map[string]any) (map
 
 // invokeProviderBootstrapStateBackend decodes the cfg map and calls
 // IaCProvider.BootstrapStateBackend, returning the result as a flat map.
-func (m *doModuleInstance) invokeProviderBootstrapStateBackend(args map[string]any) (map[string]any, error) {
+func (m *doModuleInstance) invokeProviderBootstrapStateBackend(ctx context.Context, args map[string]any) (map[string]any, error) {
 	cfg := args // args IS the cfg map (wfctl sends it unwrapped, matching Initialize convention)
 	if cfg == nil {
 		cfg = map[string]any{}
 	}
-	result, err := m.provider.BootstrapStateBackend(context.Background(), cfg)
+	result, err := m.provider.BootstrapStateBackend(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -233,6 +240,25 @@ func (m *doModuleInstance) invokeProviderBootstrapStateBackend(args map[string]a
 		return map[string]any{}, nil
 	}
 	return structToMap(result)
+}
+
+func (m *doModuleInstance) invokeProviderRepairDirtyMigration(ctx context.Context, args map[string]any) (map[string]any, error) {
+	repairer, ok := m.provider.(interfaces.ProviderMigrationRepairer)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not implement ProviderMigrationRepairer")
+	}
+	var req interfaces.MigrationRepairRequest
+	if err := decodeJSONField(args, "request", &req); err != nil {
+		return nil, fmt.Errorf("IaCProvider.RepairDirtyMigration: %w", err)
+	}
+	result, err := repairer.RepairDirtyMigration(ctx, req)
+	if result != nil {
+		return structToMap(result)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{}, nil
 }
 
 // invokeDriverUpdate decodes args and calls ResourceDriver.Update.

--- a/internal/module_instance_test.go
+++ b/internal/module_instance_test.go
@@ -2,10 +2,13 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // compile-time interface checks
@@ -765,6 +768,134 @@ func TestDoModuleInstance_InvokeMethod_BootstrapStateBackend_EndToEnd(t *testing
 	}
 }
 
+func TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_DispatchesToProvider(t *testing.T) {
+	fake := &fakeRepairProvider{
+		fakeIaCProvider: fakeIaCProvider{},
+		repairResult: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-123",
+			Status:        interfaces.MigrationRepairStatusSucceeded,
+			Applied:       []string{"20260426000006"},
+			Logs:          "repair complete",
+		},
+	}
+	mi := &doModuleInstance{provider: fake}
+
+	result, err := mi.InvokeMethod("IaCProvider.RepairDirtyMigration", map[string]any{
+		"request": map[string]any{
+			"app_resource_name":      "bmw-staging",
+			"database_resource_name": "bmw-staging-db",
+			"job_image":              "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+			"source_dir":             "/migrations",
+			"expected_dirty_version": "20260426000005",
+			"force_version":          "20260422000001",
+			"then_up":                true,
+			"confirm_force":          interfaces.MigrationRepairConfirmation,
+			"env":                    map[string]any{"DATABASE_URL": "postgres://example"},
+			"timeout_seconds":        float64(600),
+		},
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration dispatch: %v", err)
+	}
+	if !fake.repairCalled {
+		t.Fatal("RepairDirtyMigration was not called on provider")
+	}
+	if fake.repairReq.AppResourceName != "bmw-staging" {
+		t.Fatalf("AppResourceName = %q", fake.repairReq.AppResourceName)
+	}
+	if fake.repairReq.Env["DATABASE_URL"] != "postgres://example" {
+		t.Fatalf("DATABASE_URL was not decoded into request env")
+	}
+	if result["provider_job_id"] != "job-123" {
+		t.Fatalf("provider_job_id = %v", result["provider_job_id"])
+	}
+	if result["status"] != interfaces.MigrationRepairStatusSucceeded {
+		t.Fatalf("status = %v", result["status"])
+	}
+}
+
+func TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_Unsupported(t *testing.T) {
+	mi := &doModuleInstance{provider: &fakeIaCProvider{}}
+
+	_, err := mi.InvokeMethod("IaCProvider.RepairDirtyMigration", map[string]any{
+		"request": map[string]any{},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported error")
+	}
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %s, want %s", status.Code(err), codes.Unimplemented)
+	}
+}
+
+func TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_PreservesResultOnError(t *testing.T) {
+	fake := &fakeRepairProvider{
+		fakeIaCProvider: fakeIaCProvider{},
+		repairResult: &interfaces.MigrationRepairResult{
+			ProviderJobID: "job-running",
+			Status:        interfaces.MigrationRepairStatusFailed,
+			Logs:          "repair log tail",
+			Diagnostics: []interfaces.Diagnostic{{
+				ID:     "job-running",
+				Phase:  "cancel",
+				Cause:  "job invocation cancellation requested",
+				Detail: "app_id=app-123 deployment_id=dep-123",
+			}},
+		},
+		repairErr: errors.New("timed out waiting for migration repair job"),
+	}
+	mi := &doModuleInstance{provider: fake}
+
+	result, err := mi.InvokeMethod("IaCProvider.RepairDirtyMigration", map[string]any{
+		"request": map[string]any{
+			"app_resource_name":      "bmw-staging",
+			"database_resource_name": "bmw-staging-db",
+			"job_image":              "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+			"source_dir":             "/migrations",
+			"expected_dirty_version": "20260426000005",
+			"force_version":          "20260422000001",
+			"confirm_force":          interfaces.MigrationRepairConfirmation,
+		},
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration dispatch should preserve result without transport error, got %v", err)
+	}
+	if result["provider_job_id"] != "job-running" {
+		t.Fatalf("provider_job_id = %v, want job-running", result["provider_job_id"])
+	}
+	if result["status"] != interfaces.MigrationRepairStatusFailed {
+		t.Fatalf("status = %v, want failed", result["status"])
+	}
+	if result["logs"] != "repair log tail" {
+		t.Fatalf("logs = %v, want repair log tail", result["logs"])
+	}
+}
+
+func TestDoModuleInstance_InvokeMethodContext_RepairDirtyMigration_PropagatesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fake := &fakeRepairProvider{fakeIaCProvider: fakeIaCProvider{}}
+	mi := &doModuleInstance{provider: fake}
+
+	_, err := mi.InvokeMethodContext(ctx, "IaCProvider.RepairDirtyMigration", map[string]any{
+		"request": map[string]any{
+			"app_resource_name":      "bmw-staging",
+			"database_resource_name": "bmw-staging-db",
+			"job_image":              "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+			"source_dir":             "/migrations",
+			"expected_dirty_version": "20260426000005",
+			"force_version":          "20260422000001",
+			"confirm_force":          interfaces.MigrationRepairConfirmation,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if fake.repairContextErr == nil {
+		t.Fatal("expected canceled context to reach provider")
+	}
+}
+
 // ── stub driver ───────────────────────────────────────────────────────────────
 
 type stubResourceDriver struct {
@@ -918,4 +1049,23 @@ func (f *fakeIaCProvider) BootstrapStateBackend(_ context.Context, cfg map[strin
 	f.bootstrapCalled = true
 	f.bootstrapCfg = cfg
 	return f.bootstrapResult, nil
+}
+
+type fakeRepairProvider struct {
+	fakeIaCProvider
+	repairCalled     bool
+	repairReq        interfaces.MigrationRepairRequest
+	repairContextErr error
+	repairResult     *interfaces.MigrationRepairResult
+	repairErr        error
+}
+
+func (f *fakeRepairProvider) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+	f.repairCalled = true
+	f.repairReq = req
+	f.repairContextErr = ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return f.repairResult, f.repairErr
 }

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -13,6 +13,8 @@ import (
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // tokenSource implements oauth2.TokenSource for the godo client.
@@ -34,6 +36,7 @@ type DOProvider struct {
 }
 
 var _ interfaces.IaCProvider = (*DOProvider)(nil)
+var _ interfaces.ProviderMigrationRepairer = (*DOProvider)(nil)
 
 // NewDOProvider creates an uninitialised DOProvider.
 func NewDOProvider() *DOProvider {
@@ -111,6 +114,18 @@ func (p *DOProvider) ResourceDriver(resourceType string) (interfaces.ResourceDri
 		return nil, fmt.Errorf("digitalocean: unsupported resource type %q", resourceType)
 	}
 	return d, nil
+}
+
+func (p *DOProvider) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
+	driver, err := p.ResourceDriver("infra.container_service")
+	if err != nil {
+		return nil, err
+	}
+	repairer, ok := driver.(interfaces.ProviderMigrationRepairer)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "digitalocean: app platform driver does not implement migration repair")
+	}
+	return repairer.RepairDirtyMigration(ctx, req)
 }
 
 // doUnsupportedCanonicalKeys lists canonical keys that the DO plugin does not yet map.


### PR DESCRIPTION
## Summary
- upgrade the plugin to Workflow v0.19.0 provider migration repair interfaces
- add App Platform provider-executed dirty migration repair via generated pre-deploy jobs
- route `IaCProvider.RepairDirtyMigration` through the plugin boundary with caller context and failed-result diagnostics preserved
- add coverage for repair request validation, job API preflight, live-spec restore, generated job lookup, log collection, cancellation, and dispatch behavior

## Notes
- The App Platform API does not expose a CAS/ETag-style update primitive through godo for `AppUpdateRequest`, so repair rollback is best-effort: re-read live spec, remove only the exact generated job name, then update the app spec.
- Job invocation polling keys off the unique generated job name because DigitalOcean job invocation listing does not bind invocations back to a deployment candidate.

## Verification
- `GOWORK=off go test ./internal -run 'TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_PreservesResultOnError' -count=1`
- `GOWORK=off go test ./internal/drivers -run 'TestAppPlatformRepairDirtyMigration|TestWithoutMigrationRepairJobName' -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go test -race ./internal ./internal/drivers -count=1`

## TDD proof for dispatch result preservation
With fix reverted:

```text
$ GOWORK=off go test ./internal -run 'TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_PreservesResultOnError' -count=1
--- FAIL: TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_PreservesResultOnError (0.00s)
    module_instance_test.go:861: RepairDirtyMigration dispatch should preserve result without transport error, got timed out waiting for migration repair job
FAIL
```

With fix restored:

```text
$ GOWORK=off go test ./internal -run 'TestDoModuleInstance_InvokeMethod_RepairDirtyMigration_PreservesResultOnError' -count=1
ok  github.com/GoCodeAlone/workflow-plugin-digitalocean/internal
```
