### PR TITLE
feat(app-platform): fetch DO deploy logs in Troubleshoot + ListDeployments fallback in health poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,10 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   rather than falling through to `"no deployment found"`. Fixes the polling
   loop timeout described in GoCodeAlone/workflow-plugin-digitalocean#48.
 
-### Fixed
-
-- **Apply `"delete"` action** — The `Apply` method now dispatches `"delete"`
-  reports 404), `InSync` (cloud Read succeeds), or `Unknown` (driver lookup
-  fails). Required for `wfctl infra apply --refresh` ghost-prune (workflow
-  v0.20.5+).
+- **`DOProvider.DetectDrift`** — real implementation classifying resources as
+  `DriftClassGhost` (cloud reports 404), `DriftClassInSync` (cloud Read
+  succeeds), or `DriftClassUnknown` (driver lookup fails). Required for
+  `wfctl infra apply --refresh` ghost-prune (workflow v0.20.5+).
 
   - `DriftClassGhost` (`Drifted: true`): state has the resource, but cloud
     `Read` returns `interfaces.ErrResourceNotFound`. Caller should prune state
@@ -66,6 +64,8 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   `interfaces.ErrResourceNotFound` (HTTP 404) gates the ghost path.
 
   go.mod bumped to workflow v0.20.5 for `interfaces.DriftClass*` constants.
+
+### Fixed
 
 - **DetectDrift Config-drift detection**: out of scope for this release. The
   IaCProvider interface signature receives only refs, not the parsed declared
@@ -108,8 +108,6 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
   Fixes GoCodeAlone/core-dump#154 (R4 first-deploy ordering finding).
   See `docs/plans/2026-05-02-staging-deploy-blockers-design.md` (Blocker 2).
-
-### Fixed
 
 - **Apply `"delete"` action** — The `Apply` method now dispatches `"delete"`
   plan actions to `d.Delete(ctx, ref)` using `action.Current` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,49 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ### Added
 
-- **DetectDrift**: real implementation classifying resources as `Ghost` (cloud
+- **Troubleshoot fetches DO deploy/build logs** (PR-E2) — `AppPlatformDriver.Troubleshoot`
+  now calls `godo.AppsService.GetLogs` for each component in any deployment
+  whose phase is `Error`, `Canceled`, or `Superseded`. The DO API returns
+  presigned historic URLs; the plugin HTTP-fetches the most recent URL and
+  appends the last 200 lines per component to `Diagnostic.Detail` as a
+  delimited block:
+
+  ```
+  ---
+  Deploy logs — component "web" (last 200 lines):
+  <log content>
+  ---
+  ```
+
+  For build-phase failures (a `SummaryStep` named `"build"` with status
+  `Error`), `AppLogTypeBuild` is requested; all other failures use
+  `AppLogTypeDeploy`. Multi-component apps produce one block per component
+  (Services, Jobs, Workers, Functions enumerated from `dep.Spec`); if `Spec`
+  is nil or all arrays are empty, a single aggregate fetch is performed
+  (component `""` = DO API aggregate).
+
+  Graceful degradation: `GetLogs` error or HTTP-fetch non-200 are logged to
+  stderr; the `Diagnostic` is still produced without the log block. A 10 MB
+  cap prevents pathological log responses.
+
+- **`appHealthResult` ListDeployments fallback** (PR-E2) — When all three
+  deployment slots (`Active`, `InProgress`, `Pending`) are nil, `HealthCheck`
+  now falls back to `ListDeployments(Page:1, PerPage:1)` and surfaces the
+  latest deployment's short ID + phase: `"latest deployment f8b6200c: ERROR"`.
+  This catches the fast-fail case where DO removes a failed deployment from
+  all three slots before the operator's poll loop catches up (reproducer: build
+  error in ≤1 second). If `ListDeployments` errors or returns empty, falls
+  through to the previous `"no deployment found"` message.
+
+- **`appHealthResult` phase-transition handling** (PR #49) — When
+  `ActiveDeployment.Phase` is non-Active (transitioning toward Active or
+  failed), the function now returns the appropriate in-progress/failed message
+  rather than falling through to `"no deployment found"`. Fixes the polling
+  loop timeout described in GoCodeAlone/workflow-plugin-digitalocean#48.
+
+### Fixed
+
+- **Apply `"delete"` action** — The `Apply` method now dispatches `"delete"`
   reports 404), `InSync` (cloud Read succeeds), or `Unknown` (driver lookup
   fails). Required for `wfctl infra apply --refresh` ghost-prune (workflow
   v0.20.5+).

--- a/internal/drivers/api_gateway.go
+++ b/internal/drivers/api_gateway.go
@@ -146,7 +146,10 @@ func (d *APIGatewayDriver) HealthCheck(ctx context.Context, ref interfaces.Resou
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
-	return appHealthResult(app), nil
+	// APIGatewayDriver's client does not have ListDeployments; pass nil so the
+	// fallback history path is skipped and the function falls through to "no
+	// deployment found" if all three slots are empty.
+	return appHealthResult(ctx, nil, app), nil
 }
 
 func (d *APIGatewayDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -3,12 +3,15 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -456,7 +459,10 @@ func (d *AppPlatformDriver) attachDeployLogs(ctx context.Context, appID string, 
 		}
 		tail, err := fetchLogTail(ctx, logs.HistoricURLs, troubleshootLogTailLines)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "troubleshoot: log HTTP fetch app=%s dep=%s component=%q: %v\n", appID, dep.ID, comp, err)
+			// Don't print err verbatim — net/http error strings embed the
+			// presigned URL, leaking AWS-style signed credentials to the
+			// operator's terminal log. Surface only the redacted shape.
+			fmt.Fprintf(os.Stderr, "troubleshoot: log HTTP fetch app=%s dep=%s component=%q: %s (presigned URL not logged)\n", appID, dep.ID, comp, redactURLError(err))
 			continue
 		}
 		if tail == "" {
@@ -466,8 +472,28 @@ func (d *AppPlatformDriver) attachDeployLogs(ctx context.Context, appID string, 
 		if label == "" {
 			label = "<all>"
 		}
-		diag.Detail += fmt.Sprintf("\n\n---\nDeploy logs — component %q (last %d lines):\n%s\n---", label, troubleshootLogTailLines, tail)
+		header := "Deploy logs"
+		if logType == godo.AppLogTypeBuild {
+			header = "Build logs"
+		}
+		diag.Detail += fmt.Sprintf("\n\n---\n%s — component %q (last %d lines):\n%s\n---", header, label, troubleshootLogTailLines, tail)
 	}
+}
+
+// redactURLError returns an error string with any embedded URL replaced by
+// "<redacted-url>". DO's GetLogs returns presigned HistoricURLs that embed
+// signed credentials; net/http errors typically include the full request URL,
+// so verbatim logging would leak short-lived creds to the operator's log.
+func redactURLError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		// url.Error.Error() = "Op URL: Err". Hide the URL.
+		return fmt.Sprintf("%s <redacted-url>: %v", ue.Op, ue.Err)
+	}
+	return err.Error()
 }
 
 // chooseLogType returns AppLogTypeBuild when the deployment's Progress
@@ -528,7 +554,12 @@ func deploymentComponents(dep *godo.Deployment) []string {
 // fetchLogTail fetches log content from the most recent historic URL (index 0)
 // and returns the last tailLines lines. HistoricURLs is ordered newest-first
 // per the DO API. A 10 MB cap prevents pathological responses from exhausting
-// memory.
+// memory. The local 30s client timeout is a defense in depth: callers
+// typically pass a ctx with a deadline, but if a future caller passes
+// context.Background, http.DefaultClient (no timeout) would let the fetch
+// hang indefinitely on a slow presigned URL.
+var fetchLogClient = &http.Client{Timeout: 30 * time.Second}
+
 func fetchLogTail(ctx context.Context, urls []string, tailLines int) (string, error) {
 	if len(urls) == 0 {
 		return "", nil
@@ -537,7 +568,7 @@ func fetchLogTail(ctx context.Context, urls []string, tailLines int) (string, er
 	if err != nil {
 		return "", err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := fetchLogClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -4,12 +4,20 @@ package drivers
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
+	"os"
 	"strings"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
 )
+
+// troubleshootLogTailLines is the number of recent log lines fetched per
+// component for failed deployments. 200 is enough to capture a typical
+// panic/error trace without overwhelming the operator's terminal.
+const troubleshootLogTailLines = 200
 
 // ErrResourceNotFound is returned when a resource cannot be located by name or ID.
 // It is an alias for interfaces.ErrResourceNotFound so that cross-package
@@ -25,6 +33,7 @@ type AppPlatformClient interface {
 	CreateDeployment(ctx context.Context, appID string, req ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error)
 	ListDeployments(ctx context.Context, appID string, opts *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error)
 	Delete(ctx context.Context, appID string) (*godo.Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType godo.AppLogType, follow bool, tailLines int) (*godo.AppLogs, *godo.Response, error)
 }
 
 type appPlatformMigrationRepairClient interface {
@@ -225,8 +234,17 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
-	return appHealthResult(app), nil
+	listFn := func(ctx context.Context, appID string) ([]*godo.Deployment, error) {
+		deps, _, err := d.client.ListDeployments(ctx, appID, &godo.ListOptions{Page: 1, PerPage: 1})
+		return deps, err
+	}
+	return appHealthResult(ctx, listFn, app), nil
 }
+
+// listDeploymentsFn is a function that returns the most recent deployment(s)
+// for an app. It is passed to appHealthResult so the fallback path can be
+// tested without coupling appHealthResult to a concrete driver type.
+type listDeploymentsFn func(ctx context.Context, appID string) ([]*godo.Deployment, error)
 
 // appHealthResult evaluates all three DO deployment slots in priority order and
 // returns an accurate HealthResult:
@@ -236,8 +254,13 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 //   - InProgressDeployment (building)            → Healthy=false, "deployment in progress: <phase>"
 //   - InProgressDeployment (failed)              → Healthy=false, "deployment failed: <phase>"
 //   - PendingDeployment                          → Healthy=false, "deployment queued"
-//   - none of the above                          → Healthy=false, "no deployment found"
-func appHealthResult(app *godo.App) *interfaces.HealthResult {
+//   - none of the above, with history            → Healthy=false, "latest deployment <id>: <phase>"
+//   - none of the above, no history              → Healthy=false, "no deployment found"
+//
+// listFn is called only when all three slots are nil; it may be nil (in which
+// case the ListDeployments fallback is skipped and "no deployment found" is
+// returned immediately).
+func appHealthResult(ctx context.Context, listFn listDeploymentsFn, app *godo.App) *interfaces.HealthResult {
 	// 1. Active and healthy.
 	if app.ActiveDeployment != nil && app.ActiveDeployment.Phase == godo.DeploymentPhase_Active {
 		return &interfaces.HealthResult{Healthy: true}
@@ -308,8 +331,31 @@ func appHealthResult(app *godo.App) *interfaces.HealthResult {
 		return &interfaces.HealthResult{Healthy: false, Message: "deployment queued"}
 	}
 
-	// 4. No deployment at all (first-deploy not yet kicked off, or app never deployed).
+	// 4. All three slots empty — fall back to deployment history. This catches the
+	// case where DO has removed a failed/superseded deployment from all 3 slots
+	// before the next one starts (e.g. fast-fail at build time leaves the app
+	// with no current deployment but recent history).
+	if listFn != nil {
+		if hist, err := listFn(ctx, app.ID); err == nil && len(hist) > 0 {
+			latest := hist[0]
+			return &interfaces.HealthResult{
+				Healthy: false,
+				Message: fmt.Sprintf("latest deployment %s: %s", shortDepID(latest.ID), latest.Phase),
+			}
+		}
+	}
+
+	// No deployment slot AND no history available.
 	return &interfaces.HealthResult{Healthy: false, Message: "no deployment found"}
+}
+
+// shortDepID truncates a deployment UUID to its first 8 characters for
+// log readability (e.g. "f8b6200c" instead of the full UUID).
+func shortDepID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
+	}
+	return id
 }
 
 func (d *AppPlatformDriver) Scale(ctx context.Context, ref interfaces.ResourceRef, replicas int) (*interfaces.ResourceOutput, error) {
@@ -342,6 +388,12 @@ const troubleshootMaxDeployments = 5
 // Pending, Active) plus recent historical deployments, prioritises them, and
 // returns per-deployment Diagnostics so wfctl can render a structured failure
 // block on health-check timeout without requiring a DO console visit.
+//
+// For each candidate deployment in a terminal error phase (Error, Canceled,
+// Superseded), Troubleshoot fetches deploy logs via GetLogs and appends the
+// last troubleshootLogTailLines of output per component to the Diagnostic.Detail.
+// Log fetch failures are best-effort: the Diagnostic is still produced without
+// the log block when GetLogs or the HTTP fetch fails.
 func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.ResourceRef, _ string) ([]interfaces.Diagnostic, error) {
 	if ref.ProviderID == "" {
 		return nil, nil
@@ -360,11 +412,154 @@ func (d *AppPlatformDriver) Troubleshoot(ctx context.Context, ref interfaces.Res
 	}
 	var out []interfaces.Diagnostic
 	for _, dep := range candidates {
-		if diag := buildDiagnosticFor(dep); diag != nil {
-			out = append(out, *diag)
+		diag := buildDiagnosticFor(dep)
+		if diag == nil {
+			continue
 		}
+		// Attach deploy/build logs for terminal error phases.
+		if isTerminalErrorPhase(dep.Phase) {
+			d.attachDeployLogs(ctx, ref.ProviderID, dep, diag)
+		}
+		out = append(out, *diag)
 	}
 	return out, nil
+}
+
+// isTerminalErrorPhase reports whether a deployment phase indicates a terminal
+// failure for which fetching logs is useful.
+func isTerminalErrorPhase(phase godo.DeploymentPhase) bool {
+	switch phase {
+	case godo.DeploymentPhase_Error,
+		godo.DeploymentPhase_Canceled,
+		godo.DeploymentPhase_Superseded:
+		return true
+	}
+	return false
+}
+
+// attachDeployLogs fetches DO deploy (or build) logs for a failed deployment
+// and appends delimited log blocks to diag.Detail. One block per component.
+// Failures are best-effort: errors are logged to stderr but diag is never
+// withheld.
+func (d *AppPlatformDriver) attachDeployLogs(ctx context.Context, appID string, dep *godo.Deployment, diag *interfaces.Diagnostic) {
+	logType := chooseLogType(dep)
+	components := deploymentComponents(dep)
+
+	for _, comp := range components {
+		logs, _, err := d.client.GetLogs(ctx, appID, dep.ID, comp, logType, false, troubleshootLogTailLines)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "troubleshoot: GetLogs app=%s dep=%s component=%q: %v\n", appID, dep.ID, comp, err)
+			continue
+		}
+		if logs == nil || len(logs.HistoricURLs) == 0 {
+			continue
+		}
+		tail, err := fetchLogTail(ctx, logs.HistoricURLs, troubleshootLogTailLines)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "troubleshoot: log HTTP fetch app=%s dep=%s component=%q: %v\n", appID, dep.ID, comp, err)
+			continue
+		}
+		if tail == "" {
+			continue
+		}
+		label := comp
+		if label == "" {
+			label = "<all>"
+		}
+		diag.Detail += fmt.Sprintf("\n\n---\nDeploy logs — component %q (last %d lines):\n%s\n---", label, troubleshootLogTailLines, tail)
+	}
+}
+
+// chooseLogType returns AppLogTypeBuild when the deployment's Progress
+// indicates a build-phase failure (a SummaryStep named "build" has status
+// Error), and AppLogTypeDeploy otherwise. Defaults to AppLogTypeDeploy when
+// Progress is nil or no build step error is found.
+func chooseLogType(dep *godo.Deployment) godo.AppLogType {
+	if dep.Progress == nil {
+		return godo.AppLogTypeDeploy
+	}
+	for _, step := range dep.Progress.SummarySteps {
+		if step.Status == godo.DeploymentProgressStepStatus_Error &&
+			strings.EqualFold(step.Name, "build") {
+			return godo.AppLogTypeBuild
+		}
+	}
+	return godo.AppLogTypeDeploy
+}
+
+// deploymentComponents returns the list of component names to fetch logs for.
+// Components are collected from Services, Jobs, Workers, and Functions (if the
+// AppSpec is present). If the spec is nil or all four arrays are empty, a
+// single empty string is returned — the DO API treats component="" as "all
+// components aggregated".
+func deploymentComponents(dep *godo.Deployment) []string {
+	if dep.Spec == nil {
+		// No spec available — fall back to aggregate ("" = all components).
+		return []string{""}
+	}
+	var names []string
+	for _, svc := range dep.Spec.Services {
+		if svc != nil && svc.Name != "" {
+			names = append(names, svc.Name)
+		}
+	}
+	for _, job := range dep.Spec.Jobs {
+		if job != nil && job.Name != "" {
+			names = append(names, job.Name)
+		}
+	}
+	for _, w := range dep.Spec.Workers {
+		if w != nil && w.Name != "" {
+			names = append(names, w.Name)
+		}
+	}
+	for _, fn := range dep.Spec.Functions {
+		if fn != nil && fn.Name != "" {
+			names = append(names, fn.Name)
+		}
+	}
+	if len(names) == 0 {
+		// Spec present but no components enumerated — fall back to aggregate.
+		return []string{""}
+	}
+	return names
+}
+
+// fetchLogTail fetches log content from the most recent historic URL (index 0)
+// and returns the last tailLines lines. HistoricURLs is ordered newest-first
+// per the DO API. A 10 MB cap prevents pathological responses from exhausting
+// memory.
+func fetchLogTail(ctx context.Context, urls []string, tailLines int) (string, error) {
+	if len(urls) == 0 {
+		return "", nil
+	}
+	req, err := http.NewRequestWithContext(ctx, "GET", urls[0], nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("log fetch HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024)) // 10 MB cap
+	if err != nil {
+		return "", err
+	}
+	return tailString(string(body), tailLines), nil
+}
+
+// tailString returns the last n lines of s. If s has fewer than n lines, the
+// entire string is returned.
+func tailString(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
 }
 
 // pickTroubleshootDeployments returns up to 3 candidate deployments in priority

--- a/internal/drivers/app_platform_migration_repair_test.go
+++ b/internal/drivers/app_platform_migration_repair_test.go
@@ -1062,6 +1062,9 @@ func (m *migrationRepairBaseAppClient) ListDeployments(_ context.Context, _ stri
 func (m *migrationRepairBaseAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, nil
 }
+func (m *migrationRepairBaseAppClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
 
 type migrationRepairAppClient struct {
 	app                        *godo.App

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -79,6 +79,9 @@ func (c *stateHealClient) Delete(_ context.Context, appID string) (*godo.Respons
 	c.deleteCalledID = appID
 	return &godo.Response{Response: &http.Response{StatusCode: 204}}, c.deleteErr
 }
+func (c *stateHealClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
 
 // ── Create preserves UUID (regression: name must not be used as ProviderID) ──
 

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -33,6 +34,17 @@ type mockAppClient struct {
 	createDeploymentCalled bool
 	lastCreateReq          *godo.AppCreateRequest
 	lastUpdateReq          *godo.AppUpdateRequest
+	getLogsResult          *godo.AppLogs      // returned by GetLogs
+	getLogsErr             error              // error returned by GetLogs
+	getLogsRequests        []getLogsCall      // recorded GetLogs calls
+}
+
+// getLogsCall records a single GetLogs invocation for assertion in tests.
+type getLogsCall struct {
+	appID        string
+	deploymentID string
+	component    string
+	logType      godo.AppLogType
 }
 
 func (m *mockAppClient) Create(_ context.Context, req *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
@@ -58,6 +70,15 @@ func (m *mockAppClient) ListDeployments(_ context.Context, _ string, _ *godo.Lis
 }
 func (m *mockAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, m.err
+}
+func (m *mockAppClient) GetLogs(_ context.Context, appID, deploymentID, component string, logType godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	m.getLogsRequests = append(m.getLogsRequests, getLogsCall{
+		appID:        appID,
+		deploymentID: deploymentID,
+		component:    component,
+		logType:      logType,
+	})
+	return m.getLogsResult, nil, m.getLogsErr
 }
 
 func testApp() *godo.App {
@@ -1367,5 +1388,363 @@ func TestTroubleshoot_APIError(t *testing.T) {
 	_, err := d.Troubleshoot(context.Background(), ref, "")
 	if err != nil {
 		t.Fatalf("ListDeployments error should not propagate; got: %v", err)
+	}
+}
+
+// ── Troubleshoot GetLogs tests ────────────────────────────────────────────────
+
+// TestTroubleshoot_AttachesDeployLogsForFailedDeployment verifies that for an
+// Error-phase deployment, Troubleshoot calls GetLogs and the returned log
+// content (served by an httptest server) appears in Diagnostic.Detail with the
+// component name and delimiters.
+func TestTroubleshoot_AttachesDeployLogsForFailedDeployment(t *testing.T) {
+	const logContent = "error: image pull failed\nexit status 1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, logContent)
+	}))
+	defer srv.Close()
+
+	dep := &godo.Deployment{
+		ID:    "dep-err-001",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "image pull failed",
+		Spec: &godo.AppSpec{
+			Name: "my-app",
+			Services: []*godo.AppServiceSpec{
+				{Name: "web"},
+			},
+		},
+	}
+	mock := &mockAppClient{
+		app: &godo.App{
+			ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec: &godo.AppSpec{Name: "my-app"},
+			InProgressDeployment: dep,
+		},
+		getLogsResult: &godo.AppLogs{
+			HistoricURLs: []string{srv.URL},
+		},
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
+
+	diags, err := d.Troubleshoot(context.Background(), ref, "deployment failed")
+	if err != nil {
+		t.Fatalf("Troubleshoot: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Fatal("expected at least 1 diagnostic")
+	}
+	detail := diags[0].Detail
+	if !strings.Contains(detail, logContent) {
+		t.Errorf("Diagnostic.Detail missing log content\nDetail: %q\nWanted: %q", detail, logContent)
+	}
+	if !strings.Contains(detail, `"web"`) {
+		t.Errorf("Diagnostic.Detail missing component name %q\nDetail: %q", "web", detail)
+	}
+	if !strings.Contains(detail, "---") {
+		t.Errorf("Diagnostic.Detail missing delimiter\nDetail: %q", detail)
+	}
+	if !strings.Contains(detail, "Deploy logs") {
+		t.Errorf("Diagnostic.Detail missing 'Deploy logs' header\nDetail: %q", detail)
+	}
+}
+
+// TestTroubleshoot_AttachesBuildLogsForBuildErroredDeployment verifies that
+// when a SummaryStep named "build" has status Error, Troubleshoot requests
+// AppLogTypeBuild (not Deploy) from the mock.
+func TestTroubleshoot_AttachesBuildLogsForBuildErroredDeployment(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "build error: compilation failed")
+	}))
+	defer srv.Close()
+
+	dep := &godo.Deployment{
+		ID:    "dep-build-err",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "build failed",
+		Progress: &godo.DeploymentProgress{
+			SummarySteps: []*godo.DeploymentProgressStep{
+				{
+					Name:   "build",
+					Status: godo.DeploymentProgressStepStatus_Error,
+					Reason: &godo.DeploymentProgressStepReason{Message: "compilation failed"},
+				},
+			},
+		},
+		Spec: &godo.AppSpec{
+			Name:     "my-app",
+			Services: []*godo.AppServiceSpec{{Name: "api"}},
+		},
+	}
+	mock := &mockAppClient{
+		app: &godo.App{
+			ID:                   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec:                 &godo.AppSpec{Name: "my-app"},
+			InProgressDeployment: dep,
+		},
+		getLogsResult: &godo.AppLogs{
+			HistoricURLs: []string{srv.URL},
+		},
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
+
+	_, err := d.Troubleshoot(context.Background(), ref, "build failed")
+	if err != nil {
+		t.Fatalf("Troubleshoot: %v", err)
+	}
+	if len(mock.getLogsRequests) == 0 {
+		t.Fatal("expected GetLogs to be called")
+	}
+	if mock.getLogsRequests[0].logType != godo.AppLogTypeBuild {
+		t.Errorf("GetLogs logType = %q, want %q", mock.getLogsRequests[0].logType, godo.AppLogTypeBuild)
+	}
+}
+
+// TestTroubleshoot_GracefulOnGetLogsError verifies that when GetLogs returns
+// an error, the Diagnostic is still produced (no panic, no error return), and
+// the Detail does not contain a log block.
+func TestTroubleshoot_GracefulOnGetLogsError(t *testing.T) {
+	dep := &godo.Deployment{
+		ID:    "dep-getlogs-err",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "image pull failed",
+		Spec:  &godo.AppSpec{Name: "my-app", Services: []*godo.AppServiceSpec{{Name: "web"}}},
+	}
+	mock := &mockAppClient{
+		app: &godo.App{
+			ID:                   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec:                 &godo.AppSpec{Name: "my-app"},
+			InProgressDeployment: dep,
+		},
+		getLogsErr: errors.New("rate limited"),
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
+
+	diags, err := d.Troubleshoot(context.Background(), ref, "deployment failed")
+	if err != nil {
+		t.Fatalf("Troubleshoot should not error on GetLogs failure; got: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Fatal("expected Diagnostic to be produced even when GetLogs fails")
+	}
+	// Diagnostic must not contain a log block.
+	if strings.Contains(diags[0].Detail, "Deploy logs") {
+		t.Errorf("Detail should not contain log block when GetLogs fails; got: %q", diags[0].Detail)
+	}
+}
+
+// TestTroubleshoot_GracefulOnHTTPFetchError verifies that when GetLogs returns
+// a URL but the HTTP server returns 500, the Diagnostic is still produced
+// without a log block (no panic).
+func TestTroubleshoot_GracefulOnHTTPFetchError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	dep := &godo.Deployment{
+		ID:    "dep-http-err",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "image pull failed",
+		Spec:  &godo.AppSpec{Name: "my-app", Services: []*godo.AppServiceSpec{{Name: "web"}}},
+	}
+	mock := &mockAppClient{
+		app: &godo.App{
+			ID:                   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec:                 &godo.AppSpec{Name: "my-app"},
+			InProgressDeployment: dep,
+		},
+		getLogsResult: &godo.AppLogs{HistoricURLs: []string{srv.URL}},
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
+
+	diags, err := d.Troubleshoot(context.Background(), ref, "deployment failed")
+	if err != nil {
+		t.Fatalf("Troubleshoot should not error on HTTP fetch failure; got: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Fatal("expected Diagnostic to be produced even when HTTP fetch fails")
+	}
+	if strings.Contains(diags[0].Detail, "Deploy logs") {
+		t.Errorf("Detail should not contain log block when HTTP fetch fails; got: %q", diags[0].Detail)
+	}
+}
+
+// TestTroubleshoot_PerComponentLogs verifies that for a multi-component
+// deployment (2 services + 1 worker), each component produces a separate
+// labeled log block in Diagnostic.Detail.
+func TestTroubleshoot_PerComponentLogs(t *testing.T) {
+	// Each component gets its own httptest log content.
+	logBySrv := map[string]string{} // url → content
+	makeServer := func(content string) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, content)
+		}))
+		logBySrv[srv.URL] = content
+		return srv
+	}
+	srvWeb := makeServer("web: error pulling image")
+	srvApi := makeServer("api: OOM killed")
+	srvWorker := makeServer("worker: panic at startup")
+	defer srvWeb.Close()
+	defer srvApi.Close()
+	defer srvWorker.Close()
+
+	dep := &godo.Deployment{
+		ID:    "dep-multi-comp",
+		Phase: godo.DeploymentPhase_Error,
+		Cause: "multiple components failed",
+		Spec: &godo.AppSpec{
+			Name:     "my-app",
+			Services: []*godo.AppServiceSpec{{Name: "web"}, {Name: "api"}},
+			Workers:  []*godo.AppWorkerSpec{{Name: "worker"}},
+		},
+	}
+
+	callCount := 0
+	servers := []string{srvWeb.URL, srvApi.URL, srvWorker.URL}
+	mock := &mockAppClient{
+		app: &godo.App{
+			ID:                   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec:                 &godo.AppSpec{Name: "my-app"},
+			InProgressDeployment: dep,
+		},
+	}
+	// Override GetLogs to return different URLs per call.
+	// We use a custom mock that cycles through server URLs.
+	mockFn := &cyclingLogsMock{
+		mockAppClient: mock,
+		serverURLs:    servers,
+		callCount:     &callCount,
+	}
+	d := drivers.NewAppPlatformDriverWithClient(mockFn, "nyc3")
+	ref := interfaces.ResourceRef{Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"}
+
+	diags, err := d.Troubleshoot(context.Background(), ref, "deployment failed")
+	if err != nil {
+		t.Fatalf("Troubleshoot: %v", err)
+	}
+	if len(diags) == 0 {
+		t.Fatal("expected at least 1 diagnostic")
+	}
+	detail := diags[0].Detail
+	for _, comp := range []string{`"web"`, `"api"`, `"worker"`} {
+		if !strings.Contains(detail, comp) {
+			t.Errorf("Detail missing component %s\nDetail: %q", comp, detail)
+		}
+	}
+	for _, logLine := range []string{"web: error pulling image", "api: OOM killed", "worker: panic at startup"} {
+		if !strings.Contains(detail, logLine) {
+			t.Errorf("Detail missing log line %q\nDetail: %q", logLine, detail)
+		}
+	}
+	// Should have 3 delimited blocks.
+	blockCount := strings.Count(detail, "---")
+	if blockCount < 6 { // each block uses 2 "---" delimiters
+		t.Errorf("expected at least 6 '---' delimiters for 3 log blocks, got %d\nDetail: %q", blockCount, detail)
+	}
+}
+
+// cyclingLogsMock extends mockAppClient with per-call URL cycling for GetLogs.
+type cyclingLogsMock struct {
+	*mockAppClient
+	serverURLs []string
+	callCount  *int
+}
+
+func (m *cyclingLogsMock) GetLogs(_ context.Context, appID, deploymentID, component string, logType godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	m.mockAppClient.getLogsRequests = append(m.mockAppClient.getLogsRequests, getLogsCall{
+		appID: appID, deploymentID: deploymentID, component: component, logType: logType,
+	})
+	idx := *m.callCount
+	*m.callCount++
+	if idx >= len(m.serverURLs) {
+		return nil, nil, errors.New("no more server URLs")
+	}
+	return &godo.AppLogs{HistoricURLs: []string{m.serverURLs[idx]}}, nil, nil
+}
+
+// ── appHealthResult ListDeployments fallback tests ────────────────────────────
+
+// TestAppHealthResult_AllSlotsNilFallsBackToListDeployments verifies that when
+// all 3 deployment slots are nil but ListDeployments returns 1 deployment,
+// HealthResult.Message contains the short deployment ID and its phase.
+func TestAppHealthResult_AllSlotsNilFallsBackToListDeployments(t *testing.T) {
+	const depID = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app: appWithPhases(nil, nil, nil),
+		deployments: []*godo.Deployment{
+			{ID: depID, Phase: godo.DeploymentPhase_Error},
+		},
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "phased-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false")
+	}
+	// Must contain the short ID (first 8 chars) and the phase.
+	shortID := depID[:8]
+	if !strings.Contains(result.Message, shortID) {
+		t.Errorf("Message = %q, want it to contain short ID %q", result.Message, shortID)
+	}
+	if !strings.Contains(result.Message, string(godo.DeploymentPhase_Error)) {
+		t.Errorf("Message = %q, want it to contain phase %q", result.Message, godo.DeploymentPhase_Error)
+	}
+}
+
+// TestAppHealthResult_AllSlotsNilEmptyHistory verifies that when all 3 slots
+// are nil and ListDeployments returns empty, the message is "no deployment found".
+func TestAppHealthResult_AllSlotsNilEmptyHistory(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app:         appWithPhases(nil, nil, nil),
+		deployments: []*godo.Deployment{},
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "phased-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false")
+	}
+	if !strings.Contains(result.Message, "no deployment found") {
+		t.Errorf("Message = %q, want 'no deployment found'", result.Message)
+	}
+}
+
+// TestAppHealthResult_AllSlotsNilListDeploymentsError verifies that when all
+// 3 slots are nil and ListDeployments returns an error, the code falls through
+// to "no deployment found" without panicking or returning an error.
+func TestAppHealthResult_AllSlotsNilListDeploymentsError(t *testing.T) {
+	d := drivers.NewAppPlatformDriverWithClient(&mockAppClient{
+		app:                appWithPhases(nil, nil, nil),
+		listDeploymentsErr: errors.New("api error"),
+	}, "nyc3")
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "phased-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected Healthy=false")
+	}
+	if !strings.Contains(result.Message, "no deployment found") {
+		t.Errorf("Message = %q, want 'no deployment found'", result.Message)
 	}
 }

--- a/internal/drivers/app_platform_troubleshoot_test.go
+++ b/internal/drivers/app_platform_troubleshoot_test.go
@@ -44,6 +44,9 @@ func (s *stubAppClient) ListDeployments(_ context.Context, _ string, _ *godo.Lis
 func (s *stubAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
 	return nil, errors.New("not implemented in stub")
 }
+func (s *stubAppClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
 
 // ── Troubleshoot tests ─────────────────────────────────────────────────────
 

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -101,6 +101,9 @@ func (m *deployMockClient) Delete(_ context.Context, appID string) (*godo.Respon
 	delete(m.apps, appID)
 	return nil, nil
 }
+func (m *deployMockClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
 
 // seedApp inserts a pre-existing app into the mock's store.
 func seedApp(m *deployMockClient, id, name, image string) *godo.App {

--- a/internal/drivers/integration_test_helpers_test.go
+++ b/internal/drivers/integration_test_helpers_test.go
@@ -113,6 +113,9 @@ func (f *fakeAppsClient) Delete(_ context.Context, id string) (*godo.Response, e
 	delete(f.getByID, id)
 	return fakeResp(http.StatusNoContent), nil
 }
+func (f *fakeAppsClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
 
 // fakeResp creates a minimal *godo.Response with the given status.
 func fakeResp(status int) *godo.Response {


### PR DESCRIPTION
## Summary

Closes the deploy-diagnostics gap surfaced in core-dump staging deploy 25258558716: when an App Platform deployment fast-fails (build error, image pull denied, spec validation), wfctl previously displayed only "no deployment found" looped for 10 minutes then timed out — operators had to dig in DO console to find the actual error.

## Two architectural improvements

### Troubleshoot fetches DO logs

`AppPlatformDriver.Troubleshoot` now calls `godo.AppsService.GetLogs` (returns presigned historic URLs) and HTTP-fetches the log content for each component in any deployment whose phase is in {Error, Canceled, Superseded}. Last 200 lines per component appended to the Diagnostic.Detail with delimited blocks. Build-phase failures use AppLogTypeBuild; everything else uses AppLogTypeDeploy.

Graceful degradation: GetLogs error or HTTP-fetch error → Diagnostic still produced without the log block, error logged to stderr.

### appHealthResult ListDeployments fallback

When all 3 deployment slots (Active, InProgress, Pending) are nil, fall back to `ListDeployments(...).[0]` to surface the latest deployment's ID + phase mid-poll. This catches the fast-fail case where DO has removed the failed deployment from all slots before the operator's poll loop catches up.

## Test plan

- [x] go test ./internal/drivers/... — 8 new tests cover Diagnostic-with-logs, Diagnostic-without-logs (graceful), per-component log blocks, and ListDeployments fallback paths
- [x] go test ./... — full suite green

## Out of scope (deferred to follow-ups)

- Per-component log caching across poll intervals
- Structured `interfaces.Diagnostic.LogTail` field upstream in workflow (using Detail concat for v1)
- Live log streaming via `follow=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>