### PR TITLE
fix: avoid migration repair job name collisions

### DIFF
--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -25,6 +25,8 @@ var _ interfaces.ProviderMigrationRepairer = (*AppPlatformDriver)(nil)
 
 var migrationRepairHTTPClient = http.DefaultClient
 var migrationRepairPollInterval = 2 * time.Second
+var migrationRepairRandomRead = rand.Read
+var migrationRepairJobNameGenerator = migrationRepairJobName
 
 func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
 	if err := req.Validate(); err != nil {
@@ -50,11 +52,6 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 		return nil, fmt.Errorf("app platform migration repair %q: app is missing ID or spec", req.AppResourceName)
 	}
 
-	jobName := migrationRepairJobName()
-	job, err := migrationRepairJobSpec(jobName, req)
-	if err != nil {
-		return nil, err
-	}
 	if err := preflightMigrationRepairJobInvocations(operationCtx, client, app.ID); err != nil {
 		return nil, err
 	}
@@ -68,6 +65,14 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 	repairSpec, err := cloneAppSpec(liveApp.Spec)
 	if err != nil {
 		return nil, fmt.Errorf("app platform migration repair clone live spec %q: %w", req.AppResourceName, err)
+	}
+	jobName, err := migrationRepairJobNameAbsentFromJobs(repairSpec.Jobs)
+	if err != nil {
+		return nil, err
+	}
+	job, err := migrationRepairJobSpec(jobName, req)
+	if err != nil {
+		return nil, err
 	}
 	repairSpec.Jobs = append(repairSpec.Jobs, job)
 	restore := func(result *interfaces.MigrationRepairResult) (*interfaces.MigrationRepairResult, error) {
@@ -298,10 +303,29 @@ func withoutMigrationRepairJobName(jobs []*godo.AppJobSpec, name string) []*godo
 
 func migrationRepairJobName() string {
 	var token [6]byte
-	if _, err := rand.Read(token[:]); err == nil {
+	if _, err := migrationRepairRandomRead(token[:]); err == nil {
 		return migrationRepairJobPrefix + "-" + hex.EncodeToString(token[:])
 	}
-	return fmt.Sprintf("%s-%d", migrationRepairJobPrefix, time.Now().UnixNano())
+	return fmt.Sprintf("%s-%08x", migrationRepairJobPrefix, uint32(time.Now().UnixNano()))
+}
+
+func migrationRepairJobNameAbsentFromJobs(jobs []*godo.AppJobSpec) (string, error) {
+	for range 32 {
+		name := migrationRepairJobNameGenerator()
+		if !appSpecHasJobName(jobs, name) {
+			return name, nil
+		}
+	}
+	return "", errors.New("app platform migration repair: could not generate a unique temporary job name")
+}
+
+func appSpecHasJobName(jobs []*godo.AppJobSpec, name string) bool {
+	for _, job := range jobs {
+		if job != nil && job.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func preflightMigrationRepairJobInvocations(ctx context.Context, client appPlatformMigrationRepairClient, appID string) error {

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -647,7 +648,7 @@ func TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs(t *tes
 			Spec: &godo.AppSpec{
 				Name: "bmw-staging",
 				Jobs: []*godo.AppJobSpec{{
-					Name: "wfctl-migration-repair-other",
+					Name: migrationRepairJobPrefix + "-other",
 					Kind: godo.AppJobSpecKind_PreDeploy,
 				}},
 			},
@@ -676,11 +677,11 @@ func TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs(t *tes
 	if len(tempSpec.Jobs) != 2 {
 		t.Fatalf("temporary jobs = %d, want existing repair job plus this repair job", len(tempSpec.Jobs))
 	}
-	if tempSpec.Jobs[0].Name != "wfctl-migration-repair-other" {
+	if tempSpec.Jobs[0].Name != migrationRepairJobPrefix+"-other" {
 		t.Fatalf("existing repair job was not preserved: %+v", tempSpec.Jobs)
 	}
 	restoredSpec := client.updates[len(client.updates)-1].Spec
-	if len(restoredSpec.Jobs) != 1 || restoredSpec.Jobs[0].Name != "wfctl-migration-repair-other" {
+	if len(restoredSpec.Jobs) != 1 || restoredSpec.Jobs[0].Name != migrationRepairJobPrefix+"-other" {
 		t.Fatalf("restored jobs = %+v, want only other repair job preserved", restoredSpec.Jobs)
 	}
 }
@@ -749,6 +750,45 @@ func TestMigrationRepairJobNameFitsDigitalOceanLimit(t *testing.T) {
 		if len(name) > 32 {
 			t.Fatalf("job name length = %d for %q, want <= 32", len(name), name)
 		}
+	}
+}
+
+func TestMigrationRepairJobNameFallbackFitsDigitalOceanLimit(t *testing.T) {
+	originalRead := migrationRepairRandomRead
+	migrationRepairRandomRead = func([]byte) (int, error) {
+		return 0, errors.New("entropy unavailable")
+	}
+	t.Cleanup(func() {
+		migrationRepairRandomRead = originalRead
+	})
+
+	name := migrationRepairJobName()
+	if !strings.HasPrefix(name, migrationRepairJobPrefix+"-") {
+		t.Fatalf("job name = %q", name)
+	}
+	if len(name) > 32 {
+		t.Fatalf("job name length = %d for %q, want <= 32", len(name), name)
+	}
+}
+
+func TestMigrationRepairJobNameAbsentFromJobsRetriesCollisions(t *testing.T) {
+	originalGenerator := migrationRepairJobNameGenerator
+	names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
+	migrationRepairJobNameGenerator = func() string {
+		name := names[0]
+		names = names[1:]
+		return name
+	}
+	t.Cleanup(func() {
+		migrationRepairJobNameGenerator = originalGenerator
+	})
+
+	got, err := migrationRepairJobNameAbsentFromJobs([]*godo.AppJobSpec{{Name: "wfctl-mig-repair-collision"}})
+	if err != nil {
+		t.Fatalf("migrationRepairJobNameAbsentFromJobs() error = %v", err)
+	}
+	if got != "wfctl-mig-repair-available" {
+		t.Fatalf("migrationRepairJobNameAbsentFromJobs() = %q, want available candidate", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep fallback migration repair job names within DigitalOcean's 32-character job-name limit
- generate temporary repair job names after reading the live app spec and retry on existing job-name collisions
- update cleanup preservation coverage to use the current repair job prefix

## Verification
- `go test ./internal/drivers -run 'TestMigrationRepairJobName|TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs' -count=1`
- `go test ./...`
- `git diff --check`

## Context
This addresses adversarial review findings from the previous job-name limit PR before BMW consumes a new DigitalOcean plugin release for production migration repair.