### PR TITLE
fix(release): remove top-level after: hook (unblocks goreleaser v2)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,14 +4,19 @@ project_name: workflow-plugin-digitalocean
 
 before:
   hooks:
-    - cp plugin.json plugin.json.orig
     - "sed -i.bak 's/\"version\": \".*\"/\"version\": \"{{ .Version }}\"/' plugin.json && rm -f plugin.json.bak"
     - "sed -i.bak 's|/releases/download/v[^/]*/|/releases/download/{{ .Tag }}/|g' plugin.json && rm -f plugin.json.bak"
     - "export GOPRIVATE=github.com/GoCodeAlone/*; WFCTL_VERSION=$(go list -m github.com/GoCodeAlone/workflow | awk '{print $2}') && GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION} plugin validate --file plugin.json --strict-contracts"
 
-after:
-  hooks:
-    - mv plugin.json.orig plugin.json
+# NOTE: removed top-level `after:` hook (introduced in #41). goreleaser
+# v2 has no top-level `after:` hook — it failed v0.9.0's release at
+# `yaml: unmarshal errors: line 12: field after not found in type
+# config.Project`. The previous `mv plugin.json.orig plugin.json` was
+# theatre — the GH Actions runner is ephemeral, so the in-place sed
+# mutations to plugin.json are discarded the moment the runner shuts
+# down. There is no need to restore plugin.json on the runner. Removed
+# the matching `cp plugin.json plugin.json.orig` from the before block
+# too — it was preserving state nothing else reads.
 
 builds:
   - id: workflow-plugin-digitalocean


### PR DESCRIPTION
## Summary

PR #41 added a top-level `after:` hook to `.goreleaser.yaml`. goreleaser v2 has **no** top-level `after:` field — only `before:` exists. The v0.9.0 release workflow (run 25274816649) failed instantly with:

```
yaml: unmarshal errors: line 12: field after not found in type config.Project
```

Removed the `after:` block. The `mv plugin.json.orig plugin.json` it ran was theatre: the GH Actions runner is ephemeral, so the in-place sed mutations to plugin.json are discarded when the runner shuts down. There's nothing on the runner to restore. Also removed the matching `cp plugin.json plugin.json.orig` from `before:` — it was preserving state nothing else reads.

## Verification

```
goreleaser/goreleaser:v2.15.4 check
  • checking                  path=.goreleaser.yaml
  • DEPRECATED: archives.builds should not be used anymore (advisory)
  • .goreleaser.yaml          error=configuration is valid, but uses deprecated properties
```

Config is valid (the deprecation is non-blocking + pre-existing).

## After merge

The v0.9.0 tag will need to be force-moved to the new fix-included commit so the release workflow re-runs. The tag has existed for ~5 minutes with no successful release artifacts (the goreleaser failure is what we're fixing), so no consumers have pulled it.

## Test plan
- [ ] CI green
- [ ] Force-move v0.9.0 tag → release workflow runs → artifacts uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)