### PR TITLE
feat(provider): RevokeProviderCredential for digitalocean.spaces source

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -658,6 +658,9 @@ func (p *DOProvider) RevokeProviderCredential(ctx context.Context, source string
 	if credentialID == "" {
 		return fmt.Errorf("digitalocean: RevokeProviderCredential: credentialID is required")
 	}
+	if p.client == nil {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: provider not initialized")
+	}
 
 	resp, err := p.client.SpacesKeys.Delete(ctx, credentialID)
 	if err != nil {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -641,6 +641,35 @@ func (p *DOProvider) Import(ctx context.Context, cloudID string, resourceType st
 	}, nil
 }
 
+// RevokeProviderCredential satisfies interfaces.ProviderCredentialRevoker for
+// source "digitalocean.spaces". credentialID is the access_key_id of the OLD
+// DO Spaces key to revoke. Used by `wfctl infra bootstrap --force-rotate` to
+// invalidate the old key after minting its replacement (see ADR 0012).
+//
+// HTTP response handling:
+//   - 204 No Content → success
+//   - 404 Not Found  → treated as success (key already gone)
+//   - 401/403        → auth error, propagated as fatal
+//   - 5xx            → transient error, propagated to caller (caller logs + continues)
+func (p *DOProvider) RevokeProviderCredential(ctx context.Context, source string, credentialID string) error {
+	if source != "digitalocean.spaces" {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: unknown source %q (only digitalocean.spaces is supported)", source)
+	}
+	if credentialID == "" {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: credentialID is required")
+	}
+
+	resp, err := p.client.SpacesKeys.Delete(ctx, credentialID)
+	if err != nil {
+		// 404 means the key is already gone — treat as success.
+		if resp != nil && resp.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("digitalocean: revoke spaces key %q: %w", credentialID, err)
+	}
+	return nil
+}
+
 // Close is a no-op; the godo client has no persistent connection to close.
 func (p *DOProvider) Close() error { return nil }
 

--- a/internal/provider_revoke_test.go
+++ b/internal/provider_revoke_test.go
@@ -1,0 +1,138 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+// capturedRequestServer returns a DOProvider + a function that returns the last
+// request received by the stub server.
+func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *http.Request) {
+	t.Helper()
+	var last *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		last = r
+		w.WriteHeader(statusCode)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := godo.NewClient(srv.Client())
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	client.BaseURL = base
+	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request { return last }
+}
+
+// TestDOProvider_RevokeProviderCredential_204 verifies that a 204 response is
+// treated as successful revocation.
+func TestDOProvider_RevokeProviderCredential_204(t *testing.T) {
+	p, getReq := capturedRequestServer(t, http.StatusNoContent)
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID123")
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential: unexpected error: %v", err)
+	}
+	req := getReq()
+	if req == nil {
+		t.Fatal("no request captured by stub server")
+	}
+	if req.Method != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", req.Method)
+	}
+	wantPath := "/v2/spaces/keys/AKID123"
+	if req.URL.Path != wantPath {
+		t.Errorf("path = %q, want %q", req.URL.Path, wantPath)
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_404 verifies that a 404 response is
+// treated as success (key already absent — idempotent).
+func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, `{"id":"not_found","message":"key not found"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_GONE")
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential with 404: expected nil error (idempotent), got: %v", err)
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_401 verifies that a 401 response
+// propagates as an error (auth failure should surface to operator).
+func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, `{"id":"unauthorized","message":"unable to authenticate"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_AUTH")
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_5xx verifies that a 5xx response
+// propagates as an error (transient; caller logs + continues).
+func TestDOProvider_RevokeProviderCredential_5xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, `{"id":"server_error","message":"internal server error"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_5XX")
+	if err == nil {
+		t.Fatal("expected error on 5xx, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_UnknownSource verifies that an
+// unsupported source returns an error without making any HTTP request.
+func TestDOProvider_RevokeProviderCredential_UnknownSource(t *testing.T) {
+	p := &DOProvider{} // no client needed — error should be returned before HTTP call
+	err := p.RevokeProviderCredential(context.Background(), "aws.s3", "AKID_AWS")
+	if err == nil {
+		t.Fatal("expected error for unknown source, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_EmptyCredentialID verifies that an
+// empty credentialID returns an error without making any HTTP request.
+func TestDOProvider_RevokeProviderCredential_EmptyCredentialID(t *testing.T) {
+	p := &DOProvider{}
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "")
+	if err == nil {
+		t.Fatal("expected error for empty credentialID, got nil")
+	}
+}

--- a/internal/provider_revoke_test.go
+++ b/internal/provider_revoke_test.go
@@ -6,18 +6,24 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/digitalocean/godo"
 )
 
 // capturedRequestServer returns a DOProvider + a function that returns the last
-// request received by the stub server.
+// request received by the stub server. The last-request pointer is protected by
+// a mutex to avoid a data race between the httptest server goroutine (writer)
+// and the test goroutine (reader) when running under -race.
 func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *http.Request) {
 	t.Helper()
+	var mu sync.Mutex
 	var last *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		last = r
+		mu.Unlock()
 		w.WriteHeader(statusCode)
 	}))
 	t.Cleanup(srv.Close)
@@ -28,7 +34,11 @@ func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *h
 		t.Fatalf("parse httptest URL: %v", err)
 	}
 	client.BaseURL = base
-	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request { return last }
+	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
 }
 
 // TestDOProvider_RevokeProviderCredential_204 verifies that a 204 response is
@@ -53,21 +63,32 @@ func TestDOProvider_RevokeProviderCredential_204(t *testing.T) {
 	}
 }
 
+// jsonStubServer starts an httptest server that responds with the given status code and
+// a minimal JSON error body, returning a configured DOProvider. The server is closed via
+// t.Cleanup.
+func jsonStubServer(t *testing.T, statusCode int, body string) *DOProvider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = fmt.Fprintln(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := godo.NewClient(srv.Client())
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	client.BaseURL = base
+	return &DOProvider{client: client, region: "nyc3"}
+}
+
 // TestDOProvider_RevokeProviderCredential_404 verifies that a 404 response is
 // treated as success (key already absent — idempotent).
 func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, `{"id":"not_found","message":"key not found"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
+	p := jsonStubServer(t, http.StatusNotFound, `{"id":"not_found","message":"key not found"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_GONE")
 	if err != nil {
@@ -78,17 +99,7 @@ func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
 // TestDOProvider_RevokeProviderCredential_401 verifies that a 401 response
 // propagates as an error (auth failure should surface to operator).
 func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"id":"unauthorized","message":"unable to authenticate"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	p := jsonStubServer(t, http.StatusUnauthorized, `{"id":"unauthorized","message":"unable to authenticate"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_AUTH")
 	if err == nil {
@@ -99,17 +110,7 @@ func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
 // TestDOProvider_RevokeProviderCredential_5xx verifies that a 5xx response
 // propagates as an error (transient; caller logs + continues).
 func TestDOProvider_RevokeProviderCredential_5xx(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, `{"id":"server_error","message":"internal server error"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	p := jsonStubServer(t, http.StatusInternalServerError, `{"id":"server_error","message":"internal server error"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_5XX")
 	if err == nil {


### PR DESCRIPTION
## Summary

- Implements `interfaces.ProviderCredentialRevoker` on `DOProvider` using godo's `SpacesKeys.Delete(ctx, accessKeyID)` (DO API: `DELETE /v2/spaces/keys/{access_key_id}`).
- Used by `wfctl infra bootstrap --force-rotate <name>` (workflow PR #573) to revoke the OLD Spaces key after the new one is minted and stored — **mint-new-then-revoke-old** ordering per ADR 0012.
- DOProvider satisfies `ProviderCredentialRevoker` via duck typing until workflow v0.22.5 is released; compile-time assertion added in the go.mod bump commit.

## Response handling

| Status | Behavior |
|--------|----------|
| 204 No Content | Success |
| 404 Not Found | Success (idempotent — key already gone) |
| 401/403 | Propagated as error (auth failure) |
| 5xx | Propagated as error (transient; caller logs + continues) |

## Changes

| File | Change |
|------|--------|
| `internal/provider.go` | Add `RevokeProviderCredential` method on `DOProvider` |
| `internal/provider_revoke_test.go` | 6 tests: 204/404/401/5xx/unknown-source/empty-id |

## Dependency

Requires workflow PR #573 (`ProviderCredentialRevoker` interface). The go.mod bump to v0.22.5 will land in a follow-up commit after PR #573 merges and is tagged.

## Test plan

- [x] `go test ./internal/ -run Revoke` — all 6 tests pass
- [x] `go test ./...` — full suite green (159 tests)
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)