### PR TITLE
fix(app-platform): handle ActiveDeployment.Phase transition states (#48)

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -231,18 +231,51 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 // appHealthResult evaluates all three DO deployment slots in priority order and
 // returns an accurate HealthResult:
 //
-//   - ActiveDeployment ACTIVE         → Healthy=true
-//   - InProgressDeployment (building) → Healthy=false, "deployment in progress: <phase>"
-//   - InProgressDeployment (failed)   → Healthy=false, "deployment failed: <phase>"
-//   - PendingDeployment               → Healthy=false, "deployment queued"
-//   - none of the above               → Healthy=false, "no deployment found"
+//   - ActiveDeployment ACTIVE                    → Healthy=true
+//   - ActiveDeployment transitioning (non-Active) → Healthy=false, "deployment in progress (active slot): <phase>" or "deployment failed (active slot): <phase>"
+//   - InProgressDeployment (building)            → Healthy=false, "deployment in progress: <phase>"
+//   - InProgressDeployment (failed)              → Healthy=false, "deployment failed: <phase>"
+//   - PendingDeployment                          → Healthy=false, "deployment queued"
+//   - none of the above                          → Healthy=false, "no deployment found"
 func appHealthResult(app *godo.App) *interfaces.HealthResult {
 	// 1. Active and healthy.
 	if app.ActiveDeployment != nil && app.ActiveDeployment.Phase == godo.DeploymentPhase_Active {
 		return &interfaces.HealthResult{Healthy: true}
 	}
 
-	// 2. Deployment currently in progress — inspect its phase.
+	// 2a. ActiveDeployment populated but Phase not yet Active — covers the
+	// post-promotion-pre-active window where DO has moved the deployment out of
+	// the InProgressDeployment slot but its Phase is still transitioning toward
+	// Active. Without this check, the polling loop falls through to "no
+	// deployment found" and loops until timeout (issue #48).
+	if dep := app.ActiveDeployment; dep != nil {
+		switch dep.Phase {
+		case godo.DeploymentPhase_PendingBuild,
+			godo.DeploymentPhase_Building,
+			godo.DeploymentPhase_PendingDeploy,
+			godo.DeploymentPhase_Deploying:
+			return &interfaces.HealthResult{
+				Healthy: false,
+				Message: fmt.Sprintf("deployment in progress (active slot): %s", dep.Phase),
+			}
+		case godo.DeploymentPhase_Error,
+			godo.DeploymentPhase_Canceled,
+			godo.DeploymentPhase_Superseded:
+			return &interfaces.HealthResult{
+				Healthy: false,
+				Message: fmt.Sprintf("deployment failed (active slot): %s", dep.Phase),
+			}
+		default:
+			// Forward-compat: a future godo release may add new phases.
+			// Report "unknown" rather than "failed" to avoid mislabeling.
+			return &interfaces.HealthResult{
+				Healthy: false,
+				Message: fmt.Sprintf("unknown phase (active slot): %s", dep.Phase),
+			}
+		}
+	}
+
+	// 2b. Deployment currently in progress in the InProgress slot — inspect its phase.
 	if dep := app.InProgressDeployment; dep != nil {
 		switch dep.Phase {
 		case godo.DeploymentPhase_PendingBuild,

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -912,6 +912,93 @@ func TestAppPlatformDriver_HealthCheck_InProgress_UnknownPhase(t *testing.T) {
 	}
 }
 
+// ── Active-slot phase-transition tests (issue #48) ───────────────────────────
+//
+// When DO promotes a deployment from InProgressDeployment to ActiveDeployment,
+// there is a window where InProgressDeployment is nil but
+// ActiveDeployment.Phase is still transitioning (e.g. Deploying, PendingDeploy)
+// before reaching Active. The previous appHealthResult returned "no deployment
+// found" in that window, locking polling callers into a false-negative loop.
+
+// TestAppHealthResult_ActiveSlotDeployingPhase covers the core bug: ActiveDeployment
+// with Deploying phase and no InProgressDeployment must return in-progress, not
+// "no deployment found".
+func TestAppHealthResult_ActiveSlotDeployingPhase(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		// ActiveDeployment present but Phase still Deploying; InProgress slot nil.
+		app: appWithPhases(phasePtr(godo.DeploymentPhase_Deploying), nil, nil),
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false while ActiveDeployment.Phase=Deploying")
+	}
+	if !strings.Contains(result.Message, "in progress") {
+		t.Errorf("message should contain 'in progress', got: %q", result.Message)
+	}
+	// Must NOT fall through to the "no deployment found" terminal branch.
+	if strings.Contains(result.Message, "no deployment") {
+		t.Errorf("must not return 'no deployment found' during active-slot transition, got: %q", result.Message)
+	}
+}
+
+// TestAppHealthResult_ActiveSlotErrorPhase covers terminal failure when the
+// ActiveDeployment slot is populated with a failed phase.
+func TestAppHealthResult_ActiveSlotErrorPhase(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app: appWithPhases(phasePtr(godo.DeploymentPhase_Error), nil, nil),
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false for ActiveDeployment.Phase=Error")
+	}
+	if !strings.Contains(result.Message, "failed") {
+		t.Errorf("message should contain 'failed', got: %q", result.Message)
+	}
+}
+
+// TestAppHealthResult_ActiveSlotActivePhaseStillHealthy is a regression guard:
+// ActiveDeployment.Phase=Active must remain the healthy path after the new
+// checks are inserted.
+func TestAppHealthResult_ActiveSlotActivePhaseStillHealthy(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app: appWithPhases(phasePtr(godo.DeploymentPhase_Active), nil, nil),
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Errorf("expected Healthy=true for ActiveDeployment.Phase=Active, got message: %q", result.Message)
+	}
+}
+
+// TestAppHealthResult_PriorityActiveActiveSlotOverInProgress verifies that when
+// ActiveDeployment.Phase=Active and InProgressDeployment.Phase=Deploying both
+// exist simultaneously (a valid DO transient state during rolling updates),
+// Healthy=true is returned — Active wins.
+func TestAppHealthResult_PriorityActiveActiveSlotOverInProgress(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app: appWithPhases(
+			phasePtr(godo.DeploymentPhase_Active),
+			phasePtr(godo.DeploymentPhase_Deploying),
+			nil,
+		),
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "phased-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Errorf("expected Healthy=true when Active(Active)+InProgress(Deploying); got message: %q", result.Message)
+	}
+}
+
 // ── ParseImageRef unit tests ──────────────────────────────────────────────────
 
 func TestParseImageRef_DOCR(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #48. Fixes `appHealthResult` false-negative when the `ActiveDeployment` slot is populated but its `Phase` has not yet transitioned to `Active`.

## Bug

Surfaced in core-dump staging deploy [25258558716](https://github.com/GoCodeAlone/core-dump/actions/runs/25258558716): 1-second transition from "deployment in progress: DEPLOYING" to "no deployment found" → 10-minute timeout instead of detecting the eventually-healthy deployment.

When DO promotes a deployment from `InProgressDeployment` to `ActiveDeployment`, there is a window where `InProgressDeployment` is `nil` but `ActiveDeployment.Phase` is still `Deploying` (or another transitioning phase). The previous code fell through all checks and returned "no deployment found" in that window.

## Fix

When `ActiveDeployment` is populated but `Phase != Active`, classify the deployment by phase (mirrors the existing `InProgressDeployment` switch logic). The "no deployment found" terminal branch only fires when all three slots (`ActiveDeployment`, `InProgressDeployment`, `PendingDeployment`) are `nil`.

## Test plan

- [x] `go test ./internal/drivers/ -run TestAppHealth` — 4 new tests cover the active-slot transition states + priority-vs-InProgress regression
- [x] `go test ./...` — full suite green (159 tests across 3 packages)
- [ ] Validates post-merge against core-dump staging deploy via PR-D3 lockfile bump chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>