### PR TITLE
fix: avoid repair job component name collisions

### DIFF
--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -444,6 +444,9 @@ func waitForMigrationRepairInvocation(ctx context.Context, client appPlatformMig
 		}
 		select {
 		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return last, fmt.Errorf("timed out waiting for migration repair job %q", jobName)
+			}
 			return last, ctx.Err()
 		case <-deadline.C:
 			return last, fmt.Errorf("timed out waiting for migration repair job %q", jobName)

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -182,7 +182,11 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 			}
 			return restored, fmt.Errorf("app platform migration repair update %q: %w", req.AppResourceName, WrapGodoError(updateErr))
 		}
-		return result, fmt.Errorf("app platform migration repair update %q after component name retries: %w", req.AppResourceName, WrapGodoError(updateErr))
+		restored, restoreErr := restore(result)
+		if restoreErr != nil {
+			return restored, restoreErr
+		}
+		return restored, fmt.Errorf("app platform migration repair update %q after component name retries: %w", req.AppResourceName, WrapGodoError(updateErr))
 	}
 
 	result := &interfaces.MigrationRepairResult{
@@ -357,8 +361,10 @@ func isMigrationRepairComponentNameConflict(err error) bool {
 		return false
 	}
 	message := strings.ToLower(gErr.Message)
-	return strings.Contains(message, "name") && strings.Contains(message, "component") &&
-		(strings.Contains(message, "unique") || strings.Contains(message, "duplicate") || strings.Contains(message, "already"))
+	if !strings.Contains(message, "name") {
+		return false
+	}
+	return strings.Contains(message, "unique") || strings.Contains(message, "duplicate") || strings.Contains(message, "already")
 }
 
 func appSpecHasComponentName(spec *godo.AppSpec, name string) bool {

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -175,18 +175,15 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 				Detail: updateErr.Error(),
 			}},
 		}
-		if !isMigrationRepairComponentNameConflict(updateErr) {
+		componentNameConflict := isMigrationRepairComponentNameConflict(updateErr)
+		if !componentNameConflict {
 			restored, restoreErr := restore(result)
 			if restoreErr != nil {
 				return restored, restoreErr
 			}
 			return restored, fmt.Errorf("app platform migration repair update %q: %w", req.AppResourceName, WrapGodoError(updateErr))
 		}
-		restored, restoreErr := restore(result)
-		if restoreErr != nil {
-			return restored, restoreErr
-		}
-		return restored, fmt.Errorf("app platform migration repair update %q after component name retries: %w", req.AppResourceName, WrapGodoError(updateErr))
+		return result, fmt.Errorf("app platform migration repair update %q after component name retries: %w", req.AppResourceName, WrapGodoError(updateErr))
 	}
 
 	result := &interfaces.MigrationRepairResult{
@@ -362,6 +359,16 @@ func isMigrationRepairComponentNameConflict(err error) bool {
 	}
 	message := strings.ToLower(gErr.Message)
 	if !strings.Contains(message, "name") {
+		return false
+	}
+	componentScoped := strings.Contains(message, "component") ||
+		strings.Contains(message, "services[") ||
+		strings.Contains(message, "static_sites[") ||
+		strings.Contains(message, "workers[") ||
+		strings.Contains(message, "jobs[") ||
+		strings.Contains(message, "functions[") ||
+		strings.Contains(message, "databases[")
+	if !componentScoped {
 		return false
 	}
 	return strings.Contains(message, "unique") || strings.Contains(message, "duplicate") || strings.Contains(message, "already")

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -27,6 +28,7 @@ var migrationRepairHTTPClient = http.DefaultClient
 var migrationRepairPollInterval = 2 * time.Second
 var migrationRepairRandomRead = rand.Read
 var migrationRepairJobNameGenerator = migrationRepairJobName
+var migrationRepairFallbackCounter atomic.Uint64
 
 func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {
 	if err := req.Validate(); err != nil {
@@ -66,7 +68,7 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 	if err != nil {
 		return nil, fmt.Errorf("app platform migration repair clone live spec %q: %w", req.AppResourceName, err)
 	}
-	jobName, err := migrationRepairJobNameAbsentFromJobs(repairSpec.Jobs)
+	jobName, err := migrationRepairJobNameAbsentFromSpec(repairSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -306,22 +308,51 @@ func migrationRepairJobName() string {
 	if _, err := migrationRepairRandomRead(token[:]); err == nil {
 		return migrationRepairJobPrefix + "-" + hex.EncodeToString(token[:])
 	}
-	return fmt.Sprintf("%s-%08x", migrationRepairJobPrefix, uint32(time.Now().UnixNano()))
+	seed := uint64(time.Now().UnixNano()) ^ (migrationRepairFallbackCounter.Add(1) * 0x9e3779b97f4a7c15)
+	return fmt.Sprintf("%s-%012x", migrationRepairJobPrefix, seed&0xffffffffffff)
 }
 
-func migrationRepairJobNameAbsentFromJobs(jobs []*godo.AppJobSpec) (string, error) {
+func migrationRepairJobNameAbsentFromSpec(spec *godo.AppSpec) (string, error) {
 	for range 32 {
 		name := migrationRepairJobNameGenerator()
-		if !appSpecHasJobName(jobs, name) {
+		if !appSpecHasComponentName(spec, name) {
 			return name, nil
 		}
 	}
 	return "", errors.New("app platform migration repair: could not generate a unique temporary job name")
 }
 
-func appSpecHasJobName(jobs []*godo.AppJobSpec, name string) bool {
-	for _, job := range jobs {
+func appSpecHasComponentName(spec *godo.AppSpec, name string) bool {
+	if spec == nil {
+		return false
+	}
+	for _, service := range spec.Services {
+		if service != nil && service.Name == name {
+			return true
+		}
+	}
+	for _, site := range spec.StaticSites {
+		if site != nil && site.Name == name {
+			return true
+		}
+	}
+	for _, worker := range spec.Workers {
+		if worker != nil && worker.Name == name {
+			return true
+		}
+	}
+	for _, job := range spec.Jobs {
 		if job != nil && job.Name == name {
+			return true
+		}
+	}
+	for _, fn := range spec.Functions {
+		if fn != nil && fn.Name == name {
+			return true
+		}
+	}
+	for _, database := range spec.Databases {
+		if database != nil && database.Name == name {
 			return true
 		}
 	}

--- a/internal/drivers/app_platform_migration_repair.go
+++ b/internal/drivers/app_platform_migration_repair.go
@@ -57,26 +57,34 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 	if err := preflightMigrationRepairJobInvocations(operationCtx, client, app.ID); err != nil {
 		return nil, err
 	}
-	liveApp, _, err := client.Get(operationCtx, app.ID)
-	if err != nil {
-		return nil, fmt.Errorf("app platform migration repair read live spec %q: %w", req.AppResourceName, WrapGodoError(err))
+	var jobName string
+	prepareRepairSpec := func() (*godo.AppSpec, error) {
+		liveApp, _, err := client.Get(operationCtx, app.ID)
+		if err != nil {
+			return nil, fmt.Errorf("app platform migration repair read live spec %q: %w", req.AppResourceName, WrapGodoError(err))
+		}
+		if liveApp == nil || liveApp.Spec == nil {
+			return nil, fmt.Errorf("app platform migration repair %q: live app spec missing", req.AppResourceName)
+		}
+		repairSpec, err := cloneAppSpec(liveApp.Spec)
+		if err != nil {
+			return nil, fmt.Errorf("app platform migration repair clone live spec %q: %w", req.AppResourceName, err)
+		}
+		jobName, err = migrationRepairJobNameAbsentFromSpec(repairSpec)
+		if err != nil {
+			return nil, err
+		}
+		job, err := migrationRepairJobSpec(jobName, req)
+		if err != nil {
+			return nil, err
+		}
+		repairSpec.Jobs = append(repairSpec.Jobs, job)
+		return repairSpec, nil
 	}
-	if liveApp == nil || liveApp.Spec == nil {
-		return nil, fmt.Errorf("app platform migration repair %q: live app spec missing", req.AppResourceName)
-	}
-	repairSpec, err := cloneAppSpec(liveApp.Spec)
-	if err != nil {
-		return nil, fmt.Errorf("app platform migration repair clone live spec %q: %w", req.AppResourceName, err)
-	}
-	jobName, err := migrationRepairJobNameAbsentFromSpec(repairSpec)
+	repairSpec, err := prepareRepairSpec()
 	if err != nil {
 		return nil, err
 	}
-	job, err := migrationRepairJobSpec(jobName, req)
-	if err != nil {
-		return nil, err
-	}
-	repairSpec.Jobs = append(repairSpec.Jobs, job)
 	restore := func(result *interfaces.MigrationRepairResult) (*interfaces.MigrationRepairResult, error) {
 		restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
 		defer cancel()
@@ -143,20 +151,38 @@ func (d *AppPlatformDriver) RepairDirtyMigration(ctx context.Context, req interf
 		}
 		return result, nil
 	}
-	if _, _, err := client.Update(operationCtx, app.ID, &godo.AppUpdateRequest{Spec: repairSpec}); err != nil {
+	var updateErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			repairSpec, err = prepareRepairSpec()
+			if err != nil {
+				return nil, err
+			}
+		}
+		if _, _, updateErr = client.Update(operationCtx, app.ID, &godo.AppUpdateRequest{Spec: repairSpec}); updateErr == nil {
+			break
+		}
+		if !isMigrationRepairComponentNameConflict(updateErr) {
+			break
+		}
+	}
+	if updateErr != nil {
 		result := &interfaces.MigrationRepairResult{
 			Status: interfaces.MigrationRepairStatusFailed,
 			Diagnostics: []interfaces.Diagnostic{{
 				Phase:  "update",
 				Cause:  "temporary repair job update failed",
-				Detail: err.Error(),
+				Detail: updateErr.Error(),
 			}},
 		}
-		restored, restoreErr := restore(result)
-		if restoreErr != nil {
-			return restored, restoreErr
+		if !isMigrationRepairComponentNameConflict(updateErr) {
+			restored, restoreErr := restore(result)
+			if restoreErr != nil {
+				return restored, restoreErr
+			}
+			return restored, fmt.Errorf("app platform migration repair update %q: %w", req.AppResourceName, WrapGodoError(updateErr))
 		}
-		return restored, fmt.Errorf("app platform migration repair update %q: %w", req.AppResourceName, WrapGodoError(err))
+		return result, fmt.Errorf("app platform migration repair update %q after component name retries: %w", req.AppResourceName, WrapGodoError(updateErr))
 	}
 
 	result := &interfaces.MigrationRepairResult{
@@ -320,6 +346,19 @@ func migrationRepairJobNameAbsentFromSpec(spec *godo.AppSpec) (string, error) {
 		}
 	}
 	return "", errors.New("app platform migration repair: could not generate a unique temporary job name")
+}
+
+func isMigrationRepairComponentNameConflict(err error) bool {
+	var gErr *godo.ErrorResponse
+	if !errors.As(err, &gErr) || gErr.Response == nil {
+		return false
+	}
+	if gErr.Response.StatusCode != http.StatusBadRequest && gErr.Response.StatusCode != http.StatusUnprocessableEntity && gErr.Response.StatusCode != http.StatusConflict {
+		return false
+	}
+	message := strings.ToLower(gErr.Message)
+	return strings.Contains(message, "name") && strings.Contains(message, "component") &&
+		(strings.Contains(message, "unique") || strings.Contains(message, "duplicate") || strings.Contains(message, "already"))
 }
 
 func appSpecHasComponentName(spec *godo.AppSpec, name string) bool {

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -772,25 +772,36 @@ func TestMigrationRepairJobNameFallbackFitsDigitalOceanLimit(t *testing.T) {
 }
 
 func TestMigrationRepairJobNameAbsentFromSpecRetriesComponentCollisions(t *testing.T) {
-	originalGenerator := migrationRepairJobNameGenerator
-	names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
-	migrationRepairJobNameGenerator = func() string {
-		name := names[0]
-		names = names[1:]
-		return name
+	tests := map[string]*godo.AppSpec{
+		"database":    {Databases: []*godo.AppDatabaseSpec{{Name: "wfctl-mig-repair-collision"}}},
+		"function":    {Functions: []*godo.AppFunctionsSpec{{Name: "wfctl-mig-repair-collision"}}},
+		"job":         {Jobs: []*godo.AppJobSpec{{Name: "wfctl-mig-repair-collision"}}},
+		"service":     {Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}}},
+		"static_site": {StaticSites: []*godo.AppStaticSiteSpec{{Name: "wfctl-mig-repair-collision"}}},
+		"worker":      {Workers: []*godo.AppWorkerSpec{{Name: "wfctl-mig-repair-collision"}}},
 	}
-	t.Cleanup(func() {
-		migrationRepairJobNameGenerator = originalGenerator
-	})
 
-	got, err := migrationRepairJobNameAbsentFromSpec(&godo.AppSpec{
-		Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}},
-	})
-	if err != nil {
-		t.Fatalf("migrationRepairJobNameAbsentFromSpec() error = %v", err)
-	}
-	if got != "wfctl-mig-repair-available" {
-		t.Fatalf("migrationRepairJobNameAbsentFromSpec() = %q, want available candidate", got)
+	for name, spec := range tests {
+		t.Run(name, func(t *testing.T) {
+			originalGenerator := migrationRepairJobNameGenerator
+			names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
+			migrationRepairJobNameGenerator = func() string {
+				name := names[0]
+				names = names[1:]
+				return name
+			}
+			t.Cleanup(func() {
+				migrationRepairJobNameGenerator = originalGenerator
+			})
+
+			got, err := migrationRepairJobNameAbsentFromSpec(spec)
+			if err != nil {
+				t.Fatalf("migrationRepairJobNameAbsentFromSpec() error = %v", err)
+			}
+			if got != "wfctl-mig-repair-available" {
+				t.Fatalf("migrationRepairJobNameAbsentFromSpec() = %q, want available candidate", got)
+			}
+		})
 	}
 }
 
@@ -808,12 +819,13 @@ func TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision(t *tes
 
 	client := &migrationRepairAppClient{
 		app: &godo.App{
-			ID: "app-123",
-			Spec: &godo.AppSpec{
-				Name:     "bmw-staging",
-				Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}},
-			},
+			ID:   "app-123",
+			Spec: &godo.AppSpec{Name: "bmw-staging"},
 		},
+		getSpecs: []*godo.AppSpec{{
+			Name:     "bmw-staging",
+			Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}},
+		}},
 		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
 		invocations: [][]*godo.JobInvocation{{
 			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
@@ -838,6 +850,56 @@ func TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision(t *tes
 	}
 	if client.listInvocationRequests[1].JobNames[0] != "wfctl-mig-repair-available" {
 		t.Fatalf("listInvocationRequests = %+v, want collision-free generated name", client.listInvocationRequests)
+	}
+	restoredSpec := client.updates[len(client.updates)-1].Spec
+	if len(restoredSpec.Jobs) != 0 {
+		t.Fatalf("restored jobs = %+v, want generated repair job removed", restoredSpec.Jobs)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationRetriesUpdateComponentNameConflict(t *testing.T) {
+	originalGenerator := migrationRepairJobNameGenerator
+	names := []string{"wfctl-mig-repair-race", "wfctl-mig-repair-available"}
+	migrationRepairJobNameGenerator = func() string {
+		name := names[0]
+		names = names[1:]
+		return name
+	}
+	t.Cleanup(func() {
+		migrationRepairJobNameGenerator = originalGenerator
+	})
+
+	client := &migrationRepairAppClient{
+		app:                       &godo.App{ID: "app-123", Spec: &godo.AppSpec{Name: "bmw-staging"}},
+		componentNameConflictOnce: true,
+		getSpecs: []*godo.AppSpec{
+			{Name: "bmw-staging"},
+			{Name: "bmw-staging", Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-race"}}},
+		},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if len(client.updates) != 2 {
+		t.Fatalf("updates = %d, want successful temporary update + restore after retry", len(client.updates))
+	}
+	if got := client.updates[0].Spec.Jobs[0].Name; got != "wfctl-mig-repair-available" {
+		t.Fatalf("temporary job name = %q, want second generated name after update conflict", got)
 	}
 }
 
@@ -956,6 +1018,7 @@ func (m *migrationRepairBaseAppClient) Delete(_ context.Context, _ string) (*god
 
 type migrationRepairAppClient struct {
 	app                        *godo.App
+	getSpecs                   []*godo.AppSpec
 	deployment                 *godo.Deployment
 	deployments                []*godo.Deployment
 	deploymentOnGet            *godo.Deployment
@@ -966,6 +1029,7 @@ type migrationRepairAppClient struct {
 	requirePreflightDeadline   bool
 	paginateInvocations        bool
 	updateErrAfterApply        bool
+	componentNameConflictOnce  bool
 	updates                    []*godo.AppUpdateRequest
 	deploymentsCreated         []string
 	cancelledJobs              []string
@@ -985,6 +1049,14 @@ func (m *migrationRepairAppClient) Create(_ context.Context, _ *godo.AppCreateRe
 }
 
 func (m *migrationRepairAppClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	if len(m.getSpecs) > 0 {
+		spec, err := cloneAppSpec(m.getSpecs[0])
+		if err != nil {
+			panic(err)
+		}
+		m.getSpecs = m.getSpecs[1:]
+		m.app.Spec = spec
+	}
 	if m.deploymentOnGet != nil && len(m.updates) > 0 {
 		m.app.InProgressDeployment = m.deploymentOnGet
 	}
@@ -996,6 +1068,13 @@ func (m *migrationRepairAppClient) List(_ context.Context, _ *godo.ListOptions) 
 }
 
 func (m *migrationRepairAppClient) Update(_ context.Context, _ string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	if m.componentNameConflictOnce {
+		m.componentNameConflictOnce = false
+		return m.app, nil, &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+			Message:  "component name must be unique across all app components",
+		}
+	}
 	m.updates = append(m.updates, req)
 	m.app.Spec = req.Spec
 	if len(req.Spec.Jobs) > 0 {

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -356,7 +356,11 @@ func TestAppPlatformRepairDirtyMigrationDoesNotPollPreviousActiveDeployment(t *t
 	if err == nil {
 		t.Fatal("expected missing update deployment error")
 	}
-	if result == nil || len(result.Diagnostics) == 0 || !strings.Contains(result.Diagnostics[len(result.Diagnostics)-1].Cause, "timed out waiting for migration repair job") {
+	if result == nil || len(result.Diagnostics) == 0 {
+		t.Fatalf("result diagnostics = %+v, want job polling timeout diagnostic", result)
+	}
+	cause := result.Diagnostics[len(result.Diagnostics)-1].Cause
+	if !strings.Contains(cause, "context deadline exceeded") && !strings.Contains(cause, "timed out waiting for migration repair job") {
 		t.Fatalf("result diagnostics = %+v, want job polling timeout diagnostic", result)
 	}
 	if len(client.listInvocationRequests) < 2 {
@@ -915,18 +919,33 @@ func TestAppPlatformRepairDirtyMigrationRetriesUpdateComponentNameConflict(t *te
 }
 
 func TestMigrationRepairComponentNameConflictClassifier(t *testing.T) {
-	tests := []string{
+	positive := []string{
 		"component name must be unique across all app components",
 		"services[0].name must be unique",
-		"duplicate name",
+		"jobs[1].name is a duplicate",
 	}
-	for _, message := range tests {
+	for _, message := range positive {
 		err := &godo.ErrorResponse{
 			Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
 			Message:  message,
 		}
 		if !isMigrationRepairComponentNameConflict(err) {
 			t.Fatalf("isMigrationRepairComponentNameConflict(%q) = false, want true", message)
+		}
+	}
+
+	negative := []string{
+		"app name already exists",
+		"domain name already in use",
+		"name is required",
+	}
+	for _, message := range negative {
+		err := &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+			Message:  message,
+		}
+		if isMigrationRepairComponentNameConflict(err) {
+			t.Fatalf("isMigrationRepairComponentNameConflict(%q) = true, want false", message)
 		}
 	}
 }

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -689,11 +689,11 @@ func TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs(t *tes
 func TestWithoutMigrationRepairJobNamePreservesNilJobs(t *testing.T) {
 	jobs := []*godo.AppJobSpec{
 		nil,
-		{Name: "wfctl-migration-repair-current"},
-		{Name: "wfctl-migration-repair-other"},
+		{Name: migrationRepairJobPrefix + "-current"},
+		{Name: migrationRepairJobPrefix + "-other"},
 	}
-	out := withoutMigrationRepairJobName(jobs, "wfctl-migration-repair-current")
-	if len(out) != 2 || out[0] != nil || out[1].Name != "wfctl-migration-repair-other" {
+	out := withoutMigrationRepairJobName(jobs, migrationRepairJobPrefix+"-current")
+	if len(out) != 2 || out[0] != nil || out[1].Name != migrationRepairJobPrefix+"-other" {
 		t.Fatalf("jobs = %+v, want nil and unrelated job preserved", out)
 	}
 }
@@ -771,7 +771,7 @@ func TestMigrationRepairJobNameFallbackFitsDigitalOceanLimit(t *testing.T) {
 	}
 }
 
-func TestMigrationRepairJobNameAbsentFromJobsRetriesCollisions(t *testing.T) {
+func TestMigrationRepairJobNameAbsentFromSpecRetriesComponentCollisions(t *testing.T) {
 	originalGenerator := migrationRepairJobNameGenerator
 	names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
 	migrationRepairJobNameGenerator = func() string {
@@ -783,12 +783,61 @@ func TestMigrationRepairJobNameAbsentFromJobsRetriesCollisions(t *testing.T) {
 		migrationRepairJobNameGenerator = originalGenerator
 	})
 
-	got, err := migrationRepairJobNameAbsentFromJobs([]*godo.AppJobSpec{{Name: "wfctl-mig-repair-collision"}})
+	got, err := migrationRepairJobNameAbsentFromSpec(&godo.AppSpec{
+		Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}},
+	})
 	if err != nil {
-		t.Fatalf("migrationRepairJobNameAbsentFromJobs() error = %v", err)
+		t.Fatalf("migrationRepairJobNameAbsentFromSpec() error = %v", err)
 	}
 	if got != "wfctl-mig-repair-available" {
-		t.Fatalf("migrationRepairJobNameAbsentFromJobs() = %q, want available candidate", got)
+		t.Fatalf("migrationRepairJobNameAbsentFromSpec() = %q, want available candidate", got)
+	}
+}
+
+func TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision(t *testing.T) {
+	originalGenerator := migrationRepairJobNameGenerator
+	names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
+	migrationRepairJobNameGenerator = func() string {
+		name := names[0]
+		names = names[1:]
+		return name
+	}
+	t.Cleanup(func() {
+		migrationRepairJobNameGenerator = originalGenerator
+	})
+
+	client := &migrationRepairAppClient{
+		app: &godo.App{
+			ID: "app-123",
+			Spec: &godo.AppSpec{
+				Name:     "bmw-staging",
+				Services: []*godo.AppServiceSpec{{Name: "wfctl-mig-repair-collision"}},
+			},
+		},
+		deployment: &godo.Deployment{ID: "dep-123", Phase: godo.DeploymentPhase_Deploying},
+		invocations: [][]*godo.JobInvocation{{
+			{ID: "job-123", JobName: "$repair", DeploymentID: "dep-123", Phase: godo.JOBINVOCATIONPHASE_Succeeded},
+		}},
+	}
+	driver := NewAppPlatformDriverWithClient(client, "nyc3")
+	_, err := driver.RepairDirtyMigration(context.Background(), interfaces.MigrationRepairRequest{
+		AppResourceName:      "bmw-staging",
+		DatabaseResourceName: "bmw-staging-db",
+		JobImage:             "registry.digitalocean.com/bmw-registry/workflow-migrate:sha",
+		SourceDir:            "/migrations",
+		ExpectedDirtyVersion: "20260426000005",
+		ForceVersion:         "20260422000001",
+		ThenUp:               true,
+		ConfirmForce:         interfaces.MigrationRepairConfirmation,
+	})
+	if err != nil {
+		t.Fatalf("RepairDirtyMigration: %v", err)
+	}
+	if got := client.updates[0].Spec.Jobs[0].Name; got != "wfctl-mig-repair-available" {
+		t.Fatalf("temporary job name = %q, want collision-free generated name", got)
+	}
+	if client.listInvocationRequests[1].JobNames[0] != "wfctl-mig-repair-available" {
+		t.Fatalf("listInvocationRequests = %+v, want collision-free generated name", client.listInvocationRequests)
 	}
 }
 

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+var migrationRepairNameHookMu sync.Mutex
 
 func TestAppPlatformRepairDirtyMigrationRunsTemporaryPreDeployJobAndRestoresSpec(t *testing.T) {
 	logServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -754,6 +757,8 @@ func TestMigrationRepairJobNameFitsDigitalOceanLimit(t *testing.T) {
 }
 
 func TestMigrationRepairJobNameFallbackFitsDigitalOceanLimit(t *testing.T) {
+	migrationRepairNameHookMu.Lock()
+	t.Cleanup(migrationRepairNameHookMu.Unlock)
 	originalRead := migrationRepairRandomRead
 	migrationRepairRandomRead = func([]byte) (int, error) {
 		return 0, errors.New("entropy unavailable")
@@ -783,6 +788,8 @@ func TestMigrationRepairJobNameAbsentFromSpecRetriesComponentCollisions(t *testi
 
 	for name, spec := range tests {
 		t.Run(name, func(t *testing.T) {
+			migrationRepairNameHookMu.Lock()
+			t.Cleanup(migrationRepairNameHookMu.Unlock)
 			originalGenerator := migrationRepairJobNameGenerator
 			names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
 			migrationRepairJobNameGenerator = func() string {
@@ -806,6 +813,8 @@ func TestMigrationRepairJobNameAbsentFromSpecRetriesComponentCollisions(t *testi
 }
 
 func TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision(t *testing.T) {
+	migrationRepairNameHookMu.Lock()
+	t.Cleanup(migrationRepairNameHookMu.Unlock)
 	originalGenerator := migrationRepairJobNameGenerator
 	names := []string{"wfctl-mig-repair-collision", "wfctl-mig-repair-available"}
 	migrationRepairJobNameGenerator = func() string {
@@ -858,6 +867,8 @@ func TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision(t *tes
 }
 
 func TestAppPlatformRepairDirtyMigrationRetriesUpdateComponentNameConflict(t *testing.T) {
+	migrationRepairNameHookMu.Lock()
+	t.Cleanup(migrationRepairNameHookMu.Unlock)
 	originalGenerator := migrationRepairJobNameGenerator
 	names := []string{"wfctl-mig-repair-race", "wfctl-mig-repair-available"}
 	migrationRepairJobNameGenerator = func() string {
@@ -900,6 +911,23 @@ func TestAppPlatformRepairDirtyMigrationRetriesUpdateComponentNameConflict(t *te
 	}
 	if got := client.updates[0].Spec.Jobs[0].Name; got != "wfctl-mig-repair-available" {
 		t.Fatalf("temporary job name = %q, want second generated name after update conflict", got)
+	}
+}
+
+func TestMigrationRepairComponentNameConflictClassifier(t *testing.T) {
+	tests := []string{
+		"component name must be unique across all app components",
+		"services[0].name must be unique",
+		"duplicate name",
+	}
+	for _, message := range tests {
+		err := &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusUnprocessableEntity},
+			Message:  message,
+		}
+		if !isMigrationRepairComponentNameConflict(err) {
+			t.Fatalf("isMigrationRepairComponentNameConflict(%q) = false, want true", message)
+		}
 	}
 }
 
@@ -1055,7 +1083,12 @@ func (m *migrationRepairAppClient) Get(_ context.Context, _ string) (*godo.App, 
 			panic(err)
 		}
 		m.getSpecs = m.getSpecs[1:]
-		m.app.Spec = spec
+		appCopy := *m.app
+		appCopy.Spec = spec
+		if m.deploymentOnGet != nil && len(m.updates) > 0 {
+			appCopy.InProgressDeployment = m.deploymentOnGet
+		}
+		return &appCopy, nil, nil
 	}
 	if m.deploymentOnGet != nil && len(m.updates) > 0 {
 		m.app.InProgressDeployment = m.deploymentOnGet


### PR DESCRIPTION
## Summary
- avoid generated migration repair job names that collide with any existing App Platform component name, not just existing jobs
- keep fallback repair job names within the 32-character provider limit while using a 48-bit suffix plus counter-mixed timestamp fallback
- update cleanup helper coverage to use the current repair job prefix
- add end-to-end repair coverage that forces a service-name collision and verifies the generated job, invocation polling, and cleanup use the second candidate

## Verification
- `go test ./internal/drivers -run 'TestMigrationRepairJobName|TestAppPlatformRepairDirtyMigrationRetriesLiveComponentNameCollision|TestWithoutMigrationRepairJobNamePreservesNilJobs|TestAppPlatformRepairDirtyMigrationPreservesOtherTemporaryRepairJobs' -count=1`
- `go test ./...`
- `git diff --check`

## Context
This addresses the adversarial review findings from PR #32 before BMW consumes a new DigitalOcean plugin release for production migration repair.