### PR TITLE
fix(vpc): expose id in Outputs so wfctl infra_output: <vpc>.id resolves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ### Fixed
 
+- **`infra.vpc` exposes `id` output** — wfctl `infra_output: <vpc>.id`
+  secrets need an `id` field in the VPC outputs map. Previously the VPC
+  UUID lived only on `ProviderID` (metadata), not on Outputs, so
+  downstream `vpc_ref` / `vpc_uuid` references failed with `field "id"
+  not found in outputs of module`. Mirrors `ProviderID` to
+  `Outputs["id"]` so the standard `<vpc>.id` reference works. Surfaced
+  by core-dump deploy run 25278900082.
+
+## [v0.9.1]
+
+### Fixed
+
 - **`IacProviderConfig` accepts `provider` field** — wfctl bootstrap uses
   `provider: digitalocean` as the discriminator to identify which
   iac.provider module owns a given backend (e.g. `backend: spaces`).

--- a/internal/drivers/vpc.go
+++ b/internal/drivers/vpc.go
@@ -180,6 +180,12 @@ func vpcOutput(vpc *godo.VPC) *interfaces.ResourceOutput {
 		Type:       "infra.vpc",
 		ProviderID: vpc.ID,
 		Outputs: map[string]any{
+			// Expose `id` so wfctl `infra_output: <vpc>.id` secrets can
+			// read the VPC UUID. Mirrors ProviderID — without this,
+			// downstream modules can't reference the VPC by ID for
+			// vpc_ref / vpc_uuid fields (App Platform vpc_ref + Droplet
+			// vpc_uuid both want the bare UUID, not a URN).
+			"id":       vpc.ID,
 			"ip_range": vpc.IPRange,
 			"region":   vpc.RegionSlug,
 			"urn":      vpc.URN,

--- a/internal/drivers/vpc_test.go
+++ b/internal/drivers/vpc_test.go
@@ -65,6 +65,11 @@ func TestVPCDriver_Create(t *testing.T) {
 	if out.ProviderID != "vpc-123" {
 		t.Errorf("ProviderID = %q, want %q", out.ProviderID, "vpc-123")
 	}
+	// `id` output mirrors ProviderID so wfctl `infra_output: <vpc>.id`
+	// secrets can read the VPC UUID for downstream vpc_ref / vpc_uuid.
+	if got, _ := out.Outputs["id"].(string); got != "vpc-123" {
+		t.Errorf(`Outputs["id"] = %q, want %q`, got, "vpc-123")
+	}
 }
 
 func TestVPCDriver_Create_Error(t *testing.T) {


### PR DESCRIPTION
## Summary

wfctl's `infra_output` secret resolver looks up `<module>.<field>` in the module's `Outputs` map only — `ProviderID` is metadata, not an output. The VPC driver's `vpcOutput` only emitted `ip_range`/`region`/`urn`, so any downstream `infra_output: <vpc>.id` (the standard pattern for wiring `vpc_ref` into App Platform / `vpc_uuid` into Droplets) failed with:

```
error: infra_output: field "id" not found in outputs of module "core-dump-vpc"
```

Mirror `ProviderID` to `Outputs["id"]` so the canonical reference works. Test added.

Surfaced by core-dump deploy run [25278900082](https://github.com/GoCodeAlone/core-dump/actions/runs/25278900082) — first end-to-end deploy past the prior chain of fixes.

Bumps to v0.9.2.

## Test plan
- [ ] CI green
- [ ] Tag v0.9.2 → goreleaser publishes
- [ ] Registry bump to v0.9.2
- [ ] core-dump deploy resolves vpc_ref via `infra_output: core-dump-vpc.id`
- [ ] Server `/healthz` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)