### PR TITLE
feat(database): deferred trusted_sources flush for type=app refs on first deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Deferred `trusted_sources` update for `infra.database`** — When a
+  `trusted_sources` entry of `type: app` references an app that does not yet
+  exist (first-deploy ordering), `DatabaseDriver.Create` and `.Update` no
+  longer fail with a resource-not-found error. Instead, the driver:
+
+  1. Creates/updates the DB with the resolvable subset of rules (e.g. `ip_addr`)
+     applied immediately.
+  2. Queues a deferred firewall update for the post-apply second pass.
+  3. After all plan `create` actions complete, `DOProvider.Apply` calls
+     `FlushDeferredUpdates` on any driver with pending updates, which
+     re-resolves all `type=app` names (apps now exist) and calls
+     `UpdateFirewallRules` with the full intended rule set.
+
+  Failure during `FlushDeferredUpdates` (e.g. `UpdateFirewallRules` API error)
+  is **fatal** — the error surfaces in `ApplyResult.Errors` so the operator
+  knows the intended security posture was not fully applied. Failed entries are
+  **retained in the pending queue**, so a subsequent `wfctl apply` automatically
+  re-attempts the flush without requiring operator intervention (e.g. touching a
+  config field to force a Diff update).
+
+  Only "app not yet created" (name absent from `Apps.List`) triggers deferral.
+  API-level failures (rate-limit, transient, auth errors) are propagated
+  immediately and never silently deferred.
+
+  Fixes GoCodeAlone/core-dump#154 (R4 first-deploy ordering finding).
+  See `docs/plans/2026-05-02-staging-deploy-blockers-design.md` (Blocker 2).
+
 ### Fixed
 
 - **Apply `"delete"` action** — The `Apply` method now dispatches `"delete"`

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -10,6 +11,22 @@ import (
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
 )
+
+// ErrAppNotFound is returned by resolveAppNamesMap when a requested app name
+// is absent from the DO Apps.List result. It wraps ErrResourceNotFound so
+// callers using errors.Is(err, ErrResourceNotFound) continue to work; the
+// more specific sentinel is used internally to distinguish "app not yet
+// created" from API-level failures (rate-limit, transient, auth) that must
+// NOT trigger the deferred-update path.
+var ErrAppNotFound = fmt.Errorf("trusted_sources app: %w", ErrResourceNotFound)
+
+// deferredFirewallUpdate holds the context needed for a post-apply firewall
+// update: the DO database UUID and the full desired ResourceSpec (including
+// all trusted_sources entries, both resolvable and deferred).
+type deferredFirewallUpdate struct {
+	providerID string
+	spec       interfaces.ResourceSpec
+}
 
 // DatabaseClient is the godo Databases interface (for mocking).
 type DatabaseClient interface {
@@ -34,6 +51,12 @@ type DatabaseDriver struct {
 	client     DatabaseClient
 	appsClient appNameLister // optional; used to resolve type=app trusted_source names to UUIDs
 	region     string
+
+	// pendingFirewallUpdates accumulates deferred trusted_sources updates that
+	// could not be applied at create/update time because referenced apps did not
+	// exist yet. DOProvider.Apply calls FlushDeferredUpdates after all plan
+	// actions complete so the full rule set is applied once apps are provisioned.
+	pendingFirewallUpdates []deferredFirewallUpdate
 }
 
 // NewDatabaseDriver creates a DatabaseDriver backed by a real godo client.
@@ -65,8 +88,20 @@ func (d *DatabaseDriver) Create(ctx context.Context, spec interfaces.ResourceSpe
 	numNodes, _ := intFromConfig(spec.Config, "num_nodes", 1)
 
 	createRules, err := d.buildCreateFirewallRules(ctx, spec.Config)
+	deferred := false
 	if err != nil {
-		return nil, fmt.Errorf("database create %q: %w", spec.Name, err)
+		if !errors.Is(err, ErrAppNotFound) {
+			// Real API failure or config error — propagate immediately.
+			return nil, fmt.Errorf("database create %q: %w", spec.Name, err)
+		}
+		// type=app trusted_source(s) reference not-yet-existing app(s) — create
+		// DB without app-based rules now and queue a deferred firewall update for
+		// the post-apply pass (after all plan creates have completed and apps exist).
+		createRules, err = d.buildCreateFirewallRulesExcludingApps(spec.Config)
+		if err != nil {
+			return nil, fmt.Errorf("database create %q: build partial rules: %w", spec.Name, err)
+		}
+		deferred = true
 	}
 
 	req := &godo.DatabaseCreateRequest{
@@ -86,6 +121,14 @@ func (d *DatabaseDriver) Create(ctx context.Context, spec interfaces.ResourceSpe
 	if db == nil || db.ID == "" {
 		return nil, fmt.Errorf("database create %q: API returned database with empty ID", spec.Name)
 	}
+
+	if deferred {
+		d.pendingFirewallUpdates = append(d.pendingFirewallUpdates, deferredFirewallUpdate{
+			providerID: db.ID,
+			spec:       spec,
+		})
+	}
+
 	return dbOutput(db), nil
 }
 
@@ -154,8 +197,20 @@ func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef,
 	// A later UpdateFirewallRules call can still fail after Resize due to API/service
 	// errors, so this reduces—but does not eliminate—the chance of partial applies.
 	fwRules, fwPresent, fwErr := d.buildUpdateFirewallRules(ctx, spec.Config)
+	deferred := false
 	if fwErr != nil {
-		return nil, fmt.Errorf("database update firewall %q: %w", ref.Name, fwErr)
+		if !errors.Is(fwErr, ErrAppNotFound) {
+			// Real API failure or config error — propagate immediately.
+			return nil, fmt.Errorf("database update firewall %q: %w", ref.Name, fwErr)
+		}
+		// type=app trusted_source(s) reference not-yet-existing app(s) — apply the
+		// resolvable subset of rules now and queue the full spec for a deferred
+		// post-apply update.
+		fwRules, fwPresent, fwErr = d.buildUpdateFirewallRulesExcludingApps(spec.Config)
+		if fwErr != nil {
+			return nil, fmt.Errorf("database update %q: build partial rules: %w", ref.Name, fwErr)
+		}
+		deferred = true
 	}
 	size := strFromConfig(spec.Config, "size", "db-s-1vcpu-1gb")
 	numNodes, _ := intFromConfig(spec.Config, "num_nodes", 1)
@@ -175,6 +230,12 @@ func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef,
 		if err != nil {
 			return nil, fmt.Errorf("database update firewall %q: %w", ref.Name, WrapGodoError(err))
 		}
+	}
+	if deferred {
+		d.pendingFirewallUpdates = append(d.pendingFirewallUpdates, deferredFirewallUpdate{
+			providerID: providerID,
+			spec:       spec,
+		})
 	}
 	ref.ProviderID = providerID // pass healed ID to Read
 	return d.Read(ctx, ref)
@@ -326,8 +387,11 @@ func (d *DatabaseDriver) resolveAppNamesMap(ctx context.Context, raw []any) (map
 	for i, name := range missing {
 		quotedMissing[i] = fmt.Sprintf("%q", name)
 	}
+	// Use ErrAppNotFound (not ErrResourceNotFound directly) so callers can
+	// distinguish "app not yet created" from API-level failures. ErrAppNotFound
+	// wraps ErrResourceNotFound so errors.Is(err, ErrResourceNotFound) still works.
 	return nil, fmt.Errorf("trusted_sources app(s) %s: %w",
-		strings.Join(quotedMissing, ", "), ErrResourceNotFound)
+		strings.Join(quotedMissing, ", "), ErrAppNotFound)
 }
 
 // buildCreateFirewallRules converts "trusted_sources" config to
@@ -511,3 +575,109 @@ func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 }
 
 func (d *DatabaseDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }
+
+// buildCreateFirewallRulesExcludingApps builds DatabaseCreateFirewallRules from
+// the "trusted_sources" config, omitting all type=app entries. Used when
+// buildCreateFirewallRules returns ErrAppNotFound so the DB can be created with
+// the resolvable subset of rules while app-based rules are deferred.
+func (d *DatabaseDriver) buildCreateFirewallRulesExcludingApps(cfg map[string]any) ([]*godo.DatabaseCreateFirewallRule, error) {
+	rawVal, exists := cfg["trusted_sources"]
+	if !exists {
+		return nil, nil
+	}
+	raw, ok := rawVal.([]any)
+	if !ok {
+		return nil, fmt.Errorf("trusted_sources: expected a list of rule objects, got %T; check your config syntax (use a YAML list, not a scalar)", rawVal)
+	}
+	rules := make([]*godo.DatabaseCreateFirewallRule, 0, len(raw))
+	for _, v := range raw {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		ruleType := strFromConfig(m, "type", "")
+		ruleValue := strFromConfig(m, "value", "")
+		if ruleType == "" || ruleValue == "" || ruleType == "app" {
+			continue // skip app-type entries; they will be applied in the deferred pass
+		}
+		rules = append(rules, &godo.DatabaseCreateFirewallRule{
+			Type:  ruleType,
+			Value: ruleValue,
+		})
+	}
+	return rules, nil
+}
+
+// buildUpdateFirewallRulesExcludingApps builds DatabaseFirewallRules from the
+// "trusted_sources" config, omitting all type=app entries. Used when
+// buildUpdateFirewallRules returns ErrAppNotFound so the partial rule set can
+// be applied immediately while app-based rules are deferred.
+func (d *DatabaseDriver) buildUpdateFirewallRulesExcludingApps(cfg map[string]any) ([]*godo.DatabaseFirewallRule, bool, error) {
+	raw, ok := cfg["trusted_sources"]
+	if !ok {
+		return nil, false, nil
+	}
+	list, ok := raw.([]any)
+	if !ok {
+		return nil, true, fmt.Errorf("trusted_sources: expected a list of rule objects, got %T; check your config syntax (use a YAML list, not a scalar)", raw)
+	}
+	rules := make([]*godo.DatabaseFirewallRule, 0, len(list))
+	for _, v := range list {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		ruleType := strFromConfig(m, "type", "")
+		ruleValue := strFromConfig(m, "value", "")
+		if ruleType == "" || ruleValue == "" || ruleType == "app" {
+			continue // skip app-type entries; they will be applied in the deferred pass
+		}
+		rules = append(rules, &godo.DatabaseFirewallRule{
+			Type:  ruleType,
+			Value: ruleValue,
+		})
+	}
+	return rules, true, nil
+}
+
+// HasDeferredUpdates reports whether the driver has pending firewall updates
+// queued from Create or Update calls where type=app trusted_sources entries
+// referenced apps that did not exist yet. DOProvider.Apply checks this after
+// the main action loop and calls FlushDeferredUpdates when true.
+func (d *DatabaseDriver) HasDeferredUpdates() bool {
+	return len(d.pendingFirewallUpdates) > 0
+}
+
+// FlushDeferredUpdates applies all pending firewall updates that were deferred
+// during Create/Update because referenced app(s) did not exist yet. Each entry
+// re-resolves its type=app trusted_sources entries (app must now exist) and
+// calls UpdateFirewallRules with the full rule set. Returns an error if any
+// update fails — the caller (DOProvider.Apply) appends these to result.Errors
+// so the failure is visible to the operator.
+//
+// The pending queue is cleared after the flush regardless of whether all
+// updates succeeded, preventing duplicate retries on a subsequent call.
+func (d *DatabaseDriver) FlushDeferredUpdates(ctx context.Context) error {
+	if len(d.pendingFirewallUpdates) == 0 {
+		return nil
+	}
+	var errs []string
+	for _, pending := range d.pendingFirewallUpdates {
+		fwRules, _, err := d.buildUpdateFirewallRules(ctx, pending.spec.Config)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("deferred firewall update %q: resolve rules: %v", pending.spec.Name, err))
+			continue
+		}
+		_, err = d.client.UpdateFirewallRules(ctx, pending.providerID, &godo.DatabaseUpdateFirewallRulesRequest{
+			Rules: fwRules,
+		})
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("deferred firewall update %q: %v", pending.spec.Name, WrapGodoError(err)))
+		}
+	}
+	d.pendingFirewallUpdates = nil // clear queue after flush
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -655,17 +655,23 @@ func (d *DatabaseDriver) HasDeferredUpdates() bool {
 // update fails — the caller (DOProvider.Apply) appends these to result.Errors
 // so the failure is visible to the operator.
 //
-// The pending queue is cleared after the flush regardless of whether all
-// updates succeeded, preventing duplicate retries on a subsequent call.
+// Only successfully-flushed entries are removed from the queue. Entries that
+// failed (rule-resolution error or UpdateFirewallRules API error) are retained
+// so that a subsequent Apply automatically re-attempts the flush without
+// requiring operator intervention. This matters because DatabaseDriver.Diff
+// does not compare trusted_sources, meaning a retry Apply would otherwise
+// produce no update action and the second-pass flush would never fire.
 func (d *DatabaseDriver) FlushDeferredUpdates(ctx context.Context) error {
 	if len(d.pendingFirewallUpdates) == 0 {
 		return nil
 	}
 	var errs []string
+	var remaining []deferredFirewallUpdate
 	for _, pending := range d.pendingFirewallUpdates {
 		fwRules, _, err := d.buildUpdateFirewallRules(ctx, pending.spec.Config)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("deferred firewall update %q: resolve rules: %v", pending.spec.Name, err))
+			remaining = append(remaining, pending) // retain for retry
 			continue
 		}
 		_, err = d.client.UpdateFirewallRules(ctx, pending.providerID, &godo.DatabaseUpdateFirewallRulesRequest{
@@ -673,9 +679,10 @@ func (d *DatabaseDriver) FlushDeferredUpdates(ctx context.Context) error {
 		})
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("deferred firewall update %q: %v", pending.spec.Name, WrapGodoError(err)))
+			remaining = append(remaining, pending) // retain for retry
 		}
 	}
-	d.pendingFirewallUpdates = nil // clear queue after flush
+	d.pendingFirewallUpdates = remaining // only cleared entries were successfully flushed
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}

--- a/internal/drivers/database_deferred_test.go
+++ b/internal/drivers/database_deferred_test.go
@@ -1,0 +1,301 @@
+package drivers_test
+
+// TDD tests for the DatabaseDriver deferred trusted_sources update path.
+//
+// When a type=app trusted_sources entry references an app that doesn't exist
+// yet at create/update time, the driver must:
+//   (1) create/update the DB without the unresolvable app rule,
+//   (2) queue a deferred firewall update,
+//   (3) apply the full rules (including app UUID) when FlushDeferredUpdates
+//       is called after the app has been provisioned.
+//
+// Regression gate for GoCodeAlone/core-dump#154 (R4 finding) +
+// GoCodeAlone/core-dump#158 (first-deploy ordering).
+// See docs/plans/2026-05-02-staging-deploy-blockers-design.md (Blocker 2).
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// countedAppClient returns an empty app list for the first `emptyFor` calls,
+// then returns `apps` on all subsequent calls. Used to simulate the
+// first-deploy ordering: app doesn't exist during DB create, exists during
+// FlushDeferredUpdates.
+type countedAppClient struct {
+	apps      []*godo.App
+	emptyFor  int
+	callCount int
+}
+
+func (m *countedAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	m.callCount++
+	if m.callCount <= m.emptyFor {
+		return []*godo.App{}, nil, nil
+	}
+	return m.apps, nil, nil
+}
+
+// --- Create deferral tests ---
+
+// TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds verifies that
+// when a type=app trusted_source can't be resolved (app not yet created),
+// Create succeeds, the DB is created without the app rule, and a deferred
+// firewall update is queued.
+func TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds(t *testing.T) {
+	dbMock := &mockDatabaseClient{db: testDatabase()}
+	// App not found — empty list on first call.
+	appMock := &mockAppClient{listApps: []*godo.App{}}
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-db",
+		Config: map[string]any{
+			"engine": "pg",
+			"trusted_sources": []any{
+				map[string]any{"type": "app", "value": "coredump-staging"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create should succeed even when app ref is not yet resolvable; got: %v", err)
+	}
+	if out == nil || out.ProviderID != "db-123" {
+		t.Fatalf("Create should return DB output; got %+v", out)
+	}
+	if dbMock.lastCreateReq == nil {
+		t.Fatal("no create request captured")
+	}
+	if len(dbMock.lastCreateReq.Rules) != 0 {
+		t.Fatalf("create request should have no rules when app ref is deferred; got %d rules: %+v",
+			len(dbMock.lastCreateReq.Rules), dbMock.lastCreateReq.Rules)
+	}
+	if !d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be true after deferred create")
+	}
+}
+
+// TestDatabaseDriver_Create_AppNotYetExisting_MixedRules verifies that when
+// a spec has both ip_addr and type=app rules and the app is not found, the
+// DB is created with the resolvable ip_addr rule and the app rule is deferred.
+func TestDatabaseDriver_Create_AppNotYetExisting_MixedRules(t *testing.T) {
+	dbMock := &mockDatabaseClient{db: testDatabase()}
+	appMock := &mockAppClient{listApps: []*godo.App{}} // app not found
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-db",
+		Config: map[string]any{
+			"engine": "pg",
+			"trusted_sources": []any{
+				map[string]any{"type": "ip_addr", "value": "10.20.0.0/16"},
+				map[string]any{"type": "app", "value": "coredump-staging"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create with mixed rules should succeed even when app not found; got: %v", err)
+	}
+	if dbMock.lastCreateReq == nil {
+		t.Fatal("no create request captured")
+	}
+	// Only the ip_addr rule should be in the create request.
+	if len(dbMock.lastCreateReq.Rules) != 1 {
+		t.Fatalf("expected 1 rule in create request (ip_addr only), got %d: %+v",
+			len(dbMock.lastCreateReq.Rules), dbMock.lastCreateReq.Rules)
+	}
+	if dbMock.lastCreateReq.Rules[0].Type != "ip_addr" || dbMock.lastCreateReq.Rules[0].Value != "10.20.0.0/16" {
+		t.Errorf("rule[0] = {%s %s}, want {ip_addr 10.20.0.0/16}",
+			dbMock.lastCreateReq.Rules[0].Type, dbMock.lastCreateReq.Rules[0].Value)
+	}
+	if !d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be true after deferred create")
+	}
+}
+
+// TestDatabaseDriver_Create_AppAPIFailure_NotDeferred verifies that when the
+// DO Apps.List call itself fails (transient, auth, rate-limit), Create fails
+// with the original error and does NOT silently defer. The caller must know
+// that the DB was not created under its intended security constraints.
+func TestDatabaseDriver_Create_AppAPIFailure_NotDeferred(t *testing.T) {
+	dbMock := &mockDatabaseClient{db: testDatabase()}
+	// Apps.List returns a hard API error — must NOT be treated as deferral.
+	appMock := &mockAppClient{listErr: fmt.Errorf("DO API: connection reset")}
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-db",
+		Config: map[string]any{
+			"engine": "pg",
+			"trusted_sources": []any{
+				map[string]any{"type": "app", "value": "coredump-staging"},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Create should fail when Apps.List returns an API error")
+	}
+	if d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() must be false when failure is an API error, not app-not-found")
+	}
+	// API failure error must NOT wrap ErrAppNotFound — only app-not-found errors
+	// are deferral-eligible.
+	if errors.Is(err, drivers.ErrAppNotFound) {
+		t.Errorf("error from API failure must not wrap ErrAppNotFound; got: %v", err)
+	}
+}
+
+// --- Update deferral tests ---
+
+// TestDatabaseDriver_Update_AppNotYetExisting_DefersAndAppliesPartialRules
+// verifies the same deferral behaviour on the Update path: when a type=app
+// trusted_source can't be resolved, Update applies the resolvable rules
+// immediately and queues a deferred update for the full rule set.
+func TestDatabaseDriver_Update_AppNotYetExisting_DefersAndAppliesPartialRules(t *testing.T) {
+	dbMock := &mockDatabaseClient{db: testDatabase()}
+	appMock := &mockAppClient{listApps: []*godo.App{}} // app not found
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	_, err := d.Update(context.Background(),
+		interfaces.ResourceRef{Name: "my-db", ProviderID: "db-123"},
+		interfaces.ResourceSpec{
+			Name: "my-db",
+			Config: map[string]any{
+				"size": "db-s-1vcpu-1gb",
+				"trusted_sources": []any{
+					map[string]any{"type": "ip_addr", "value": "10.20.0.0/16"},
+					map[string]any{"type": "app", "value": "coredump-staging"},
+				},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("Update should succeed even when app ref is not yet resolvable; got: %v", err)
+	}
+	// Partial rules (ip_addr only) should have been applied immediately.
+	if dbMock.lastFirewallReq == nil {
+		t.Fatal("UpdateFirewallRules should be called for partial rules")
+	}
+	if len(dbMock.lastFirewallReq.Rules) != 1 {
+		t.Fatalf("expected 1 partial rule (ip_addr only), got %d: %+v",
+			len(dbMock.lastFirewallReq.Rules), dbMock.lastFirewallReq.Rules)
+	}
+	if dbMock.lastFirewallReq.Rules[0].Type != "ip_addr" {
+		t.Errorf("partial rule should be ip_addr, got %q", dbMock.lastFirewallReq.Rules[0].Type)
+	}
+	if !d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be true after deferred update")
+	}
+}
+
+// --- FlushDeferredUpdates tests ---
+
+// TestDatabaseDriver_FlushDeferredUpdates_FullRulesApplied verifies that after
+// a deferred create, FlushDeferredUpdates calls UpdateFirewallRules with the
+// full rule set (including app UUID) once the app is available.
+func TestDatabaseDriver_FlushDeferredUpdates_FullRulesApplied(t *testing.T) {
+	const appUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	dbMock := &mockDatabaseClient{db: testDatabase()}
+	// First call returns empty (create time); second+ returns app (flush time).
+	appMock := &countedAppClient{
+		apps:     []*godo.App{makeAppForTrustedSource("coredump-staging", appUUID)},
+		emptyFor: 1, // first call (during Create) returns empty
+	}
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	// Create triggers deferred path.
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-db",
+		Config: map[string]any{
+			"engine": "pg",
+			"trusted_sources": []any{
+				map[string]any{"type": "app", "value": "coredump-staging"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !d.HasDeferredUpdates() {
+		t.Fatal("expected deferred update queued after create")
+	}
+
+	// Flush — app now exists.
+	if err := d.FlushDeferredUpdates(context.Background()); err != nil {
+		t.Fatalf("FlushDeferredUpdates: %v", err)
+	}
+
+	// UpdateFirewallRules should have been called with the app UUID.
+	if dbMock.lastFirewallReq == nil {
+		t.Fatal("UpdateFirewallRules was not called during flush")
+	}
+	if len(dbMock.lastFirewallReq.Rules) != 1 {
+		t.Fatalf("expected 1 rule after flush, got %d: %+v",
+			len(dbMock.lastFirewallReq.Rules), dbMock.lastFirewallReq.Rules)
+	}
+	rule := dbMock.lastFirewallReq.Rules[0]
+	if rule.Type != "app" || rule.Value != appUUID {
+		t.Errorf("flush rule = {%s %s}, want {app %s}", rule.Type, rule.Value, appUUID)
+	}
+	// After flush, deferred queue is cleared.
+	if d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be false after successful flush")
+	}
+}
+
+// TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError verifies that
+// when UpdateFirewallRules fails during flush, FlushDeferredUpdates returns
+// an error (fatal — operator needs to know intent diverged from achieved state).
+func TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError(t *testing.T) {
+	const appUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	dbMock := &mockDatabaseClient{
+		db:          testDatabase(),
+		firewallErr: fmt.Errorf("UpdateFirewallRules: service unavailable"),
+	}
+	appMock := &countedAppClient{
+		apps:     []*godo.App{makeAppForTrustedSource("coredump-staging", appUUID)},
+		emptyFor: 1,
+	}
+	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-db",
+		Config: map[string]any{
+			"engine": "pg",
+			"trusted_sources": []any{
+				map[string]any{"type": "app", "value": "coredump-staging"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := d.FlushDeferredUpdates(context.Background()); err == nil {
+		t.Fatal("FlushDeferredUpdates should return error when UpdateFirewallRules fails")
+	}
+}
+
+// TestDatabaseDriver_HasDeferredUpdates_FalseWhenNone verifies baseline:
+// a freshly-created driver with no deferred state reports false.
+func TestDatabaseDriver_HasDeferredUpdates_FalseWhenNone(t *testing.T) {
+	d := drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3")
+	if d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be false for a fresh driver")
+	}
+}
+
+// TestDatabaseDriver_FlushDeferredUpdates_NoopWhenEmpty verifies that calling
+// FlushDeferredUpdates on a driver with no pending updates returns nil.
+func TestDatabaseDriver_FlushDeferredUpdates_NoopWhenEmpty(t *testing.T) {
+	d := drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3")
+	if err := d.FlushDeferredUpdates(context.Background()); err != nil {
+		t.Fatalf("FlushDeferredUpdates on empty driver should return nil; got: %v", err)
+	}
+}

--- a/internal/drivers/database_deferred_test.go
+++ b/internal/drivers/database_deferred_test.go
@@ -249,10 +249,18 @@ func TestDatabaseDriver_FlushDeferredUpdates_FullRulesApplied(t *testing.T) {
 	}
 }
 
-// TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError verifies that
-// when UpdateFirewallRules fails during flush, FlushDeferredUpdates returns
-// an error (fatal — operator needs to know intent diverged from achieved state).
-func TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError(t *testing.T) {
+// TestDatabaseDriver_FlushDeferredUpdates_APIError_RetainsQueue verifies that
+// when UpdateFirewallRules fails during flush, FlushDeferredUpdates returns an
+// error AND retains the failed entry in the pending queue so a subsequent
+// Apply (once the API is reachable) will automatically re-attempt the flush
+// without requiring operator intervention (e.g. touching a config field to
+// force a Diff update).
+//
+// This is the correct behaviour: silently clearing the queue on failure would
+// leave the database permanently stuck with partial rules because DatabaseDriver.Diff
+// does not compare trusted_sources, so a retry Apply would produce no update
+// action and the second-pass flush would never fire.
+func TestDatabaseDriver_FlushDeferredUpdates_APIError_RetainsQueue(t *testing.T) {
 	const appUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	dbMock := &mockDatabaseClient{
 		db:          testDatabase(),
@@ -279,6 +287,10 @@ func TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError(t *testing.T)
 
 	if err := d.FlushDeferredUpdates(context.Background()); err == nil {
 		t.Fatal("FlushDeferredUpdates should return error when UpdateFirewallRules fails")
+	}
+	// Failed entry must be retained so a retry Apply can re-attempt the flush.
+	if !d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() must be true after failed flush — retry Apply must re-attempt without operator intervention")
 	}
 }
 

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -540,14 +540,20 @@ func TestDatabaseDriver_Update_WithTrustedSources_AppNameResolved(t *testing.T) 
 	}
 }
 
-func TestDatabaseDriver_Create_AppNameNotFound_ReturnsError(t *testing.T) {
-	// When the app name cannot be found in the Apps list, Create must return an
-	// error that wraps ErrResourceNotFound and names the missing app.
+func TestDatabaseDriver_Create_AppNameNotFound_Defers(t *testing.T) {
+	// When the app name cannot be found in the Apps list at create time, Create
+	// must SUCCEED (no error), create the DB without the app-based firewall rule,
+	// and queue a deferred update for the post-apply pass. This replaces the
+	// old fail-on-not-found behaviour: the root cause is apply-ordering (DB is
+	// created before the app in the same plan); erroring here prevents the DB
+	// from being created at all, which is worse.
+	//
+	// See drivers.ErrAppNotFound and DatabaseDriver.FlushDeferredUpdates.
 	dbMock := &mockDatabaseClient{db: testDatabase()}
 	appMock := &mockAppClient{listApps: []*godo.App{}} // empty list — name not found
 	d := drivers.NewDatabaseDriverWithClients(dbMock, appMock, "nyc3")
 
-	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
 		Name: "my-db",
 		Config: map[string]any{
 			"engine": "pg",
@@ -556,14 +562,21 @@ func TestDatabaseDriver_Create_AppNameNotFound_ReturnsError(t *testing.T) {
 			},
 		},
 	})
-	if err == nil {
-		t.Fatal("expected error when app name not found, got nil")
+	if err != nil {
+		t.Fatalf("Create should succeed (deferred) when app name not found; got: %v", err)
 	}
-	if !errors.Is(err, drivers.ErrResourceNotFound) {
-		t.Errorf("expected error to wrap drivers.ErrResourceNotFound; got: %v", err)
+	if out == nil || out.ProviderID != "db-123" {
+		t.Fatalf("Create should return db output; got %+v", out)
 	}
-	if !strings.Contains(err.Error(), "nonexistent-app") {
-		t.Errorf("expected error to mention missing app name %q; got: %v", "nonexistent-app", err)
+	// DB should be created without any app-based rules.
+	if dbMock.lastCreateReq == nil {
+		t.Fatal("no create request captured")
+	}
+	if len(dbMock.lastCreateReq.Rules) != 0 {
+		t.Errorf("expected 0 rules in create request (app rule deferred); got %d", len(dbMock.lastCreateReq.Rules))
+	}
+	if !d.HasDeferredUpdates() {
+		t.Error("HasDeferredUpdates() should be true after deferred create")
 	}
 }
 

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -224,6 +224,17 @@ type upsertSupporter interface {
 	SupportsUpsert() bool
 }
 
+// deferredUpdater is an optional interface for ResourceDrivers that accumulate
+// resource-level updates that cannot be applied until all plan creates complete.
+// The canonical case is DatabaseDriver deferring type=app trusted_sources entries
+// that reference apps created later in the same plan. Apply calls
+// FlushDeferredUpdates once after the main action loop; errors are appended to
+// ApplyResult.Errors so the failure is visible to the operator.
+type deferredUpdater interface {
+	HasDeferredUpdates() bool
+	FlushDeferredUpdates(ctx context.Context) error
+}
+
 // Apply executes the plan.
 func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*interfaces.ApplyResult, error) {
 	result := &interfaces.ApplyResult{PlanID: plan.ID}
@@ -326,6 +337,35 @@ func (p *DOProvider) Apply(ctx context.Context, plan *interfaces.IaCPlan) (*inte
 			})
 		}
 	}
+
+	// Second pass: flush deferred updates accumulated by drivers during the main
+	// action loop. These arise when a resource's config (e.g. DB trusted_sources
+	// with type=app) references another resource provisioned later in the same
+	// plan. By this point all plan creates have completed and the referenced
+	// resources exist. Each driver type is flushed at most once.
+	seen := make(map[string]struct{}, len(plan.Actions))
+	for _, action := range plan.Actions {
+		if _, done := seen[action.Resource.Type]; done {
+			continue
+		}
+		seen[action.Resource.Type] = struct{}{}
+		d, dErr := p.ResourceDriver(action.Resource.Type)
+		if dErr != nil {
+			continue
+		}
+		du, ok := d.(deferredUpdater)
+		if !ok || !du.HasDeferredUpdates() {
+			continue
+		}
+		if flushErr := du.FlushDeferredUpdates(ctx); flushErr != nil {
+			result.Errors = append(result.Errors, interfaces.ActionError{
+				Resource: action.Resource.Name,
+				Action:   "deferred_update",
+				Error:    flushErr.Error(),
+			})
+		}
+	}
+
 	return result, nil
 }
 

--- a/internal/provider_deferred_test.go
+++ b/internal/provider_deferred_test.go
@@ -1,0 +1,144 @@
+package internal
+
+// TDD test for DOProvider.Apply second-pass deferred flush.
+//
+// Regression gate: Apply must call FlushDeferredUpdates on any driver that
+// accumulated pending updates during the main action loop. Without this, a
+// DB created with deferred app-ref trusted_sources never gets the full rules
+// applied, even after the app is provisioned in the same plan run.
+//
+// See docs/plans/2026-05-02-staging-deploy-blockers-design.md (Blocker 2).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// fakeAppForDeferred constructs a minimal *godo.App for deferred-test mocks.
+func fakeAppForDeferred(name, id string) *godo.App {
+	return &godo.App{ID: id, Spec: &godo.AppSpec{Name: name}}
+}
+
+// minimalDBMock satisfies drivers.DatabaseClient for the provider-level
+// deferred flush test. Stores the last UpdateFirewallRules request so the
+// test can assert the flush occurred.
+type minimalDBMock struct {
+	db              *godo.Database
+	lastFirewallReq *godo.DatabaseUpdateFirewallRulesRequest
+}
+
+func (m *minimalDBMock) Create(_ context.Context, _ *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error) {
+	return m.db, nil, nil
+}
+func (m *minimalDBMock) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
+	return m.db, nil, nil
+}
+func (m *minimalDBMock) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	if m.db == nil {
+		return nil, nil, nil
+	}
+	return []godo.Database{*m.db}, nil, nil
+}
+func (m *minimalDBMock) Resize(_ context.Context, _ string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
+	return nil, nil
+}
+func (m *minimalDBMock) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+func (m *minimalDBMock) UpdateFirewallRules(_ context.Context, _ string, req *godo.DatabaseUpdateFirewallRulesRequest) (*godo.Response, error) {
+	m.lastFirewallReq = req
+	return nil, nil
+}
+
+// sequencedAppsForDeferred returns empty on the first call, then the app list.
+// Simulates: DB create call (app absent) → flush call (app present).
+type sequencedAppsForDeferred struct {
+	apps      []*godo.App
+	callCount int
+}
+
+func (m *sequencedAppsForDeferred) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	m.callCount++
+	if m.callCount == 1 {
+		return []*godo.App{}, nil, nil // first call: app doesn't exist yet
+	}
+	return m.apps, nil, nil
+}
+
+// TestDOProvider_Apply_FlushesDeferred_AfterAllCreates verifies the end-to-end
+// deferred-update flow through DOProvider.Apply:
+//
+//  1. Plan has one "create" action for an infra.database with a type=app
+//     trusted_sources ref.
+//  2. During Create the app doesn't exist yet — driver defers.
+//  3. After the main action loop, Apply calls FlushDeferredUpdates.
+//  4. The flush calls UpdateFirewallRules with the full rule set (app UUID).
+func TestDOProvider_Apply_FlushesDeferred_AfterAllCreates(t *testing.T) {
+	const appUUID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+
+	dbMock := &minimalDBMock{db: &godo.Database{
+		ID:   "db-abc",
+		Name: "coredump-staging-db",
+		Connection: &godo.DatabaseConnection{
+			Host: "host.db.ondigitalocean.com",
+			Port: 5432,
+		},
+	}}
+	appsSeq := &sequencedAppsForDeferred{
+		apps: []*godo.App{fakeAppForDeferred("coredump-staging", appUUID)},
+	}
+	dbDriver := drivers.NewDatabaseDriverWithClients(dbMock, appsSeq, "nyc3")
+
+	p := &DOProvider{
+		drivers: map[string]interfaces.ResourceDriver{
+			"infra.database": dbDriver,
+		},
+	}
+
+	plan := &interfaces.IaCPlan{
+		ID: "test-plan",
+		Actions: []interfaces.PlanAction{
+			{
+				Action: "create",
+				Resource: interfaces.ResourceSpec{
+					Name: "coredump-staging-db",
+					Type: "infra.database",
+					Config: map[string]any{
+						"engine": "pg",
+						"trusted_sources": []any{
+							map[string]any{"type": "app", "value": "coredump-staging"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := p.Apply(context.Background(), plan)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Fatalf("Apply result errors: %+v", result.Errors)
+	}
+	if len(result.Resources) != 1 {
+		t.Fatalf("expected 1 created resource, got %d", len(result.Resources))
+	}
+
+	// The deferred flush should have called UpdateFirewallRules with app UUID.
+	if dbMock.lastFirewallReq == nil {
+		t.Fatal("UpdateFirewallRules was never called — deferred flush did not run")
+	}
+	if len(dbMock.lastFirewallReq.Rules) != 1 {
+		t.Fatalf("expected 1 rule in deferred flush, got %d: %+v",
+			len(dbMock.lastFirewallReq.Rules), dbMock.lastFirewallReq.Rules)
+	}
+	rule := dbMock.lastFirewallReq.Rules[0]
+	if rule.Type != "app" || rule.Value != appUUID {
+		t.Errorf("deferred flush rule = {%s %s}, want {app %s}", rule.Type, rule.Value, appUUID)
+	}
+}


### PR DESCRIPTION
## Summary

- `DatabaseDriver.Create` and `.Update` now defer firewall updates when a `trusted_sources` entry of `type: app` references an app that does not yet exist (first-deploy ordering), instead of failing with a resource-not-found error.
- `DOProvider.Apply` runs a second pass after the main action loop, calling `FlushDeferredUpdates` on any driver with pending updates — the full rule set (including resolved app UUIDs) is applied once apps are provisioned.
- `ErrAppNotFound` sentinel distinguishes "app not yet created" (deferral-eligible) from API-level failures (rate-limit, transient, auth) which are never silently deferred. Flush failures are fatal and surface in `ApplyResult.Errors`.

Fixes GoCodeAlone/core-dump#154 (R4 first-deploy ordering finding).
See `docs/plans/2026-05-02-staging-deploy-blockers-design.md` (Blocker 2).

## TDD Regression Invariant Proof

With fix reverted (Create propagates error on ErrAppNotFound without deferring):
```
$ GOWORK=off go test -v -run "TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds|TestDOProvider_Apply_FlushesDeferred_AfterAllCreates" ./internal/...
--- FAIL: TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds
    Create should succeed even when app ref is not yet resolvable; got: database create "my-db": trusted_sources app(s) "coredump-staging": trusted_sources app: resource not found
--- FAIL: TestDOProvider_Apply_FlushesDeferred_AfterAllCreates
    Apply result errors: [{Resource:coredump-staging-db Action:create Error:database create "coredump-staging-db": trusted_sources app(s) "coredump-staging": trusted_sources app: resource not found}]
FAIL
```

With fix restored:
```
$ GOWORK=off go test -v -run "TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds|TestDOProvider_Apply_FlushesDeferred_AfterAllCreates" ./internal/...
--- PASS: TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds
--- PASS: TestDOProvider_Apply_FlushesDeferred_AfterAllCreates
PASS
```

## Test plan

- [x] `TestDatabaseDriver_Create_AppNotYetExisting_DefersAndSucceeds` — app absent → Create succeeds, no app rules, deferred queued
- [x] `TestDatabaseDriver_Create_AppNotYetExisting_MixedRules` — ip_addr+app, app absent → ip_addr rule in create request, app deferred
- [x] `TestDatabaseDriver_Create_AppAPIFailure_NotDeferred` — API error → Create fails, NOT deferred, error is not ErrAppNotFound
- [x] `TestDatabaseDriver_Update_AppNotYetExisting_DefersAndAppliesPartialRules` — Update with unresolvable app → partial rules applied, deferred queued
- [x] `TestDatabaseDriver_FlushDeferredUpdates_FullRulesApplied` — after deferred create, flush calls UpdateFirewallRules with app UUID
- [x] `TestDatabaseDriver_FlushDeferredUpdates_APIError_ReturnsError` — flush propagates UpdateFirewallRules error
- [x] `TestDatabaseDriver_HasDeferredUpdates_FalseWhenNone` — fresh driver returns false
- [x] `TestDatabaseDriver_FlushDeferredUpdates_NoopWhenEmpty` — flush on empty driver returns nil
- [x] `TestDOProvider_Apply_FlushesDeferred_AfterAllCreates` — end-to-end: provider Apply calls flush after creates, UpdateFirewallRules receives app UUID
- [x] All existing tests pass (`GOWORK=off go test -count=1 ./internal/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)