### PR TITLE
docs(changelog): v0.8.0 legacy-compat note + filed follow-up #37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ fixtures from workflow v0.20.1.
   start ensures `Diff` reads symmetric values whether `current.Outputs`
   is consumed in-process or after a structpb round-trip.
 
+### Notes
+
+- **Plugin dispatch mode: legacy compat.** This release ships under
+  workflow's legacy plugin dispatch (untyped `map[string]any` arguments
+  transported via `structpb`). The F7 firewall Diff fix uses
+  canonical-shape Outputs (typed values converted to structpb-compatible
+  `[]any` of primitive/map shapes) as a stopgap to survive the gRPC
+  structpb boundary. Migration to workflow's strict typed-contract
+  dispatch (`v0.19.0-alpha.5+`) is scoped for v0.9.0. Once strict-mode
+  is enabled, the canonical-shape conversion becomes obsolete and
+  Outputs writers + Diff readers will use generated proto types
+  end-to-end.
+- **Filed follow-up:** issue #37 — use `ref.Name` consistently for
+  `FirewallDriver.Update` error formatting (Minor advisory from F7
+  review; non-blocking, scoped for v0.8.x).
+
 ## [v0.7.9] - 2026-04-24
 
 ### Added


### PR DESCRIPTION
## Summary

Doc-only follow-up to PR #38 (v0.8.0 release cut). Adds the legacy-compat note + filed-follow-up paragraph that team-lead's release-task spec called for, but which crossed paths with the admin-merge of PR #38 in the original push.

Lands BEFORE the v0.8.0 tag push so the tag's CHANGELOG includes the note.

## Branch / SHAs

- Base: `origin/main` @ `554f80df` (post-#38 merge)
- Head: `c88d4b4041f1f637f28b70b7e4bbc8696b7dbe4d`

## Diff

```
 CHANGELOG.md | 16 ++++++++++++++++
 1 file changed, 16 insertions(+)
```

Adds a `### Notes` block under `## [v0.8.0]` with two entries:

1. **Plugin dispatch mode: legacy compat.** Documents that this release ships under workflow's legacy untyped `map[string]any` + `structpb` dispatch. Explains why F7's canonical-shape Outputs are a stopgap for the gRPC structpb boundary. Pins the strict typed-contract migration (workflow `v0.19.0-alpha.5+`) for v0.9.0.

2. **Filed follow-up:** issue #37 — `ref.Name` vs `spec.Name` consistency in `FirewallDriver.Update` error formatting (Minor advisory from F7 review, non-blocking, scoped for v0.8.x).

## Self-review checklist

- [x] Doc-only change (no code, no tests)
- [x] Branched off post-#38 main (`554f80df`)
- [x] `git pull --ff-only origin main` clean before commit + push
- [x] CHANGELOG addition is in the correct `[v0.8.0]` section, immediately after the existing F4/F5/F7 entries
- [x] Pre-authorized for admin-merge per team-lead's "release-shape PRs go through Copilot + CI + admin-merge per memory" guidance

## Post-merge

After this lands on main, push the v0.8.0 tag pointing to the post-merge commit so the tagged release's CHANGELOG includes the note:

```sh
git checkout main && git pull
git tag -a v0.8.0 -m "v0.8.0 — expose: internal, http_port_protocol, firewall target enforcement"
git push origin v0.8.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)