### PR TITLE
feat(do-plugin): expose http_port_protocol for gRPC services (F5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to workflow-plugin-digitalocean are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`http_port_protocol` canonical key + `protocol: grpc` alias (P-2.F5)** —
+  App Platform services now honor an explicit `http_port_protocol` config key
+  that maps to `godo.AppServiceSpec.Protocol` (godo v1.178.0 `apps.gen.go:568`).
+  The historic `protocol` shorthand still works and gains a `grpc` alias that
+  resolves to `HTTP2` (gRPC requires HTTP/2 with prior knowledge per DO docs).
+  When both keys are set, `http_port_protocol` takes precedence.
+
 ## [v0.7.9] - 2026-04-24
 
 ### Added

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -124,16 +124,27 @@ func instanceSizeSlugFromConfig(cfg map[string]any) string {
 // Two canonical keys are accepted:
 //
 //   - "http_port_protocol" — explicit, mirrors the DO App Platform API field
-//     name. Takes precedence when both keys are set.
-//   - "protocol" — historic shorthand. Recognized aliases: "grpc" → HTTP2
+//     name. Takes precedence by KEY PRESENCE: if the key is set in cfg (even
+//     to an empty string), its value is honored and the shorthand is NOT
+//     consulted. This makes `http_port_protocol: ""` an explicit opt-out
+//     rather than a silent fallthrough.
+//   - "protocol" — historic shorthand. Consulted only when
+//     "http_port_protocol" is absent. Recognized aliases: "grpc" → HTTP2
 //     (gRPC requires HTTP/2 with prior knowledge per DO docs).
 //
 // DO recognizes HTTP and HTTP2; unknown values pass through for forward
 // compatibility with future godo releases.
 func httpPortProtocolFromConfig(cfg map[string]any) godo.ServingProtocol {
-	// Explicit canonical key wins over the shorthand.
-	raw := strFromConfig(cfg, "http_port_protocol", "")
-	if raw == "" {
+	// Key presence — not value emptiness — decides precedence, so that an
+	// explicit `http_port_protocol: ""` does NOT fall through to `protocol`.
+	var raw string
+	if v, ok := cfg["http_port_protocol"]; ok {
+		// If present but not a string (or explicitly empty), raw stays "" —
+		// which the switch below treats as "no protocol override".
+		if s, ok := v.(string); ok {
+			raw = s
+		}
+	} else {
 		raw = strFromConfig(cfg, "protocol", "")
 	}
 	switch strings.ToUpper(raw) {

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -121,13 +121,13 @@ func instanceSizeSlugFromConfig(cfg map[string]any) string {
 // httpPortProtocolFromConfig maps the canonical port protocol to a godo.ServingProtocol
 // on godo.AppServiceSpec.Protocol (godo v1.178.0 apps.gen.go:568).
 //
-// Two canonical keys are accepted:
+// Two config keys are accepted:
 //
-//   - "http_port_protocol" — explicit, mirrors the DO App Platform API field
-//     name. Takes precedence by KEY PRESENCE: if the key is set in cfg (even
-//     to an empty string), its value is honored and the shorthand is NOT
-//     consulted. This makes `http_port_protocol: ""` an explicit opt-out
-//     rather than a silent fallthrough.
+//   - "http_port_protocol" — the canonical key, mirrors the DO App Platform
+//     API field name. Takes precedence by KEY PRESENCE: if the key is set in
+//     cfg (even to an empty string), its value is honored and the shorthand
+//     is NOT consulted. This makes `http_port_protocol: ""` an explicit
+//     opt-out rather than a silent fallthrough.
 //   - "protocol" — historic shorthand. Consulted only when
 //     "http_port_protocol" is absent. Recognized aliases: "grpc" → HTTP2
 //     (gRPC requires HTTP/2 with prior knowledge per DO docs).

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -38,7 +38,7 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		DockerfilePath:      strFromConfig(cfg, "dockerfile_path", ""),
 		SourceDir:           strFromConfig(cfg, "source_dir", ""),
 		InstanceSizeSlug:    instanceSizeSlugFromConfig(cfg),
-		Protocol:            servingProtocolFromConfig(cfg),
+		Protocol:            httpPortProtocolFromConfig(cfg),
 		InternalPorts:       internalPortsFromConfig(cfg),
 		Routes:              routesFromConfig(cfg),
 		HealthCheck:         serviceHealthCheckFromConfig(cfg),
@@ -118,17 +118,32 @@ func instanceSizeSlugFromConfig(cfg map[string]any) string {
 	return ""
 }
 
-// servingProtocolFromConfig maps canonical "protocol" to a godo.ServingProtocol.
-// DO supports HTTP and HTTP2; unknown values are passed through for forward compatibility.
-func servingProtocolFromConfig(cfg map[string]any) godo.ServingProtocol {
-	proto := strings.ToUpper(strFromConfig(cfg, "protocol", ""))
-	switch proto {
-	case "HTTP2":
+// httpPortProtocolFromConfig maps the canonical port protocol to a godo.ServingProtocol
+// on godo.AppServiceSpec.Protocol (godo v1.178.0 apps.gen.go:568).
+//
+// Two canonical keys are accepted:
+//
+//   - "http_port_protocol" — explicit, mirrors the DO App Platform API field
+//     name. Takes precedence when both keys are set.
+//   - "protocol" — historic shorthand. Recognized aliases: "grpc" → HTTP2
+//     (gRPC requires HTTP/2 with prior knowledge per DO docs).
+//
+// DO recognizes HTTP and HTTP2; unknown values pass through for forward
+// compatibility with future godo releases.
+func httpPortProtocolFromConfig(cfg map[string]any) godo.ServingProtocol {
+	// Explicit canonical key wins over the shorthand.
+	raw := strFromConfig(cfg, "http_port_protocol", "")
+	if raw == "" {
+		raw = strFromConfig(cfg, "protocol", "")
+	}
+	switch strings.ToUpper(raw) {
+	case "HTTP2", "GRPC":
+		// gRPC over App Platform is served as HTTP/2 with prior knowledge.
 		return godo.SERVINGPROTOCOL_HTTP2
 	case "HTTP", "":
 		return "" // omit — DO defaults to HTTP
 	default:
-		return godo.ServingProtocol(proto)
+		return godo.ServingProtocol(strings.ToUpper(raw))
 	}
 }
 

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -155,6 +155,51 @@ func TestBuildAppSpec_Protocol_Default(t *testing.T) {
 	}
 }
 
+// TestBuildAppSpec_HTTPPortProtocol_HTTP2 exercises the canonical
+// `http_port_protocol: HTTP2` key — the official spelling that mirrors the
+// DO App Platform API field semantics. It must reach godo.AppServiceSpec.Protocol.
+func TestBuildAppSpec_HTTPPortProtocol_HTTP2(t *testing.T) {
+	cfg := map[string]any{
+		"image":              "registry.digitalocean.com/myrepo/myapp:v1",
+		"http_port_protocol": "HTTP2",
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Services[0].Protocol; got != godo.SERVINGPROTOCOL_HTTP2 {
+		t.Errorf("Protocol = %q, want HTTP2 (from http_port_protocol)", got)
+	}
+}
+
+// TestBuildAppSpec_Protocol_GRPC_AliasesHTTP2 exercises the shorthand
+// `protocol: grpc` alias. gRPC requires HTTP/2 transport (DO docs note HTTP2
+// "needs to be implemented in the service by serving HTTP/2 with prior
+// knowledge"), so the alias must resolve to godo.SERVINGPROTOCOL_HTTP2.
+func TestBuildAppSpec_Protocol_GRPC_AliasesHTTP2(t *testing.T) {
+	cfg := map[string]any{
+		"image":    "registry.digitalocean.com/myrepo/myapp:v1",
+		"protocol": "grpc",
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Services[0].Protocol; got != godo.SERVINGPROTOCOL_HTTP2 {
+		t.Errorf("Protocol = %q, want HTTP2 (gRPC alias)", got)
+	}
+}
+
+// TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol verifies precedence:
+// when both `http_port_protocol` and `protocol` are set, the explicit
+// `http_port_protocol` wins. This protects callers who mix the two during
+// migration from the shorthand to the canonical key.
+func TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol(t *testing.T) {
+	cfg := map[string]any{
+		"image":              "registry.digitalocean.com/myrepo/myapp:v1",
+		"http_port_protocol": "HTTP2",
+		"protocol":           "HTTP",
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Services[0].Protocol; got != godo.SERVINGPROTOCOL_HTTP2 {
+		t.Errorf("Protocol = %q, want HTTP2 (http_port_protocol takes precedence)", got)
+	}
+}
+
 // ── BuildCommand / RunCommand / DockerfilePath / SourceDir ───────────────────
 
 func TestBuildAppSpec_SourceFields(t *testing.T) {

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -205,10 +205,11 @@ func TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol(t *testing.T) {
 // An explicit `http_port_protocol: ""` is the user opting out of any protocol
 // override; it must NOT silently fall back to a `protocol: grpc` shorthand.
 //
-// Without the key-presence check, `strFromConfig("http_port_protocol", "")`
-// would return the empty default and the function would proceed to read
-// `protocol`, surfacing HTTP2 — surprising and contrary to the documented
-// precedence. (Code-review Finding #3 / Copilot inline comment, F5 round 2.)
+// Without the key-presence check, the function would treat
+// `http_port_protocol: ""` as absent (because `strFromConfig`'s
+// default-on-empty logic conflates explicit-empty with omitted) and consult
+// `protocol` instead, surfacing HTTP2 — surprising and contrary to the
+// documented precedence.
 func TestBuildAppSpec_HTTPPortProtocol_ExplicitEmpty_DoesNotFallThrough(t *testing.T) {
 	cfg := map[string]any{
 		"image":              "registry.digitalocean.com/myrepo/myapp:v1",

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -200,6 +200,27 @@ func TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol(t *testing.T) {
 	}
 }
 
+// TestBuildAppSpec_HTTPPortProtocol_ExplicitEmpty_DoesNotFallThrough verifies
+// that the precedence rule is decided by KEY PRESENCE, not value emptiness.
+// An explicit `http_port_protocol: ""` is the user opting out of any protocol
+// override; it must NOT silently fall back to a `protocol: grpc` shorthand.
+//
+// Without the key-presence check, `strFromConfig("http_port_protocol", "")`
+// would return the empty default and the function would proceed to read
+// `protocol`, surfacing HTTP2 — surprising and contrary to the documented
+// precedence. (Code-review Finding #3 / Copilot inline comment, F5 round 2.)
+func TestBuildAppSpec_HTTPPortProtocol_ExplicitEmpty_DoesNotFallThrough(t *testing.T) {
+	cfg := map[string]any{
+		"image":              "registry.digitalocean.com/myrepo/myapp:v1",
+		"http_port_protocol": "", // explicit empty — opt out
+		"protocol":           "grpc",
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Services[0].Protocol; got != "" {
+		t.Errorf("Protocol = %q, want empty (explicit empty http_port_protocol must not fall through to protocol: grpc)", got)
+	}
+}
+
 // ── BuildCommand / RunCommand / DockerfilePath / SourceDir ───────────────────
 
 func TestBuildAppSpec_SourceFields(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements P-2.F5 from the IaC DO staging plan. Adds the canonical `http_port_protocol` config key for `infra.container_service` (App Platform services) and teaches the historic `protocol` shorthand a `grpc` alias.

- Both keys flow into **`godo.AppServiceSpec.Protocol`** (`ServingProtocol` enum) — see godo v1.178.0 [`apps.gen.go:568`](https://github.com/digitalocean/godo/blob/v1.178.0/apps.gen.go#L568) and the constant block at [lines 1553-1554](https://github.com/digitalocean/godo/blob/v1.178.0/apps.gen.go#L1553-L1554).
- `HTTP2` and `grpc` (case-insensitive) both resolve to `godo.SERVINGPROTOCOL_HTTP2`. gRPC is served as HTTP/2 with prior knowledge per the godo `ServingProtocol` doc comment.
- When both keys are set, the explicit `http_port_protocol` wins (precedence test included).
- Empty / `HTTP` / unset → empty string (DO defaults to HTTP). Unknown values pass through as `godo.ServingProtocol(strings.ToUpper(...))` for forward compatibility.

## Branch / SHAs
- Branch: `feat/http-port-protocol`
- Base SHA: `2a26a08865af2fe83f0f315b4a8d9a5ea3c2993a` (origin/main)
- Head SHA: `a4212d302097ede9cdeab961325f8979d6f881b9`

## Files
- `internal/drivers/app_platform_buildspec.go` — rename `servingProtocolFromConfig` → `httpPortProtocolFromConfig`, accept both keys, add `grpc` alias.
- `internal/drivers/app_platform_buildspec_test.go` — three new tests (see below).
- `CHANGELOG.md` — Unreleased entry.

## Test output

```
$ GOWORK=off go test -race -run 'TestBuildAppSpec_HTTPPortProtocol|TestBuildAppSpec_Protocol' -v ./internal/drivers/...
=== RUN   TestBuildAppSpec_Protocol_HTTP2
--- PASS: TestBuildAppSpec_Protocol_HTTP2 (0.00s)
=== RUN   TestBuildAppSpec_Protocol_Default
--- PASS: TestBuildAppSpec_Protocol_Default (0.00s)
=== RUN   TestBuildAppSpec_HTTPPortProtocol_HTTP2
--- PASS: TestBuildAppSpec_HTTPPortProtocol_HTTP2 (0.00s)
=== RUN   TestBuildAppSpec_Protocol_GRPC_AliasesHTTP2
--- PASS: TestBuildAppSpec_Protocol_GRPC_AliasesHTTP2 (0.00s)
=== RUN   TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol
--- PASS: TestBuildAppSpec_HTTPPortProtocol_OverridesProtocol (0.00s)
PASS
ok  	github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers	1.471s
```

Full repo: `GOWORK=off go test -race ./...` → all packages pass.

## Self-review checklist

- [x] TDD: RED (3 new tests fail with expected mismatch) → GREEN → regression invariant verified (full driver suite + full repo green).
- [x] PR scope matches task "Files" section: only `app_platform_buildspec.go`, `app_platform_buildspec_test.go`, `CHANGELOG.md` modified.
- [x] Existing `TestBuildAppSpec_Protocol_HTTP2` and `TestBuildAppSpec_Protocol_Default` still pass — no regression on the original `protocol: HTTP2` path.
- [x] `go test -race` clean.
- [x] `golangci-lint run` reports only pre-existing issues in `database.go` / `app_platform_migration_repair_test.go` — unrelated to this PR.
- [x] Both `http_port_protocol: HTTP2` AND `protocol: grpc` (alias) exercised, plus precedence test.
- [x] Branched off `origin/main` (`2a26a08`), `git pull --ff-only origin main` before push, no other tasks pre-baked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)