### PR TITLE
fix(volume): detect region drift when current region is empty; bump workflow to v0.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.21.2
+	github.com/GoCodeAlone/workflow v0.22.3
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.21.2 h1:c3ayFyz3bDK10XbC2YmuGdrWYE/7PRwDmOhAjxMow6k=
-github.com/GoCodeAlone/workflow v0.21.2/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.22.3 h1:LySE0RYJrtuRmV57hVMyIKX4857aD5072bOH5gFNTnE=
+github.com/GoCodeAlone/workflow v0.22.3/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/drivers/volume.go
+++ b/internal/drivers/volume.go
@@ -164,7 +164,7 @@ func (d *VolumeDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, 
 
 	if region := strFromConfig(desired.Config, "region", ""); region != "" {
 		curRegion, _ := current.Outputs["region"].(string)
-		if curRegion != "" && curRegion != region {
+		if curRegion != region {
 			changes = append(changes, interfaces.FieldChange{
 				Path: "region", Old: curRegion, New: region, ForceNew: true,
 			})

--- a/internal/drivers/volume_test.go
+++ b/internal/drivers/volume_test.go
@@ -438,6 +438,51 @@ func TestVolumeDriver_Diff_RegionForcesReplace(t *testing.T) {
 	}
 }
 
+// TestVolumeDriver_Diff_EmptyCurrentRegion_ForceNew tests that a newly
+// provisioned volume with no "region" in Outputs (empty curRegion) is still
+// detected as needing replace when the desired region is set. The previous
+// guard `if curRegion != "" && curRegion != region` silently ignored this
+// case (Bug 1).
+func TestVolumeDriver_Diff_EmptyCurrentRegion_ForceNew(t *testing.T) {
+	d := drivers.NewVolumeDriverWithClient(&mockStorageClient{}, nil, "nyc3")
+	cur := &interfaces.ResourceOutput{
+		// Outputs deliberately missing "region" — simulates a volume whose
+		// state record did not capture region at creation time.
+		Outputs: map[string]any{"size_gb": float64(100)},
+	}
+	r, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{"size_gb": 100, "region": "nyc3"},
+	}, cur)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !r.NeedsReplace {
+		t.Errorf("empty curRegion with non-empty desired region must force replace")
+	}
+	if len(r.Changes) == 0 {
+		t.Fatalf("expected at least one change entry, got none")
+	}
+	var regionChange *interfaces.FieldChange
+	for i := range r.Changes {
+		if r.Changes[i].Path == "region" {
+			regionChange = &r.Changes[i]
+			break
+		}
+	}
+	if regionChange == nil {
+		t.Fatalf("expected FieldChange for 'region'; changes: %+v", r.Changes)
+	}
+	if regionChange.Old != "" {
+		t.Errorf("Old: got %q, want empty string", regionChange.Old)
+	}
+	if regionChange.New != "nyc3" {
+		t.Errorf("New: got %q, want %q", regionChange.New, "nyc3")
+	}
+	if !regionChange.ForceNew {
+		t.Errorf("ForceNew must be true for region change")
+	}
+}
+
 func TestVolumeDriver_Diff_FilesystemTypeForcesReplace(t *testing.T) {
 	d := drivers.NewVolumeDriverWithClient(&mockStorageClient{}, nil, "nyc3")
 	cur := &interfaces.ResourceOutput{

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -41,6 +41,7 @@ type DOProvider struct {
 var _ interfaces.IaCProvider = (*DOProvider)(nil)
 var _ interfaces.ProviderMigrationRepairer = (*DOProvider)(nil)
 var _ interfaces.Enumerator = (*DOProvider)(nil)
+var _ interfaces.DriftConfigDetector = (*DOProvider)(nil)
 
 // NewDOProvider creates an uninitialised DOProvider.
 func NewDOProvider() *DOProvider {


### PR DESCRIPTION
## Summary

- Fixes a bug in `VolumeDriver.Diff` where a volume whose state record is missing `region` in Outputs would not detect region drift against a declared desired region. The old guard `if curRegion != "" && curRegion != region` silently skipped detection when `curRegion` was empty — now any mismatch (including empty-vs-set) forces a replace.
- Adds `TestVolumeDriver_Diff_EmptyCurrentRegion_ForceNew` regression test for the fixed path.
- Adds compile-time assertion `var _ interfaces.DriftConfigDetector = (*DOProvider)(nil)` in `provider.go`.
- Bumps `github.com/GoCodeAlone/workflow` from v0.21.2 → v0.22.3, which includes the `DriftConfigDetector.DetectDriftWithSpecs` rename (workflow PR #571). DOProvider's existing `DetectDriftWithSpecs` already matches the canonical signature — this bump closes the interface alignment.

## Test plan
- [ ] `go test ./...` passes (includes new `TestVolumeDriver_Diff_EmptyCurrentRegion_ForceNew`)
- [ ] `go build ./...` passes with compile-time assertion
- [ ] CI: Build, Lint, Test, cross-plugin-build all pass
- [ ] Verify `grep -r DetectDriftWithApplied .` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)