### PR TITLE
feat(dispatch): wire IaCProvider.RevokeProviderCredential in module_instance.go + bump workflow v0.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.22.3
+	github.com/GoCodeAlone/workflow v0.22.5
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQT
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
 github.com/GoCodeAlone/workflow v0.22.3 h1:LySE0RYJrtuRmV57hVMyIKX4857aD5072bOH5gFNTnE=
 github.com/GoCodeAlone/workflow v0.22.3/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.22.5 h1:qslD7auMeYPmnrJO4rlbwn7ud3FRy/oLG4i/D4CxY2I=
+github.com/GoCodeAlone/workflow v0.22.5/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -342,14 +342,14 @@ func (m *doModuleInstance) invokeProviderRepairDirtyMigration(ctx context.Contex
 // provider doesn't support the interface, matching the opt-in pattern used by
 // EnumerateByTag and RepairDirtyMigration.
 //
-// args contract: {"source": <string>, "credentialID": <string>}
+// args contract: {"source": <string>, "credential_id": <string>}
 func (m *doModuleInstance) invokeProviderRevokeCredential(ctx context.Context, args map[string]any) (map[string]any, error) {
 	revoker, ok := m.provider.(interfaces.ProviderCredentialRevoker)
 	if !ok {
 		return nil, status.Error(codes.Unimplemented, "provider does not implement ProviderCredentialRevoker")
 	}
 	source := stringArg(args, "source")
-	credentialID := stringArg(args, "credentialID")
+	credentialID := stringArg(args, "credential_id")
 	if err := revoker.RevokeProviderCredential(ctx, source, credentialID); err != nil {
 		return nil, err
 	}

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -86,6 +86,9 @@ func (m *doModuleInstance) InvokeMethodContext(ctx context.Context, method strin
 	case "IaCProvider.EnumerateByTag":
 		return m.invokeProviderEnumerateByTag(ctx, args)
 
+	case "IaCProvider.RevokeProviderCredential":
+		return m.invokeProviderRevokeCredential(ctx, args)
+
 	case "ResourceDriver.Update":
 		return m.invokeDriverUpdate(args)
 
@@ -328,6 +331,26 @@ func (m *doModuleInstance) invokeProviderRepairDirtyMigration(ctx context.Contex
 		return structToMap(result)
 	}
 	if err != nil {
+		return nil, err
+	}
+	return map[string]any{}, nil
+}
+
+// invokeProviderRevokeCredential routes "IaCProvider.RevokeProviderCredential"
+// to the underlying provider when it implements the opt-in
+// interfaces.ProviderCredentialRevoker. Returns codes.Unimplemented when the
+// provider doesn't support the interface, matching the opt-in pattern used by
+// EnumerateByTag and RepairDirtyMigration.
+//
+// args contract: {"source": <string>, "credentialID": <string>}
+func (m *doModuleInstance) invokeProviderRevokeCredential(ctx context.Context, args map[string]any) (map[string]any, error) {
+	revoker, ok := m.provider.(interfaces.ProviderCredentialRevoker)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not implement ProviderCredentialRevoker")
+	}
+	source := stringArg(args, "source")
+	credentialID := stringArg(args, "credentialID")
+	if err := revoker.RevokeProviderCredential(ctx, source, credentialID); err != nil {
 		return nil, err
 	}
 	return map[string]any{}, nil

--- a/internal/module_instance_test.go
+++ b/internal/module_instance_test.go
@@ -984,7 +984,7 @@ func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_HappyPath(t *tes
 
 	result, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
 		"source":       "digitalocean.spaces",
-		"credentialID": "AKID123",
+		"credential_id": "AKID123",
 	})
 	if err != nil {
 		t.Fatalf("RevokeProviderCredential dispatch: %v", err)
@@ -1009,7 +1009,7 @@ func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_Unsupported(t *t
 
 	_, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
 		"source":       "digitalocean.spaces",
-		"credentialID": "AKID_UNSUP",
+		"credential_id": "AKID_UNSUP",
 	})
 	if err == nil {
 		t.Fatal("expected Unimplemented error when provider lacks ProviderCredentialRevoker")
@@ -1025,7 +1025,7 @@ func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_PropagatesError(
 
 	_, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
 		"source":       "digitalocean.spaces",
-		"credentialID": "AKID_FAIL",
+		"credential_id": "AKID_FAIL",
 	})
 	if err == nil {
 		t.Fatal("expected error to propagate from provider")
@@ -1043,7 +1043,7 @@ func TestDoModuleInstance_InvokeMethodContext_RevokeProviderCredential_Propagate
 
 	_, err := mi.InvokeMethodContext(ctx, "IaCProvider.RevokeProviderCredential", map[string]any{
 		"source":       "digitalocean.spaces",
-		"credentialID": "AKID_CTX",
+		"credential_id": "AKID_CTX",
 	})
 	if err == nil {
 		t.Fatal("expected context cancellation error")

--- a/internal/module_instance_test.go
+++ b/internal/module_instance_test.go
@@ -976,6 +976,83 @@ func TestDoModuleInstance_InvokeMethodContext_RepairDirtyMigration_PropagatesCon
 	}
 }
 
+// ── IaCProvider.RevokeProviderCredential dispatch tests ───────────────────────
+
+func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_HappyPath(t *testing.T) {
+	fake := &fakeRevokerProvider{}
+	mi := &doModuleInstance{provider: fake}
+
+	result, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
+		"source":       "digitalocean.spaces",
+		"credentialID": "AKID123",
+	})
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential dispatch: %v", err)
+	}
+	if !fake.revokeCalled {
+		t.Fatal("RevokeProviderCredential was not called on provider")
+	}
+	if fake.revokeSource != "digitalocean.spaces" {
+		t.Errorf("source = %q, want %q", fake.revokeSource, "digitalocean.spaces")
+	}
+	if fake.revokeCredentialID != "AKID123" {
+		t.Errorf("credentialID = %q, want %q", fake.revokeCredentialID, "AKID123")
+	}
+	if result == nil {
+		t.Error("expected non-nil result map")
+	}
+}
+
+func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_Unsupported(t *testing.T) {
+	// fakeIaCProvider does NOT implement ProviderCredentialRevoker.
+	mi := &doModuleInstance{provider: &fakeIaCProvider{}}
+
+	_, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
+		"source":       "digitalocean.spaces",
+		"credentialID": "AKID_UNSUP",
+	})
+	if err == nil {
+		t.Fatal("expected Unimplemented error when provider lacks ProviderCredentialRevoker")
+	}
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %s, want %s", status.Code(err), codes.Unimplemented)
+	}
+}
+
+func TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_PropagatesError(t *testing.T) {
+	fake := &fakeRevokerProvider{revokeErr: errors.New("DO API: 403 forbidden")}
+	mi := &doModuleInstance{provider: fake}
+
+	_, err := mi.InvokeMethod("IaCProvider.RevokeProviderCredential", map[string]any{
+		"source":       "digitalocean.spaces",
+		"credentialID": "AKID_FAIL",
+	})
+	if err == nil {
+		t.Fatal("expected error to propagate from provider")
+	}
+	if err.Error() != "DO API: 403 forbidden" {
+		t.Errorf("error = %q, want %q", err.Error(), "DO API: 403 forbidden")
+	}
+}
+
+func TestDoModuleInstance_InvokeMethodContext_RevokeProviderCredential_PropagatesContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fake := &fakeRevokerProvider{}
+	mi := &doModuleInstance{provider: fake}
+
+	_, err := mi.InvokeMethodContext(ctx, "IaCProvider.RevokeProviderCredential", map[string]any{
+		"source":       "digitalocean.spaces",
+		"credentialID": "AKID_CTX",
+	})
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if fake.revokeContextErr == nil {
+		t.Fatal("expected canceled context to reach provider")
+	}
+}
+
 // ── stub driver ───────────────────────────────────────────────────────────────
 
 type stubResourceDriver struct {
@@ -1148,4 +1225,25 @@ func (f *fakeRepairProvider) RepairDirtyMigration(ctx context.Context, req inter
 		return nil, err
 	}
 	return f.repairResult, f.repairErr
+}
+
+// fakeRevokerProvider embeds fakeIaCProvider and adds ProviderCredentialRevoker.
+type fakeRevokerProvider struct {
+	fakeIaCProvider
+	revokeCalled       bool
+	revokeSource       string
+	revokeCredentialID string
+	revokeContextErr   error
+	revokeErr          error
+}
+
+func (f *fakeRevokerProvider) RevokeProviderCredential(ctx context.Context, source string, credentialID string) error {
+	f.revokeCalled = true
+	f.revokeSource = source
+	f.revokeCredentialID = credentialID
+	f.revokeContextErr = ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return f.revokeErr
 }

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -658,6 +658,9 @@ func (p *DOProvider) RevokeProviderCredential(ctx context.Context, source string
 	if credentialID == "" {
 		return fmt.Errorf("digitalocean: RevokeProviderCredential: credentialID is required")
 	}
+	if p.client == nil {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: provider not initialized")
+	}
 
 	resp, err := p.client.SpacesKeys.Delete(ctx, credentialID)
 	if err != nil {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -641,6 +641,35 @@ func (p *DOProvider) Import(ctx context.Context, cloudID string, resourceType st
 	}, nil
 }
 
+// RevokeProviderCredential satisfies interfaces.ProviderCredentialRevoker for
+// source "digitalocean.spaces". credentialID is the access_key_id of the OLD
+// DO Spaces key to revoke. Used by `wfctl infra bootstrap --force-rotate` to
+// invalidate the old key after minting its replacement (see ADR 0012).
+//
+// HTTP response handling:
+//   - 204 No Content → success
+//   - 404 Not Found  → treated as success (key already gone)
+//   - 401/403        → auth error, propagated as fatal
+//   - 5xx            → transient error, propagated to caller (caller logs + continues)
+func (p *DOProvider) RevokeProviderCredential(ctx context.Context, source string, credentialID string) error {
+	if source != "digitalocean.spaces" {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: unknown source %q (only digitalocean.spaces is supported)", source)
+	}
+	if credentialID == "" {
+		return fmt.Errorf("digitalocean: RevokeProviderCredential: credentialID is required")
+	}
+
+	resp, err := p.client.SpacesKeys.Delete(ctx, credentialID)
+	if err != nil {
+		// 404 means the key is already gone — treat as success.
+		if resp != nil && resp.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("digitalocean: revoke spaces key %q: %w", credentialID, err)
+	}
+	return nil
+}
+
 // Close is a no-op; the godo client has no persistent connection to close.
 func (p *DOProvider) Close() error { return nil }
 

--- a/internal/provider_revoke_test.go
+++ b/internal/provider_revoke_test.go
@@ -1,0 +1,138 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/digitalocean/godo"
+)
+
+// capturedRequestServer returns a DOProvider + a function that returns the last
+// request received by the stub server.
+func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *http.Request) {
+	t.Helper()
+	var last *http.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		last = r
+		w.WriteHeader(statusCode)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := godo.NewClient(srv.Client())
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	client.BaseURL = base
+	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request { return last }
+}
+
+// TestDOProvider_RevokeProviderCredential_204 verifies that a 204 response is
+// treated as successful revocation.
+func TestDOProvider_RevokeProviderCredential_204(t *testing.T) {
+	p, getReq := capturedRequestServer(t, http.StatusNoContent)
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID123")
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential: unexpected error: %v", err)
+	}
+	req := getReq()
+	if req == nil {
+		t.Fatal("no request captured by stub server")
+	}
+	if req.Method != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", req.Method)
+	}
+	wantPath := "/v2/spaces/keys/AKID123"
+	if req.URL.Path != wantPath {
+		t.Errorf("path = %q, want %q", req.URL.Path, wantPath)
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_404 verifies that a 404 response is
+// treated as success (key already absent — idempotent).
+func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintln(w, `{"id":"not_found","message":"key not found"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_GONE")
+	if err != nil {
+		t.Fatalf("RevokeProviderCredential with 404: expected nil error (idempotent), got: %v", err)
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_401 verifies that a 401 response
+// propagates as an error (auth failure should surface to operator).
+func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprintln(w, `{"id":"unauthorized","message":"unable to authenticate"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_AUTH")
+	if err == nil {
+		t.Fatal("expected error on 401, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_5xx verifies that a 5xx response
+// propagates as an error (transient; caller logs + continues).
+func TestDOProvider_RevokeProviderCredential_5xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, `{"id":"server_error","message":"internal server error"}`)
+	}))
+	defer srv.Close()
+
+	client := godo.NewClient(srv.Client())
+	base, _ := url.Parse(srv.URL + "/")
+	client.BaseURL = base
+	p := &DOProvider{client: client, region: "nyc3"}
+
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_5XX")
+	if err == nil {
+		t.Fatal("expected error on 5xx, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_UnknownSource verifies that an
+// unsupported source returns an error without making any HTTP request.
+func TestDOProvider_RevokeProviderCredential_UnknownSource(t *testing.T) {
+	p := &DOProvider{} // no client needed — error should be returned before HTTP call
+	err := p.RevokeProviderCredential(context.Background(), "aws.s3", "AKID_AWS")
+	if err == nil {
+		t.Fatal("expected error for unknown source, got nil")
+	}
+}
+
+// TestDOProvider_RevokeProviderCredential_EmptyCredentialID verifies that an
+// empty credentialID returns an error without making any HTTP request.
+func TestDOProvider_RevokeProviderCredential_EmptyCredentialID(t *testing.T) {
+	p := &DOProvider{}
+	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "")
+	if err == nil {
+		t.Fatal("expected error for empty credentialID, got nil")
+	}
+}

--- a/internal/provider_revoke_test.go
+++ b/internal/provider_revoke_test.go
@@ -6,18 +6,24 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 
 	"github.com/digitalocean/godo"
 )
 
 // capturedRequestServer returns a DOProvider + a function that returns the last
-// request received by the stub server.
+// request received by the stub server. The last-request pointer is protected by
+// a mutex to avoid a data race between the httptest server goroutine (writer)
+// and the test goroutine (reader) when running under -race.
 func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *http.Request) {
 	t.Helper()
+	var mu sync.Mutex
 	var last *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
 		last = r
+		mu.Unlock()
 		w.WriteHeader(statusCode)
 	}))
 	t.Cleanup(srv.Close)
@@ -28,7 +34,11 @@ func capturedRequestServer(t *testing.T, statusCode int) (*DOProvider, func() *h
 		t.Fatalf("parse httptest URL: %v", err)
 	}
 	client.BaseURL = base
-	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request { return last }
+	return &DOProvider{client: client, region: "nyc3"}, func() *http.Request {
+		mu.Lock()
+		defer mu.Unlock()
+		return last
+	}
 }
 
 // TestDOProvider_RevokeProviderCredential_204 verifies that a 204 response is
@@ -53,21 +63,32 @@ func TestDOProvider_RevokeProviderCredential_204(t *testing.T) {
 	}
 }
 
+// jsonStubServer starts an httptest server that responds with the given status code and
+// a minimal JSON error body, returning a configured DOProvider. The server is closed via
+// t.Cleanup.
+func jsonStubServer(t *testing.T, statusCode int, body string) *DOProvider {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = fmt.Fprintln(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := godo.NewClient(srv.Client())
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	client.BaseURL = base
+	return &DOProvider{client: client, region: "nyc3"}
+}
+
 // TestDOProvider_RevokeProviderCredential_404 verifies that a 404 response is
 // treated as success (key already absent — idempotent).
 func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintln(w, `{"id":"not_found","message":"key not found"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	// godo expects an error body for 4xx/5xx responses to populate ErrorResponse.
+	p := jsonStubServer(t, http.StatusNotFound, `{"id":"not_found","message":"key not found"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_GONE")
 	if err != nil {
@@ -78,17 +99,7 @@ func TestDOProvider_RevokeProviderCredential_404(t *testing.T) {
 // TestDOProvider_RevokeProviderCredential_401 verifies that a 401 response
 // propagates as an error (auth failure should surface to operator).
 func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		fmt.Fprintln(w, `{"id":"unauthorized","message":"unable to authenticate"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	p := jsonStubServer(t, http.StatusUnauthorized, `{"id":"unauthorized","message":"unable to authenticate"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_AUTH")
 	if err == nil {
@@ -99,17 +110,7 @@ func TestDOProvider_RevokeProviderCredential_401(t *testing.T) {
 // TestDOProvider_RevokeProviderCredential_5xx verifies that a 5xx response
 // propagates as an error (transient; caller logs + continues).
 func TestDOProvider_RevokeProviderCredential_5xx(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, `{"id":"server_error","message":"internal server error"}`)
-	}))
-	defer srv.Close()
-
-	client := godo.NewClient(srv.Client())
-	base, _ := url.Parse(srv.URL + "/")
-	client.BaseURL = base
-	p := &DOProvider{client: client, region: "nyc3"}
+	p := jsonStubServer(t, http.StatusInternalServerError, `{"id":"server_error","message":"internal server error"}`)
 
 	err := p.RevokeProviderCredential(context.Background(), "digitalocean.spaces", "AKID_5XX")
 	if err == nil {


### PR DESCRIPTION
## Summary
- Adds `case "IaCProvider.RevokeProviderCredential"` to `doModuleInstance.InvokeMethodContext` dispatch switch — without this, the gRPC plugin silently falls to the `default` unknown-method branch, meaning `DOProvider.RevokeProviderCredential` is never called when wfctl dispatches credential revocation
- Bumps `workflow` dependency `v0.22.3 → v0.22.5` so `interfaces.ProviderCredentialRevoker` is available at compile time (introduced in workflow PR #573 / v0.22.5)
- Follows the opt-in interface pattern used by `EnumerateByTag` and `RepairDirtyMigration`: if the provider doesn't implement `ProviderCredentialRevoker`, returns `codes.Unimplemented`

## Root cause
The full revocation chain needed two fixes:
1. **workflow PR #574** — `remoteIaCProvider` in wfctl gained `RevokeProviderCredential` (dispatches to plugin)
2. **This PR** — the DO plugin's `InvokeMethodContext` switch receives the call and routes to `DOProvider.RevokeProviderCredential`

Without this PR, the call reaches the plugin gRPC boundary but returns "unknown method" error. The `tc2-rotate-spaces-keys.yml` rotation run (25503485781) minted and stored new SPACES credentials correctly but the old DO Spaces key was NOT revoked because this dispatch layer was missing.

## Test plan
- [x] `TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_HappyPath` — happy path; source + credentialID forwarded to provider
- [x] `TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_Unsupported` — `codes.Unimplemented` when provider lacks the interface
- [x] `TestDoModuleInstance_InvokeMethod_RevokeProviderCredential_PropagatesError` — provider error surfaces unchanged
- [x] `TestDoModuleInstance_InvokeMethodContext_RevokeProviderCredential_PropagatesContext` — canceled context reaches provider
- [x] Full `./internal/...` test suite passes with `-race` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)