### PR TITLE
fix(plugin): handle delete action in Apply + nil-output guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Apply `"delete"` action** — The `Apply` method now dispatches `"delete"`
+  plan actions to `d.Delete(ctx, ref)` using `action.Current` for the
+  `ResourceRef` (which carries the `ProviderID`; `action.Resource` is empty for
+  deletes). Previously, `"delete"` fell through to the `default` case and
+  returned `unknown action "delete"`, blocking any plan that removed a resource
+  from config. Reproducer: BMW deploy failed with `delete/bmw-staging-firewall:
+  unknown action "delete"` after the firewall was removed from infra.yaml.
+- **Apply nil-output guard** — After a successful `"delete"` action, `out`
+  is `nil` (deleted resources have no post-apply state). Added a nil check
+  before `result.Resources = append(result.Resources, *out)` to prevent a
+  nil-pointer panic on mixed delete+create plans.
+
 ## [v0.8.0] - 2026-04-28
 
 P-2 staging IaC alignment. Three independent canonical-config additions

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -291,9 +291,9 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 			}
 			out, err = d.Create(ctx, action.Resource)
 		case "delete":
-			// Delete uses Current (not Resource) because the desired state is
-			// "absent" — Resource is empty for delete actions. Current carries
-			// the ProviderID needed by the cloud API.
+			// Delete uses Current for the ref (ProviderID). Resource.Config is
+			// empty for deletes — the desired state is "absent" — but
+			// Resource.Type and Name are still set (required for driver lookup above).
 			if action.Current == nil {
 				err = fmt.Errorf("delete action for %q missing current resource state", action.Resource.Name)
 				break
@@ -316,6 +316,14 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 		}
 		if out != nil {
 			result.Resources = append(result.Resources, *out)
+		} else if action.Action != "delete" {
+			// A nil output without an error from create/update/replace is a driver
+			// bug — surface it explicitly so callers aren't silently missing state
+			// entries. "delete" legitimately returns nil out, so it's excluded.
+			result.Errors = append(result.Errors, interfaces.ActionError{
+				Resource: action.Resource.Name, Action: action.Action,
+				Error: "driver returned nil output without error",
+			})
 		}
 	}
 	return result, nil

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -290,6 +290,21 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 				break
 			}
 			out, err = d.Create(ctx, action.Resource)
+		case "delete":
+			// Delete uses Current (not Resource) because the desired state is
+			// "absent" — Resource is empty for delete actions. Current carries
+			// the ProviderID needed by the cloud API.
+			if action.Current == nil {
+				err = fmt.Errorf("delete action for %q missing current resource state", action.Resource.Name)
+				break
+			}
+			ref := interfaces.ResourceRef{
+				Name:       action.Current.Name,
+				Type:       action.Current.Type,
+				ProviderID: action.Current.ProviderID,
+			}
+			err = d.Delete(ctx, ref)
+			// out remains nil — deleted resources have no post-apply output.
 		default:
 			err = fmt.Errorf("unknown action %q", action.Action)
 		}
@@ -299,7 +314,9 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 			})
 			continue
 		}
-		result.Resources = append(result.Resources, *out)
+		if out != nil {
+			result.Resources = append(result.Resources, *out)
+		}
 	}
 	return result, nil
 }

--- a/internal/provider_apply_test.go
+++ b/internal/provider_apply_test.go
@@ -1,0 +1,182 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// deleteFakeDriver records calls to Delete so tests can assert dispatch.
+type deleteFakeDriver struct {
+	deleteCalls  int
+	deletedRef   interfaces.ResourceRef
+	deleteReturn error
+}
+
+func (f *deleteFakeDriver) Create(_ context.Context, s interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{Name: s.Name, Type: s.Type, ProviderID: "created-id"}, nil
+}
+func (f *deleteFakeDriver) Read(_ context.Context, _ interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *deleteFakeDriver) Update(_ context.Context, _ interfaces.ResourceRef, s interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return &interfaces.ResourceOutput{Name: s.Name, Type: s.Type, ProviderID: "updated-id"}, nil
+}
+func (f *deleteFakeDriver) Delete(_ context.Context, ref interfaces.ResourceRef) error {
+	f.deleteCalls++
+	f.deletedRef = ref
+	return f.deleteReturn
+}
+func (f *deleteFakeDriver) Diff(_ context.Context, _ interfaces.ResourceSpec, _ *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	return nil, nil
+}
+func (f *deleteFakeDriver) HealthCheck(_ context.Context, _ interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	return nil, nil
+}
+func (f *deleteFakeDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, nil
+}
+func (f *deleteFakeDriver) SensitiveKeys() []string { return nil }
+
+// TestDOProvider_Apply_DeleteAction verifies that a "delete" plan action:
+//  1. dispatches to d.Delete with a ref built from action.Current (ProviderID)
+//  2. returns no error on success
+//  3. does NOT add a resource entry to ApplyResult.Resources (deleted resources
+//     have no post-apply output)
+func TestDOProvider_Apply_DeleteAction(t *testing.T) {
+	fake := &deleteFakeDriver{}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.firewall": fake}}
+
+	plan := &interfaces.IaCPlan{
+		ID: "plan-delete",
+		Actions: []interfaces.PlanAction{{
+			Action:   "delete",
+			Resource: interfaces.ResourceSpec{Name: "bmw-staging-firewall", Type: "infra.firewall"},
+			Current: &interfaces.ResourceState{
+				Name:       "bmw-staging-firewall",
+				Type:       "infra.firewall",
+				ProviderID: "do-firewall-abc123",
+			},
+		}},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply returned non-nil error: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply returned action errors: %v", result.Errors)
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("Delete called %d times, want 1", fake.deleteCalls)
+	}
+	if fake.deletedRef.ProviderID != "do-firewall-abc123" {
+		t.Errorf("Delete called with ProviderID %q, want do-firewall-abc123", fake.deletedRef.ProviderID)
+	}
+	if fake.deletedRef.Name != "bmw-staging-firewall" {
+		t.Errorf("Delete called with Name %q, want bmw-staging-firewall", fake.deletedRef.Name)
+	}
+	// Deleted resource should NOT appear in Resources (it no longer exists).
+	if len(result.Resources) != 0 {
+		t.Errorf("ApplyResult.Resources = %d entries, want 0 for a delete action", len(result.Resources))
+	}
+}
+
+// TestDOProvider_Apply_DeleteAction_MissingCurrent verifies that a delete
+// action with no Current state is collected as an error (not a panic/crash).
+func TestDOProvider_Apply_DeleteAction_MissingCurrent(t *testing.T) {
+	fake := &deleteFakeDriver{}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.firewall": fake}}
+
+	plan := &interfaces.IaCPlan{
+		ID: "plan-delete-no-current",
+		Actions: []interfaces.PlanAction{{
+			Action:  "delete",
+			Resource: interfaces.ResourceSpec{Name: "orphan-firewall", Type: "infra.firewall"},
+			Current: nil, // missing — defensive handling required
+		}},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply returned top-level error (want nil + error in result.Errors): %v", err)
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error in result.Errors for delete with missing Current, got none")
+	}
+	if fake.deleteCalls != 0 {
+		t.Errorf("Delete should not be called when Current is nil, but called %d times", fake.deleteCalls)
+	}
+}
+
+// TestDOProvider_Apply_DeleteAction_DriverError verifies that a driver error
+// on Delete is collected in result.Errors (Apply itself still returns nil).
+func TestDOProvider_Apply_DeleteAction_DriverError(t *testing.T) {
+	driverErr := errors.New("DO API: firewall not found")
+	fake := &deleteFakeDriver{deleteReturn: driverErr}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.firewall": fake}}
+
+	plan := &interfaces.IaCPlan{
+		ID: "plan-delete-err",
+		Actions: []interfaces.PlanAction{{
+			Action:   "delete",
+			Resource: interfaces.ResourceSpec{Name: "bmw-staging-firewall", Type: "infra.firewall"},
+			Current: &interfaces.ResourceState{
+				Name: "bmw-staging-firewall", Type: "infra.firewall", ProviderID: "do-firewall-abc123",
+			},
+		}},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) == 0 {
+		t.Fatal("expected error in result.Errors for failed delete, got none")
+	}
+	if result.Errors[0].Action != "delete" {
+		t.Errorf("ActionError.Action = %q, want delete", result.Errors[0].Action)
+	}
+}
+
+// TestDOProvider_Apply_DeleteAndCreate_NilOutGuard verifies that a plan with
+// a delete followed by a create does not panic: the delete produces nil output
+// and the create produces non-nil output. Both must land correctly in result.
+func TestDOProvider_Apply_DeleteAndCreate_NilOutGuard(t *testing.T) {
+	fake := &deleteFakeDriver{}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.firewall": fake}}
+
+	plan := &interfaces.IaCPlan{
+		ID: "plan-delete-then-create",
+		Actions: []interfaces.PlanAction{
+			{
+				Action:   "delete",
+				Resource: interfaces.ResourceSpec{Name: "old-firewall", Type: "infra.firewall"},
+				Current: &interfaces.ResourceState{
+					Name: "old-firewall", Type: "infra.firewall", ProviderID: "old-fw-id",
+				},
+			},
+			{
+				Action:   "create",
+				Resource: interfaces.ResourceSpec{Name: "new-firewall", Type: "infra.firewall"},
+			},
+		},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply errors: %v", result.Errors)
+	}
+	// Only the create result should be in Resources (1 entry, not 2).
+	if len(result.Resources) != 1 {
+		t.Errorf("ApplyResult.Resources = %d entries, want 1 (delete produces no output)", len(result.Resources))
+	}
+	if len(result.Resources) > 0 && result.Resources[0].Name != "new-firewall" {
+		t.Errorf("Resources[0].Name = %q, want new-firewall", result.Resources[0].Name)
+	}
+}

--- a/internal/provider_apply_test.go
+++ b/internal/provider_apply_test.go
@@ -180,3 +180,45 @@ func TestDOProvider_Apply_DeleteAndCreate_NilOutGuard(t *testing.T) {
 		t.Errorf("Resources[0].Name = %q, want new-firewall", result.Resources[0].Name)
 	}
 }
+
+// TestDOProvider_Apply_DeleteAction_ResourceTypePopulated locks in the invariant
+// that for delete actions, action.Resource.Type IS populated (required for driver
+// lookup) while action.Resource.Config is nil (desired state is "absent").
+// This protects against a future regression where wfctl omits Resource.Type on
+// delete actions, causing the driver lookup to fail with "unsupported resource type".
+func TestDOProvider_Apply_DeleteAction_ResourceTypePopulated(t *testing.T) {
+	fake := &deleteFakeDriver{}
+	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{"infra.firewall": fake}}
+
+	plan := &interfaces.IaCPlan{
+		ID: "plan-delete-type-check",
+		Actions: []interfaces.PlanAction{{
+			Action: "delete",
+			Resource: interfaces.ResourceSpec{
+				Name:   "bmw-staging-firewall",
+				Type:   "infra.firewall",
+				Config: nil, // explicitly nil — desired state is "absent"
+			},
+			Current: &interfaces.ResourceState{
+				Name:       "bmw-staging-firewall",
+				Type:       "infra.firewall",
+				ProviderID: "do-firewall-abc123",
+			},
+		}},
+	}
+
+	result, err := p.Apply(t.Context(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply errors for delete with nil Config: %v", result.Errors)
+	}
+	if fake.deleteCalls != 1 {
+		t.Fatalf("Delete called %d times, want 1", fake.deleteCalls)
+	}
+	// The ref used for Delete must be built from Current, not Resource.
+	if fake.deletedRef.ProviderID != "do-firewall-abc123" {
+		t.Errorf("Delete ref.ProviderID = %q, want do-firewall-abc123", fake.deletedRef.ProviderID)
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes `Apply` dispatch for `\"delete\"` plan actions — previously fell through to `default → unknown action \"delete\"`
- Adds nil-output guard before `result.Resources = append(result.Resources, *out)` to prevent nil-pointer panic on delete

**Reproducer:** BMW staging deploy (commit bf5a5c68) failed with:
```
error: 1 resource(s) failed: delete/bmw-staging-firewall: unknown action \"delete\"
```
BMW removed `bmw-staging-firewall` from `infra.yaml`; wfctl plan correctly generated a `delete` action; the plugin couldn't dispatch it.

## Changes

- `internal/provider.go`: Add `case \"delete\":` to Apply switch; build `ResourceRef` from `action.Current` (ProviderID lives there for deletes); call `d.Delete(ctx, ref)`. Guard `result.Resources` append with nil check.
- `internal/provider_apply_test.go` (new): 4 tests covering dispatch, missing-current defensive path, driver error propagation, and mixed delete+create nil guard.
- `CHANGELOG.md`: Unreleased entry.

## Notes

- `\"replace\"` was **already implemented** (delete then create) — no change needed there
- `\"scale\"` is **not a PlanAction.Action value** per the `interfaces.PlanAction` doc comment (`// create, update, replace, delete`) — no scale case added

## Test plan

- [x] `go test ./internal/...` green (all 4 new tests + no regressions)
- [ ] CI green
- [ ] After release + BMW pin bump: deploy re-run; `delete/bmw-staging-firewall` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)