### PR TITLE
fix: wait for app platform update deployments

### DIFF
--- a/internal/drivers/deploy.go
+++ b/internal/drivers/deploy.go
@@ -12,10 +12,13 @@ import (
 // AppDeployDriver implements module.DeployDriver for DigitalOcean App Platform.
 // It manages a single App Platform application identified by its app ID.
 type AppDeployDriver struct {
-	client  AppPlatformClient
-	region  string
-	appID   string
-	appName string
+	client                     AppPlatformClient
+	region                     string
+	appID                      string
+	appName                    string
+	targetDeploymentID         string
+	previousActiveDeploymentID string
+	waitingForDeployment       bool
 }
 
 // NewAppDeployDriver creates a DeployDriver backed by a DO App Platform app.
@@ -28,6 +31,7 @@ func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
 	if err != nil {
 		return fmt.Errorf("app deploy: get %q: %w", d.appName, err)
 	}
+	d.previousActiveDeploymentID = deploymentID(app.ActiveDeployment)
 	spec := app.Spec
 	for _, svc := range spec.Services {
 		if svc.Image != nil {
@@ -35,9 +39,12 @@ func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
 			svc.Image.Tag = imageTag(image)
 		}
 	}
-	if _, _, err := d.client.Update(ctx, d.appID, &godo.AppUpdateRequest{Spec: spec}); err != nil {
+	updated, _, err := d.client.Update(ctx, d.appID, &godo.AppUpdateRequest{Spec: spec})
+	if err != nil {
 		return fmt.Errorf("app deploy: update %q: %w", d.appName, err)
 	}
+	d.waitingForDeployment = true
+	d.targetDeploymentID = deploymentID(selectUpdateDeployment(updated, d.previousActiveDeploymentID))
 	return nil
 }
 
@@ -45,6 +52,16 @@ func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
 	app, _, err := d.client.Get(ctx, d.appID)
 	if err != nil {
 		return fmt.Errorf("app deploy: health check %q: %w", d.appName, err)
+	}
+	if d.waitingForDeployment {
+		dep, err := d.currentTargetDeployment(ctx, app)
+		if err != nil {
+			return err
+		}
+		if dep == nil {
+			return fmt.Errorf("app deploy: %q waiting for deployment after update", d.appName)
+		}
+		return deploymentHealthError(d.appName, dep)
 	}
 	if app.ActiveDeployment == nil || app.ActiveDeployment.Phase != godo.DeploymentPhase_Active {
 		phase := ""
@@ -54,6 +71,90 @@ func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
 		return fmt.Errorf("app deploy: %q not active (phase: %q)", d.appName, phase)
 	}
 	return nil
+}
+
+func (d *AppDeployDriver) currentTargetDeployment(ctx context.Context, app *godo.App) (*godo.Deployment, error) {
+	if dep := selectUpdateDeployment(app, d.previousActiveDeploymentID); dep != nil {
+		if d.targetDeploymentID == "" || dep.ID == d.targetDeploymentID {
+			d.targetDeploymentID = dep.ID
+			return dep, nil
+		}
+	}
+	deployments, _, err := d.client.ListDeployments(ctx, d.appID, &godo.ListOptions{Page: 1, PerPage: 20})
+	if err != nil {
+		return nil, fmt.Errorf("app deploy: list deployments %q: %w", d.appName, err)
+	}
+	for _, dep := range deployments {
+		if dep == nil {
+			continue
+		}
+		if d.targetDeploymentID != "" && dep.ID == d.targetDeploymentID {
+			return dep, nil
+		}
+		if d.targetDeploymentID == "" && isHistoricalUpdateDeployment(dep, d.previousActiveDeploymentID) {
+			d.targetDeploymentID = dep.ID
+			return dep, nil
+		}
+	}
+	return nil, nil
+}
+
+func deploymentHealthError(appName string, dep *godo.Deployment) error {
+	switch dep.Phase {
+	case godo.DeploymentPhase_Active:
+		return nil
+	case godo.DeploymentPhase_PendingBuild,
+		godo.DeploymentPhase_Building,
+		godo.DeploymentPhase_PendingDeploy,
+		godo.DeploymentPhase_Deploying:
+		return fmt.Errorf("app deploy: %q deployment in progress: %s (%s)", appName, dep.Phase, dep.ID)
+	case godo.DeploymentPhase_Error,
+		godo.DeploymentPhase_Canceled,
+		godo.DeploymentPhase_Superseded:
+		cause := dep.Cause
+		if cause == "" {
+			cause = string(dep.Phase)
+		}
+		return fmt.Errorf("app deploy: %q deployment failed: %s (%s): %s", appName, dep.Phase, dep.ID, cause)
+	default:
+		return fmt.Errorf("app deploy: %q deployment phase unknown: %s (%s)", appName, dep.Phase, dep.ID)
+	}
+}
+
+func selectUpdateDeployment(app *godo.App, previousActiveID string) *godo.Deployment {
+	if app == nil {
+		return nil
+	}
+	for _, dep := range []*godo.Deployment{app.InProgressDeployment, app.PendingDeployment, app.ActiveDeployment} {
+		if isNewerDeployment(dep, previousActiveID) {
+			return dep
+		}
+	}
+	return nil
+}
+
+func isNewerDeployment(dep *godo.Deployment, previousActiveID string) bool {
+	if dep == nil || dep.ID == "" {
+		return false
+	}
+	return dep.ID != previousActiveID || dep.PreviousDeploymentID == previousActiveID
+}
+
+func isHistoricalUpdateDeployment(dep *godo.Deployment, previousActiveID string) bool {
+	if dep == nil || dep.ID == "" {
+		return false
+	}
+	if previousActiveID == "" {
+		return true
+	}
+	return dep.PreviousDeploymentID == previousActiveID
+}
+
+func deploymentID(dep *godo.Deployment) string {
+	if dep == nil {
+		return ""
+	}
+	return dep.ID
 }
 
 func (d *AppDeployDriver) CurrentImage(ctx context.Context) (string, error) {
@@ -93,12 +194,15 @@ func (d *AppDeployDriver) ReplicaCount(ctx context.Context) (int, error) {
 // image (making blue the new stable), then DestroyBlue removes the green clone.
 // The green app's live URL is returned from GreenEndpoint.
 type AppBlueGreenDriver struct {
-	client    AppPlatformClient
-	region    string
-	blueID    string
-	blueName  string
-	greenID   string // set during CreateGreen
-	greenURL  string // set during CreateGreen
+	client      AppPlatformClient
+	region      string
+	blueID      string
+	blueName    string
+	greenID     string // set during CreateGreen
+	greenURL    string // set during CreateGreen
+	stableCheck bool
+	blueDeploy  *AppDeployDriver
+	greenDeploy *AppDeployDriver
 }
 
 // NewAppBlueGreenDriver creates a BlueGreenDriver for DO App Platform.
@@ -109,29 +213,22 @@ func NewAppBlueGreenDriver(c AppPlatformClient, region, blueID, blueName string)
 // DeployDriver methods delegate to the blue (stable) app.
 
 func (d *AppBlueGreenDriver) Update(ctx context.Context, image string) error {
-	stable := NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName)
-	return stable.Update(ctx, image)
+	return d.blueDriver().Update(ctx, image)
 }
 
 func (d *AppBlueGreenDriver) HealthCheck(ctx context.Context, path string) error {
-	target := d.greenID
-	name := d.blueName + "-green"
-	if target == "" {
-		target = d.blueID
-		name = d.blueName
+	if d.greenID != "" && !d.stableCheck {
+		return d.greenDriver().HealthCheck(ctx, path)
 	}
-	drv := NewAppDeployDriver(d.client, d.region, target, name)
-	return drv.HealthCheck(ctx, path)
+	return d.blueDriver().HealthCheck(ctx, path)
 }
 
 func (d *AppBlueGreenDriver) CurrentImage(ctx context.Context) (string, error) {
-	stable := NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName)
-	return stable.CurrentImage(ctx)
+	return d.blueDriver().CurrentImage(ctx)
 }
 
 func (d *AppBlueGreenDriver) ReplicaCount(ctx context.Context) (int, error) {
-	stable := NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName)
-	return stable.ReplicaCount(ctx)
+	return d.blueDriver().ReplicaCount(ctx)
 }
 
 // CreateGreen creates a new App Platform app with the "-green" name suffix and
@@ -157,6 +254,8 @@ func (d *AppBlueGreenDriver) CreateGreen(ctx context.Context, image string) erro
 	}
 	d.greenID = greenApp.ID
 	d.greenURL = greenApp.LiveURL
+	d.greenDeploy = NewAppDeployDriver(d.client, d.region, d.greenID, d.blueName+"-green")
+	d.stableCheck = false
 	return nil
 }
 
@@ -167,11 +266,15 @@ func (d *AppBlueGreenDriver) SwitchTraffic(ctx context.Context) error {
 	if d.greenID == "" {
 		return fmt.Errorf("app blue-green: CreateGreen must be called before SwitchTraffic")
 	}
-	greenImg, err := NewAppDeployDriver(d.client, d.region, d.greenID, d.blueName+"-green").CurrentImage(ctx)
+	greenImg, err := d.greenDriver().CurrentImage(ctx)
 	if err != nil {
 		return fmt.Errorf("app blue-green: get green image: %w", err)
 	}
-	return NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName).Update(ctx, greenImg)
+	if err := d.blueDriver().Update(ctx, greenImg); err != nil {
+		return err
+	}
+	d.stableCheck = true
+	return nil
 }
 
 // DestroyBlue deletes the green clone (the temporary environment).
@@ -193,6 +296,20 @@ func (d *AppBlueGreenDriver) GreenEndpoint(_ context.Context) (string, error) {
 	return d.greenURL, nil
 }
 
+func (d *AppBlueGreenDriver) blueDriver() *AppDeployDriver {
+	if d.blueDeploy == nil {
+		d.blueDeploy = NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName)
+	}
+	return d.blueDeploy
+}
+
+func (d *AppBlueGreenDriver) greenDriver() *AppDeployDriver {
+	if d.greenDeploy == nil {
+		d.greenDeploy = NewAppDeployDriver(d.client, d.region, d.greenID, d.blueName+"-green")
+	}
+	return d.greenDeploy
+}
+
 // ─── AppCanaryDriver ──────────────────────────────────────────────────────────
 
 // AppCanaryDriver implements module.CanaryDriver for DigitalOcean App Platform.
@@ -204,11 +321,13 @@ func (d *AppBlueGreenDriver) GreenEndpoint(_ context.Context) (string, error) {
 // CreateCanary, PromoteCanary, and DestroyCanary follow the standard
 // create/promote/delete pattern using two separate apps.
 type AppCanaryDriver struct {
-	client     AppPlatformClient
-	region     string
-	stableID   string
-	stableName string
-	canaryID   string // set during CreateCanary
+	client       AppPlatformClient
+	region       string
+	stableID     string
+	stableName   string
+	canaryID     string // set during CreateCanary
+	stableDeploy *AppDeployDriver
+	canaryDeploy *AppDeployDriver
 }
 
 // NewAppCanaryDriver creates a CanaryDriver for DO App Platform.
@@ -219,24 +338,22 @@ func NewAppCanaryDriver(c AppPlatformClient, region, stableID, stableName string
 // DeployDriver methods delegate to the stable app.
 
 func (d *AppCanaryDriver) Update(ctx context.Context, image string) error {
-	return NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName).Update(ctx, image)
+	return d.stableDriver().Update(ctx, image)
 }
 
 func (d *AppCanaryDriver) HealthCheck(ctx context.Context, path string) error {
-	target, name := d.stableID, d.stableName
 	if d.canaryID != "" {
-		target = d.canaryID
-		name = d.stableName + "-canary"
+		return d.canaryDriver().HealthCheck(ctx, path)
 	}
-	return NewAppDeployDriver(d.client, d.region, target, name).HealthCheck(ctx, path)
+	return d.stableDriver().HealthCheck(ctx, path)
 }
 
 func (d *AppCanaryDriver) CurrentImage(ctx context.Context) (string, error) {
-	return NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName).CurrentImage(ctx)
+	return d.stableDriver().CurrentImage(ctx)
 }
 
 func (d *AppCanaryDriver) ReplicaCount(ctx context.Context) (int, error) {
-	return NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName).ReplicaCount(ctx)
+	return d.stableDriver().ReplicaCount(ctx)
 }
 
 // CreateCanary creates a new App Platform app with the "-canary" name suffix
@@ -261,6 +378,7 @@ func (d *AppCanaryDriver) CreateCanary(ctx context.Context, image string) error 
 		return fmt.Errorf("app canary: create canary: %w", err)
 	}
 	d.canaryID = canaryApp.ID
+	d.canaryDeploy = NewAppDeployDriver(d.client, d.region, d.canaryID, d.stableName+"-canary")
 	return nil
 }
 
@@ -281,11 +399,11 @@ func (d *AppCanaryDriver) PromoteCanary(ctx context.Context) error {
 	if d.canaryID == "" {
 		return fmt.Errorf("app canary: CreateCanary must be called before PromoteCanary")
 	}
-	canaryImg, err := NewAppDeployDriver(d.client, d.region, d.canaryID, d.stableName+"-canary").CurrentImage(ctx)
+	canaryImg, err := d.canaryDriver().CurrentImage(ctx)
 	if err != nil {
 		return fmt.Errorf("app canary: get canary image: %w", err)
 	}
-	if err := NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName).Update(ctx, canaryImg); err != nil {
+	if err := d.stableDriver().Update(ctx, canaryImg); err != nil {
 		return fmt.Errorf("app canary: promote to stable: %w", err)
 	}
 	return d.DestroyCanary(ctx)
@@ -300,5 +418,20 @@ func (d *AppCanaryDriver) DestroyCanary(ctx context.Context) error {
 		return fmt.Errorf("app canary: destroy canary: %w", err)
 	}
 	d.canaryID = ""
+	d.canaryDeploy = nil
 	return nil
+}
+
+func (d *AppCanaryDriver) stableDriver() *AppDeployDriver {
+	if d.stableDeploy == nil {
+		d.stableDeploy = NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName)
+	}
+	return d.stableDeploy
+}
+
+func (d *AppCanaryDriver) canaryDriver() *AppDeployDriver {
+	if d.canaryDeploy == nil {
+		d.canaryDeploy = NewAppDeployDriver(d.client, d.region, d.canaryID, d.stableName+"-canary")
+	}
+	return d.canaryDeploy
 }

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -14,14 +14,19 @@ import (
 
 // deployMockClient supports stateful create/get/update/delete for deploy tests.
 type deployMockClient struct {
-	apps   map[string]*godo.App
-	err    error
-	nextID int
+	apps        map[string]*godo.App
+	deployments map[string][]*godo.Deployment
+	err         error
+	nextID      int
 }
 
 func newDeployMock() *deployMockClient {
 	// Start at 100 so seeded apps like "app-1" don't collide with generated IDs.
-	return &deployMockClient{apps: make(map[string]*godo.App), nextID: 100}
+	return &deployMockClient{
+		apps:        make(map[string]*godo.App),
+		deployments: make(map[string][]*godo.Deployment),
+		nextID:      100,
+	}
 }
 
 func (m *deployMockClient) Create(_ context.Context, req *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
@@ -83,8 +88,11 @@ func (m *deployMockClient) CreateDeployment(_ context.Context, _ string, _ ...*g
 	return &godo.Deployment{ID: "dep-deploy"}, nil, nil
 }
 
-func (m *deployMockClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
-	return nil, &godo.Response{}, m.err
+func (m *deployMockClient) ListDeployments(_ context.Context, appID string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	if m.err != nil {
+		return nil, &godo.Response{}, m.err
+	}
+	return m.deployments[appID], &godo.Response{}, nil
 }
 func (m *deployMockClient) Delete(_ context.Context, appID string) (*godo.Response, error) {
 	if m.err != nil {
@@ -120,6 +128,15 @@ func seedApp(m *deployMockClient, id, name, image string) *godo.App {
 	return app
 }
 
+func findAppExceptID(m *deployMockClient, id string) *godo.App {
+	for appID, app := range m.apps {
+		if appID != id {
+			return app
+		}
+	}
+	return nil
+}
+
 func splitImage(image string) (repo, tag string) {
 	parts := strings.SplitN(image, ":", 2)
 	if len(parts) == 2 {
@@ -144,6 +161,99 @@ func TestAppDeployDriver_Update(t *testing.T) {
 	}
 	if img != "registry.digitalocean.com/myrepo/myapp:v2" {
 		t.Errorf("CurrentImage = %q, want v2", img)
+	}
+}
+
+func TestAppDeployDriver_HealthCheck_WaitsForUpdateDeployment(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.ActiveDeployment.ID = "dep-old"
+	app.InProgressDeployment = &godo.Deployment{
+		ID:    "dep-new",
+		Phase: godo.DeploymentPhase_Building,
+	}
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "deployment in progress") ||
+		!strings.Contains(err.Error(), "dep-new") {
+		t.Fatalf("HealthCheck should wait for new deployment, got: %v", err)
+	}
+
+	app.InProgressDeployment = nil
+	app.ActiveDeployment = &godo.Deployment{
+		ID:    "dep-new",
+		Phase: godo.DeploymentPhase_Active,
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err != nil {
+		t.Fatalf("HealthCheck after new deployment active: %v", err)
+	}
+}
+
+func TestAppDeployDriver_HealthCheck_FailsUpdateDeploymentErrorDespiteOldActive(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.ActiveDeployment.ID = "dep-old"
+	app.InProgressDeployment = &godo.Deployment{
+		ID:    "dep-new",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "pre-deploy job failed",
+	}
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "deployment failed") ||
+		!strings.Contains(err.Error(), "pre-deploy job failed") {
+		t.Fatalf("HealthCheck should fail on update deployment error, got: %v", err)
+	}
+}
+
+func TestAppDeployDriver_HealthCheck_WaitsUntilNewDeploymentObserved(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.ActiveDeployment.ID = "dep-old"
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "waiting for deployment") {
+		t.Fatalf("HealthCheck should wait instead of passing old active deployment, got: %v", err)
+	}
+
+	m.deployments["app-1"] = []*godo.Deployment{{
+		ID:                   "dep-new",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-old",
+	}}
+	if err := d.HealthCheck(context.Background(), "/health"); err != nil {
+		t.Fatalf("HealthCheck after observed deployment active: %v", err)
+	}
+}
+
+func TestAppDeployDriver_HealthCheck_IgnoresUnrelatedHistoricalDeployments(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.ActiveDeployment.ID = "dep-old"
+	m.deployments["app-1"] = []*godo.Deployment{
+		{ID: "dep-unrelated", Phase: godo.DeploymentPhase_Active},
+		{ID: "dep-old", Phase: godo.DeploymentPhase_Active},
+	}
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "waiting for deployment") {
+		t.Fatalf("HealthCheck should ignore unrelated historical deployment, got: %v", err)
 	}
 }
 
@@ -249,6 +359,63 @@ func TestAppBlueGreenDriver_SwitchTraffic(t *testing.T) {
 	}
 }
 
+func TestAppBlueGreenDriver_SwitchTraffic_HealthCheckWaitsForBlueDeployment(t *testing.T) {
+	m := newDeployMock()
+	blue := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	blue.ActiveDeployment.ID = "dep-old"
+
+	d := drivers.NewAppBlueGreenDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.CreateGreen(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("CreateGreen: %v", err)
+	}
+	blue.InProgressDeployment = &godo.Deployment{ID: "dep-new", Phase: godo.DeploymentPhase_Building}
+	if err := d.SwitchTraffic(context.Background()); err != nil {
+		t.Fatalf("SwitchTraffic: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "deployment in progress") ||
+		!strings.Contains(err.Error(), "dep-new") {
+		t.Fatalf("HealthCheck should wait for switched blue deployment, got: %v", err)
+	}
+}
+
+func TestAppBlueGreenDriver_CreateGreenAfterSwitchChecksNewGreen(t *testing.T) {
+	m := newDeployMock()
+	blue := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	blue.ActiveDeployment.ID = "dep-old"
+
+	d := drivers.NewAppBlueGreenDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.CreateGreen(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("CreateGreen first: %v", err)
+	}
+	blue.InProgressDeployment = &godo.Deployment{ID: "dep-switch", Phase: godo.DeploymentPhase_Building}
+	if err := d.SwitchTraffic(context.Background()); err != nil {
+		t.Fatalf("SwitchTraffic: %v", err)
+	}
+	blue.InProgressDeployment = nil
+	blue.ActiveDeployment = &godo.Deployment{ID: "dep-switch", Phase: godo.DeploymentPhase_Active}
+	if err := d.HealthCheck(context.Background(), "/health"); err != nil {
+		t.Fatalf("HealthCheck after switch active: %v", err)
+	}
+
+	if err := d.DestroyBlue(context.Background()); err != nil {
+		t.Fatalf("DestroyBlue: %v", err)
+	}
+	if err := d.CreateGreen(context.Background(), "registry.digitalocean.com/myrepo/myapp:v3"); err != nil {
+		t.Fatalf("CreateGreen second: %v", err)
+	}
+	green := findAppExceptID(m, "app-1")
+	if green == nil {
+		t.Fatal("second green app missing")
+	}
+	green.ActiveDeployment = nil
+	green.InProgressDeployment = &godo.Deployment{ID: "dep-green-next", Phase: godo.DeploymentPhase_Building}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "not active") && !strings.Contains(err.Error(), "deployment in progress") {
+		t.Fatalf("HealthCheck should inspect second green deployment, got: %v", err)
+	}
+}
+
 func TestAppBlueGreenDriver_DestroyBlue(t *testing.T) {
 	m := newDeployMock()
 	seedApp(m, "app-1", "myapp", "image:v1")
@@ -350,6 +517,26 @@ func TestAppCanaryDriver_PromoteCanary(t *testing.T) {
 			tag = svc.Image.Tag
 		}
 		t.Errorf("after promote stable image tag = %q, want v2", tag)
+	}
+}
+
+func TestAppCanaryDriver_PromoteCanary_HealthCheckWaitsForStableDeployment(t *testing.T) {
+	m := newDeployMock()
+	stable := seedApp(m, "app-1", "myapp", "image:v1")
+	stable.ActiveDeployment.ID = "dep-old"
+
+	d := drivers.NewAppCanaryDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.CreateCanary(context.Background(), "image:v2"); err != nil {
+		t.Fatalf("CreateCanary: %v", err)
+	}
+	stable.InProgressDeployment = &godo.Deployment{ID: "dep-new", Phase: godo.DeploymentPhase_Building}
+	if err := d.PromoteCanary(context.Background()); err != nil {
+		t.Fatalf("PromoteCanary: %v", err)
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil ||
+		!strings.Contains(err.Error(), "deployment in progress") ||
+		!strings.Contains(err.Error(), "dep-new") {
+		t.Fatalf("HealthCheck should wait for promoted stable deployment, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- track the deployment produced by App Platform image/spec updates instead of accepting an older active deployment
- report in-progress, failed, canceled, superseded, and not-yet-observed update deployments as non-success states
- preserve deployment tracking through blue/green switch and canary promotion wrappers

## BMW prod deploy context
The failed prod job showed the DO migrate component failed with a dirty DB migration. This platform fix prevents wfctl/plugin-DO from reporting deploy success against the previously active app while the update/pre-deploy job is still running or failed.

## Verification
- `go test ./internal/drivers -count=1`
- `go test ./... -count=1`
- `git diff --check`

## Review
- Spec review: initial BLOCK resolved; final PASS
- Antagonistic code review: initial BLOCK resolved; final PASS