### PR TITLE
feat(do): DropletDriver.Replace detach-before-create orchestration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data/plugins/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`DropletDriver.Replace` implements `interfaces.ResourceReplacer`** (workflow v0.23.0+). Replaces use detach-before-create orchestration: read old → DetachByDropletID per attached Block Storage Volume → wait for each detach action completion (60s/2s bounds) → delete old Droplet → create new Droplet with the resolved volume IDs (bypassing the name-resolution race in `resolveDropletVolumes`). Fixes the "422 storage already associated with another droplet" failure class when replacing Droplets with attached Volumes.
+
+- **`ActionsClient` interface** for the godo Actions service subset (Get only). Enables testing of action wait-polling without live API.
+
+- **`waitForActionComplete` helper** — bounded async-action polling with immediate context-cancellation propagation, "errored" status detection, and configurable timeout/poll-interval bounds (parameterized for testability; 60s/2s production defaults).
+
+- **`createWithResolvedVolumes` unexported helper** — shared Create/Replace request builder. When `resolvedIDs` is non-nil (Replace path), volume IDs are used verbatim, bypassing name-lookup. When nil (Create path), existing `resolveDropletVolumes` runs unchanged.
+
+### Changed
+
+- **`DropletDriver` constructors now wire `c.StorageActions` + `c.Actions`** into the driver automatically. `NewDropletDriverWithClient` gains a variadic optional-clients parameter (type-switched) preserving existing test call sites.
+
+- **`StorageActionsClient` now includes `DetachByDropletID`** alongside `Resize`. The godo `StorageActionsService` implements both; one interface covers VolumeDriver (resize) and DropletDriver.Replace (detach).
+
+- **Replace operations on Droplets with attached Block Storage Volumes no longer fail with `422 storage already associated`**. Recovery sequence after partial Replace failure is: retry `wfctl infra apply --refresh-outputs` to sync state from cloud truth before the next plan; without refresh, persisted state may still claim the Volume is attached.
+
 ### Fixed
 
 - **VPCDriver / DropletDriver / AppPlatformDriver `Diff` now compares `region`** (#70) — previously only `VolumeDriver.Diff` checked region drift; the other three drivers silently no-op'd on region changes despite DO having no in-place region update on those resources. Region change now correctly emits `FieldChange{ForceNew: true}` and sets `NeedsReplace=true`. Surfaced by core-dump's TC2 cutover plan-shape assertion which expected a 5-resource cascade replace but got 1 (Volume only); without the assertion gate the partial cutover would have left VPC + Droplet in nyc3 while the App + Volume moved to nyc1, producing a half-migrated state requiring manual cleanup. Includes upgrade-safe guard: `vpcOutput` and `dropletOutput` already populated `region`, and this PR adds `region` to `appOutput.Outputs` so AppPlatformDriver.Diff has a current-side value to compare; the new check then skips when `current.Outputs["region"]` is empty so state from earlier plugin versions doesn't false-positive — the next Read populates it without spurious drift. Regression tests cover both the change-detection and empty-current-skip paths for all three drivers.

--- a/docs/runtime-validation/2026-05-07-do-pin-bump.log
+++ b/docs/runtime-validation/2026-05-07-do-pin-bump.log
@@ -1,0 +1,15 @@
+Task 13: workflow pin bump smoke-test — 2026-05-07
+
+workflow version: github.com/GoCodeAlone/workflow v0.23.0
+DO plugin binary: /tmp/do-plugin-pin-test
+
+Build: GOWORK=off go build -o /tmp/do-plugin-pin-test ./cmd/plugin/ => exit 0
+Tests: GOWORK=off go test ./...
+
+ok  	github.com/GoCodeAlone/workflow-plugin-digitalocean	2.181s
+?   	github.com/GoCodeAlone/workflow-plugin-digitalocean/cmd/plugin	[no test files]
+ok  	github.com/GoCodeAlone/workflow-plugin-digitalocean/internal	0.874s
+ok  	github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers	6.885s
+?   	github.com/GoCodeAlone/workflow-plugin-digitalocean/proto	[no test files]
+
+All PASS. ResourceReplacer interface available at github.com/GoCodeAlone/workflow/interfaces.ResourceReplacer.

--- a/docs/runtime-validation/2026-05-07-droplet-replace-integration.log
+++ b/docs/runtime-validation/2026-05-07-droplet-replace-integration.log
@@ -1,0 +1,4 @@
+=== RUN   TestReplaceTC2ScenarioReplay
+--- PASS: TestReplaceTC2ScenarioReplay (0.00s)
+PASS
+ok  	github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers	(cached)

--- a/docs/runtime-validation/2026-05-07-tc2-equivalent-launch.log
+++ b/docs/runtime-validation/2026-05-07-tc2-equivalent-launch.log
@@ -1,0 +1,39 @@
+=== Task 20: TC2-equivalent runtime-launch validation ===
+Date: Thu May  7 17:54:20 EDT 2026
+
+=== Plugin build ===
+Plugin build: exit 0
+
+=== Plugin list ===
+NAME                 VERSION    TYPE       DESCRIPTION
+----                 -------    ----       -----------
+digitalocean         0.10.0     external   DigitalOcean IaC provider: App Platfo...
+
+⚡ wfctl v0.23.0 is available (you have v0.0.0-20260427145658-e0ab7fc38230). Run 'wfctl update' to upgrade.
+
+
+=== wfctl infra plan (TC2-equivalent fixture) ===
+Infrastructure Plan — testfixture/tc2-equivalent/infra.yaml
+
++ create  core-dump-vpc  (infra.vpc)
+    region:  nyc1
+
++ create  coredump-staging-pg  (infra.droplet)
+    region:      nyc1
+    size:        s-1vcpu-2gb
+    image:       ubuntu-24-04-x64
+    monitoring:  true
+    provider:    do-provider
+
+Plan: 2 to create, 0 to update, 0 to destroy.
+
+⚡ wfctl v0.23.0 is available (you have v0.0.0-20260427145658-e0ab7fc38230). Run 'wfctl update' to upgrade.
+
+
+=== Verification ===
+Plugin loaded: YES (gRPC handshake + shutdown logged above)
+Plan invocation: exit 0
+Note: State not loaded (filesystem backend path relative resolution)
+  - vpc_uuid shows empty (JIT resolver needs state populated)
+  - Both resources show as 'create' (expected: state file format TBD)
+  - Plugin binary is loadable and plan-capable; no panic/crash

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.22.5
+	github.com/GoCodeAlone/workflow v0.23.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.22.3 h1:LySE0RYJrtuRmV57hVMyIKX4857aD5072bOH5gFNTnE=
-github.com/GoCodeAlone/workflow v0.22.3/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
-github.com/GoCodeAlone/workflow v0.22.5 h1:qslD7auMeYPmnrJO4rlbwn7ud3FRy/oLG4i/D4CxY2I=
-github.com/GoCodeAlone/workflow v0.22.5/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.23.0 h1:/n6RF4PbDpChJLt/b/2tJmf3C8YFlqnYaOncrHYMLR4=
+github.com/GoCodeAlone/workflow v0.23.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/drivers/actions_wait.go
+++ b/internal/drivers/actions_wait.go
@@ -1,0 +1,48 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// waitForActionComplete polls actions.Get(ctx, actionID) until Status
+// transitions to "completed" or "errored", or until timeout expires
+// (returning a wrapped error). ctx cancellation propagates immediately.
+//
+// Bounds: 60s default with 2s polling — typical DO action time is 1-5s
+// for volume detach; 60s is the operator-recovery boundary documented
+// in the design doc. Both bounds are parameterized for testability.
+func waitForActionComplete(ctx context.Context, c ActionsClient, actionID int, timeout, pollInterval time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("wait action %d: %w", actionID, err)
+		}
+		action, _, err := c.Get(ctx, actionID)
+		if err != nil {
+			return fmt.Errorf("wait action %d: poll: %w", actionID, err)
+		}
+		switch action.Status {
+		case "completed":
+			return nil
+		case "errored":
+			return fmt.Errorf("wait action %d: errored", actionID)
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("wait action %d: timeout after %s (status=%s)", actionID, timeout, action.Status)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait action %d: %w", actionID, ctx.Err())
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// Production defaults — exported for callers that want the canonical
+// bounds without naming magic numbers.
+const (
+	defaultActionWaitTimeout      = 60 * time.Second
+	defaultActionWaitPollInterval = 2 * time.Second
+)

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -17,26 +18,62 @@ type DropletsClient interface {
 	Delete(ctx context.Context, dropletID int) (*godo.Response, error)
 }
 
+// ActionsClient is the godo ActionsService subset DropletDriver uses for
+// waiting on async actions (volume detach is the canonical case). Subset
+// means: only Get(ctx, actionID) — the pollable status read.
+type ActionsClient interface {
+	Get(ctx context.Context, actionID int) (*godo.Action, *godo.Response, error)
+}
+
 // DropletDriver manages DigitalOcean Droplets (infra.droplet).
 type DropletDriver struct {
-	client  DropletsClient
-	storage StorageClient // optional; required only when spec.Config["volumes"] is non-empty
-	region  string
+	client         DropletsClient
+	storage        StorageClient        // optional; required only when spec.Config["volumes"] is non-empty
+	storageActions StorageActionsClient // required for Replace; nil-safe in non-Replace paths
+	actions        ActionsClient        // required for Replace; nil-safe in non-Replace paths
+	region         string
+	// test-only timeout overrides (zero = use production defaults)
+	replaceTimeout      time.Duration
+	replacePollInterval time.Duration
 }
 
 // NewDropletDriver creates a DropletDriver backed by a real godo client.
-// The Storage client is wired so volumes-by-name resolution works.
+// The Storage, StorageActions, and Actions clients are wired so volumes-by-name
+// resolution and Replace's detach-wait work without additional configuration.
 func NewDropletDriver(c *godo.Client, region string) *DropletDriver {
-	return &DropletDriver{client: c.Droplets, storage: c.Storage, region: region}
+	return &DropletDriver{
+		client:         c.Droplets,
+		storage:        c.Storage,
+		storageActions: c.StorageActions,
+		actions:        c.Actions,
+		region:         region,
+	}
 }
 
-// NewDropletDriverWithClient creates a driver with an injected client (for tests).
-// The optional storage argument is used only when a spec references volumes by
-// name; pass nil if your test does not exercise that path.
-func NewDropletDriverWithClient(c DropletsClient, region string, storage ...StorageClient) *DropletDriver {
+// NewDropletDriverWithClient creates a driver with injected clients (for tests).
+// Optional clients are provided via a variadic interface{} parameter; each value
+// is type-switched to the appropriate field. Typed-nil interface values are
+// rejected (treated as "not provided") to prevent nil-method-set panics at call time.
+//
+// Existing tests that pass (DropletsClient, region) continue to compile unchanged.
+// Tests that exercise Replace must additionally pass StorageActionsClient and ActionsClient.
+func NewDropletDriverWithClient(c DropletsClient, region string, optional ...interface{}) *DropletDriver {
 	d := &DropletDriver{client: c, region: region}
-	if len(storage) > 0 {
-		d.storage = storage[0]
+	for _, o := range optional {
+		switch v := o.(type) {
+		case StorageClient:
+			if v != nil {
+				d.storage = v
+			}
+		case StorageActionsClient:
+			if v != nil {
+				d.storageActions = v
+			}
+		case ActionsClient:
+			if v != nil {
+				d.actions = v
+			}
+		}
 	}
 	return d
 }

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -79,6 +79,17 @@ func NewDropletDriverWithClient(c DropletsClient, region string, optional ...int
 }
 
 func (d *DropletDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return d.createWithResolvedVolumes(ctx, spec, nil) // nil → existing name-based resolution
+}
+
+// createWithResolvedVolumes is the shared body of Create + Replace's
+// post-detach create step. When resolvedIDs is non-nil, it is used
+// verbatim as the godo.DropletCreateVolume IDs and spec.Config["volumes"]
+// (names) is IGNORED. When nil, the existing name-resolution path runs
+// (resolveDropletVolumes calls Storage.ListVolumes by name).
+func (d *DropletDriver) createWithResolvedVolumes(
+	ctx context.Context, spec interfaces.ResourceSpec, resolvedIDs []string,
+) (*interfaces.ResourceOutput, error) {
 	size := strFromConfig(spec.Config, "size", "s-1vcpu-2gb")
 	image := strFromConfig(spec.Config, "image", "ubuntu-24-04-x64")
 	region := strFromConfig(spec.Config, "region", d.region)
@@ -102,11 +113,21 @@ func (d *DropletDriver) Create(ctx context.Context, spec interfaces.ResourceSpec
 	}
 	req.SSHKeys = sshKeys
 
-	volumes, err := d.resolveDropletVolumes(ctx, spec.Config, region)
-	if err != nil {
-		return nil, fmt.Errorf("droplet create %q: %w", spec.Name, err)
+	if resolvedIDs != nil {
+		// Replace path: bypass name lookup; use the IDs the caller
+		// resolved pre-detach.
+		req.Volumes = make([]godo.DropletCreateVolume, len(resolvedIDs))
+		for i, id := range resolvedIDs {
+			req.Volumes[i] = godo.DropletCreateVolume{ID: id}
+		}
+	} else {
+		// Default Create path: existing name-based resolution.
+		volumes, err := d.resolveDropletVolumes(ctx, spec.Config, region)
+		if err != nil {
+			return nil, fmt.Errorf("droplet create %q: %w", spec.Name, err)
+		}
+		req.Volumes = volumes
 	}
-	req.Volumes = volumes
 
 	droplet, _, err := d.client.Create(ctx, req)
 	if err != nil {

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -644,4 +645,95 @@ func (d *DropletDriver) SensitiveKeys() []string { return nil }
 // UUIDs. We declare Freeform; providerIDToInt performs strict local validation
 // and rejects any non-integer ProviderID with an explicit error before any
 // API call is made — no UUID-based state-heal needed for Droplet.
-func (d *DropletDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }
+func (d *DropletDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatFreeform
+}
+
+// Compile-time assertion: DropletDriver implements interfaces.ResourceReplacer.
+var _ interfaces.ResourceReplacer = (*DropletDriver)(nil)
+
+// Replace implements interfaces.ResourceReplacer for DigitalOcean Droplets.
+// Orchestration: read old → DetachByDropletID per attached Volume → wait for
+// each detach action → delete old Droplet → create new Droplet with the same
+// resolved Volume IDs (bypassing the name-resolution race in Create's
+// resolveDropletVolumes path).
+//
+// On 404 from the initial Get(oldID), Replace falls through with
+// detach-skipped + delete-skipped; Create still fires (orphan-state recovery
+// — same as engine-default Delete-then-Create when the old Droplet is gone).
+//
+// Error wrapping: every sub-step wraps with "droplet replace %q: <step>: %w"
+// so the workflow engine's error-prefix backstop sees the recognized
+// "<resource-type> replace " family and passes the error through unchanged.
+func (d *DropletDriver) Replace(ctx context.Context, oldRef interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	oldID, err := providerIDToInt(oldRef.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("droplet replace %q: invalid old ProviderID %q: %w", oldRef.Name, oldRef.ProviderID, err)
+	}
+
+	old, _, err := d.client.Get(ctx, oldID)
+	if err != nil {
+		wrapped := WrapGodoError(err)
+		if !isResourceNotFound(wrapped) {
+			return nil, fmt.Errorf("droplet replace %q: read old: %w", oldRef.Name, wrapped)
+		}
+		// Old Droplet is already gone — skip detach + delete, proceed to create.
+		old = nil
+	}
+
+	var detachedVolumeIDs []string
+	if old != nil && len(old.VolumeIDs) > 0 {
+		if d.storageActions == nil {
+			return nil, fmt.Errorf("droplet replace %q: storage_actions client not configured; cannot detach %d volume(s)", oldRef.Name, len(old.VolumeIDs))
+		}
+		if d.actions == nil {
+			return nil, fmt.Errorf("droplet replace %q: actions client not configured; cannot wait for detach completion", oldRef.Name)
+		}
+		timeout, pollInterval := d.replaceTimeouts()
+		for _, volID := range old.VolumeIDs {
+			action, _, err := d.storageActions.DetachByDropletID(ctx, volID, oldID)
+			if err != nil {
+				return nil, fmt.Errorf("droplet replace %q: detach volume %q: %w", oldRef.Name, volID, WrapGodoError(err))
+			}
+			if err := waitForActionComplete(ctx, d.actions, action.ID, timeout, pollInterval); err != nil {
+				return nil, fmt.Errorf("droplet replace %q: wait detach action %d: %w", oldRef.Name, action.ID, err)
+			}
+			detachedVolumeIDs = append(detachedVolumeIDs, volID)
+		}
+	}
+
+	if old != nil {
+		if _, err := d.client.Delete(ctx, oldID); err != nil {
+			return nil, fmt.Errorf("droplet replace %q: delete old: %w", oldRef.Name, WrapGodoError(err))
+		}
+	}
+
+	out, err := d.createWithResolvedVolumes(ctx, spec, detachedVolumeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("droplet replace %q: create new: %w", oldRef.Name, err)
+	}
+	return out, nil
+}
+
+// replaceTimeouts returns the production timeout + poll interval, or the
+// test-overridden values when SetReplaceTimeoutsForTest has been called.
+func (d *DropletDriver) replaceTimeouts() (time.Duration, time.Duration) {
+	if d.replaceTimeout != 0 {
+		return d.replaceTimeout, d.replacePollInterval
+	}
+	return defaultActionWaitTimeout, defaultActionWaitPollInterval
+}
+
+// SetReplaceTimeoutsForTest is a test-only seam to override the production
+// 60s/2s detach-wait bounds. Production code MUST NOT call this.
+func (d *DropletDriver) SetReplaceTimeoutsForTest(timeout, pollInterval time.Duration) {
+	d.replaceTimeout = timeout
+	d.replacePollInterval = pollInterval
+}
+
+// isResourceNotFound returns true when the error is (or wraps)
+// interfaces.ErrResourceNotFound — the sentinel WrapGodoError injects for
+// HTTP 404 / 405 responses from the DO API.
+func isResourceNotFound(err error) bool {
+	return errors.Is(err, interfaces.ErrResourceNotFound)
+}

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -61,22 +62,42 @@ func NewDropletDriver(c *godo.Client, region string) *DropletDriver {
 func NewDropletDriverWithClient(c DropletsClient, region string, optional ...interface{}) *DropletDriver {
 	d := &DropletDriver{client: c, region: region}
 	for _, o := range optional {
+		// Skip both nil interface values AND typed-nil interface values (e.g.,
+		// `var sc *someStorage; StorageClient(sc)` is a non-nil interface
+		// wrapping a nil concrete pointer; assigning that to d.storage would
+		// pass nil-checks downstream then panic on method call). isNilLike
+		// uses reflection to detect the underlying-nil case the type-assertion
+		// nil-check misses.
+		if isNilLike(o) {
+			continue
+		}
 		switch v := o.(type) {
 		case StorageClient:
-			if v != nil {
-				d.storage = v
-			}
+			d.storage = v
 		case StorageActionsClient:
-			if v != nil {
-				d.storageActions = v
-			}
+			d.storageActions = v
 		case ActionsClient:
-			if v != nil {
-				d.actions = v
-			}
+			d.actions = v
 		}
 	}
 	return d
+}
+
+// isNilLike returns true when v is either a nil interface OR a non-nil
+// interface wrapping a nil pointer/map/slice/chan/func/interface. The
+// type-assertion `v != nil` check alone misses the typed-nil case — Go's
+// interface holds (type, value) and is non-nil whenever type is set, even
+// when value is a nil pointer. Detecting this reliably requires reflection.
+func isNilLike(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return rv.IsNil()
+	}
+	return false
 }
 
 func (d *DropletDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/droplet_replace_fakes_test.go
+++ b/internal/drivers/droplet_replace_fakes_test.go
@@ -114,10 +114,12 @@ func newRecordingStorageActionsClient() *recordingStorageActionsClient {
 }
 
 // recordingActionsClient: programmable Get-status sequence. callCount
-// indexes into statusSequence; out-of-bounds returns "completed" by
-// default (so tests don't need to enumerate exhaustively).
+// indexes into statusSequence; out-of-bounds returns defaultStatus
+// ("completed" for happy-path tests; override via withDefaultStatus for
+// timeout tests that need perpetual "in-progress").
 type recordingActionsClient struct {
 	statusSequence []string
+	defaultStatus  string
 	callCount      int
 }
 
@@ -126,12 +128,19 @@ func (m *recordingActionsClient) Get(_ context.Context, _ int) (*godo.Action, *g
 	if m.callCount < len(m.statusSequence) {
 		status = m.statusSequence[m.callCount]
 	} else {
-		status = "completed"
+		status = m.defaultStatus
 	}
 	m.callCount++
 	return &godo.Action{Status: status}, nil, nil
 }
 
 func newRecordingActionsClient(seq ...string) *recordingActionsClient {
-	return &recordingActionsClient{statusSequence: seq}
+	return &recordingActionsClient{statusSequence: seq, defaultStatus: "completed"}
+}
+
+// withDefaultStatus returns a copy of c with the given default status for
+// out-of-sequence polls. Use "in-progress" for timeout-boundary tests.
+func (c *recordingActionsClient) withDefaultStatus(status string) *recordingActionsClient {
+	c.defaultStatus = status
+	return c
 }

--- a/internal/drivers/droplet_replace_fakes_test.go
+++ b/internal/drivers/droplet_replace_fakes_test.go
@@ -1,0 +1,137 @@
+package drivers_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/digitalocean/godo"
+)
+
+// recordingDropletsClient records every method call and lets tests
+// program per-method responses. Replaces mockDropletClient for tests
+// that need ordering / request-inspection guarantees.
+type recordingDropletsClient struct {
+	// Programmable responses
+	getResponse *godo.Droplet
+	getErr      error
+	createResp  *godo.Droplet
+	createErr   error
+	deleteErr   error
+
+	// Call recording
+	getCalled    bool
+	deleteCalled bool
+	createCalled bool
+	createReq    *godo.DropletCreateRequest // most-recent create request (nil before first call)
+}
+
+func (m *recordingDropletsClient) Get(_ context.Context, _ int) (*godo.Droplet, *godo.Response, error) {
+	m.getCalled = true
+	return m.getResponse, nil, m.getErr
+}
+func (m *recordingDropletsClient) Create(_ context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
+	m.createCalled = true
+	m.createReq = req
+	return m.createResp, nil, m.createErr
+}
+func (m *recordingDropletsClient) Delete(_ context.Context, _ int) (*godo.Response, error) {
+	m.deleteCalled = true
+	return nil, m.deleteErr
+}
+
+// newRecordingDropletsClient defaults to: Get returning nil (caller programs
+// explicitly); Create returning a nominal new Droplet; Delete success.
+func newRecordingDropletsClient() *recordingDropletsClient {
+	return &recordingDropletsClient{
+		createResp: &godo.Droplet{
+			ID:     200,
+			Name:   "new-droplet",
+			Status: "active",
+			Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+			Region: &godo.Region{Slug: "nyc1"},
+		},
+	}
+}
+
+// recordingStorageClient: only ListVolumes and GetVolume are exercised by
+// Replace's supporting paths. ListVolumes filtering is not needed by Replace
+// (it bypasses name lookup via resolved IDs), but GetVolume is used by
+// dropletOutput to resolve VolumeIDs to names.
+type recordingStorageClient struct {
+	listResponse []godo.Volume
+	listErr      error
+	listCalls    int
+}
+
+func (m *recordingStorageClient) CreateVolume(_ context.Context, _ *godo.VolumeCreateRequest) (*godo.Volume, *godo.Response, error) {
+	return nil, nil, fmt.Errorf("not implemented in this fake")
+}
+func (m *recordingStorageClient) GetVolume(_ context.Context, id string) (*godo.Volume, *godo.Response, error) {
+	for _, v := range m.listResponse {
+		if v.ID == id {
+			return &v, nil, nil
+		}
+	}
+	return nil, nil, fmt.Errorf("volume %q not in fake", id)
+}
+func (m *recordingStorageClient) DeleteVolume(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+func (m *recordingStorageClient) ListVolumes(_ context.Context, _ *godo.ListVolumeParams) ([]godo.Volume, *godo.Response, error) {
+	m.listCalls++
+	return m.listResponse, nil, m.listErr
+}
+
+func newRecordingStorageClient() *recordingStorageClient {
+	return &recordingStorageClient{}
+}
+
+// recordingStorageActionsClient records DetachByDropletID calls
+// (volume + droplet IDs in invocation order). Returns programmable
+// action ID (incrementing) so subsequent Actions.Get can match.
+type recordingStorageActionsClient struct {
+	detachCalls  []struct{ VolumeID string; DropletID int }
+	detachErr    error
+	nextActionID int
+}
+
+func (m *recordingStorageActionsClient) DetachByDropletID(_ context.Context, vol string, drop int) (*godo.Action, *godo.Response, error) {
+	m.detachCalls = append(m.detachCalls, struct{ VolumeID string; DropletID int }{vol, drop})
+	if m.detachErr != nil {
+		return nil, nil, m.detachErr
+	}
+	m.nextActionID++
+	return &godo.Action{ID: m.nextActionID, Status: "in-progress"}, nil, nil
+}
+
+// Resize satisfies StorageActionsClient — not used in Replace tests.
+func (m *recordingStorageActionsClient) Resize(_ context.Context, _ string, _ int, _ string) (*godo.Action, *godo.Response, error) {
+	return nil, nil, fmt.Errorf("not implemented in this fake")
+}
+
+func newRecordingStorageActionsClient() *recordingStorageActionsClient {
+	return &recordingStorageActionsClient{}
+}
+
+// recordingActionsClient: programmable Get-status sequence. callCount
+// indexes into statusSequence; out-of-bounds returns "completed" by
+// default (so tests don't need to enumerate exhaustively).
+type recordingActionsClient struct {
+	statusSequence []string
+	callCount      int
+}
+
+func (m *recordingActionsClient) Get(_ context.Context, _ int) (*godo.Action, *godo.Response, error) {
+	var status string
+	if m.callCount < len(m.statusSequence) {
+		status = m.statusSequence[m.callCount]
+	} else {
+		status = "completed"
+	}
+	m.callCount++
+	return &godo.Action{Status: status}, nil, nil
+}
+
+func newRecordingActionsClient(seq ...string) *recordingActionsClient {
+	return &recordingActionsClient{statusSequence: seq}
+}

--- a/internal/drivers/droplet_replace_fakes_test.go
+++ b/internal/drivers/droplet_replace_fakes_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/digitalocean/godo"
 )
 
+// callLog is a shared ordered log of method calls across all recording fakes.
+// Tests assert the cross-fake call sequence (Get → Detach → Wait → Delete →
+// Create) — the load-bearing invariant for avoiding the 422 failure class.
+// Per-fake booleans are kept for backwards-compat with tests that don't need
+// ordering.
+type callLog struct {
+	events []string
+}
+
+func (l *callLog) record(s string) {
+	if l == nil {
+		return
+	}
+	l.events = append(l.events, s)
+}
+
 // recordingDropletsClient records every method call and lets tests
 // program per-method responses. Replaces mockDropletClient for tests
 // that need ordering / request-inspection guarantees.
@@ -23,19 +39,31 @@ type recordingDropletsClient struct {
 	deleteCalled bool
 	createCalled bool
 	createReq    *godo.DropletCreateRequest // most-recent create request (nil before first call)
+
+	// log: optional shared call log (set via withCallLog) for cross-fake
+	// ordering assertions. nil-safe via callLog.record's nil-receiver check.
+	log *callLog
+}
+
+func (m *recordingDropletsClient) withCallLog(log *callLog) *recordingDropletsClient {
+	m.log = log
+	return m
 }
 
 func (m *recordingDropletsClient) Get(_ context.Context, _ int) (*godo.Droplet, *godo.Response, error) {
 	m.getCalled = true
+	m.log.record("Droplets.Get")
 	return m.getResponse, nil, m.getErr
 }
 func (m *recordingDropletsClient) Create(_ context.Context, req *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
 	m.createCalled = true
 	m.createReq = req
+	m.log.record("Droplets.Create")
 	return m.createResp, nil, m.createErr
 }
 func (m *recordingDropletsClient) Delete(_ context.Context, _ int) (*godo.Response, error) {
 	m.deleteCalled = true
+	m.log.record("Droplets.Delete")
 	return nil, m.deleteErr
 }
 
@@ -93,10 +121,18 @@ type recordingStorageActionsClient struct {
 	detachCalls  []struct{ VolumeID string; DropletID int }
 	detachErr    error
 	nextActionID int
+
+	log *callLog
+}
+
+func (m *recordingStorageActionsClient) withCallLog(log *callLog) *recordingStorageActionsClient {
+	m.log = log
+	return m
 }
 
 func (m *recordingStorageActionsClient) DetachByDropletID(_ context.Context, vol string, drop int) (*godo.Action, *godo.Response, error) {
 	m.detachCalls = append(m.detachCalls, struct{ VolumeID string; DropletID int }{vol, drop})
+	m.log.record("StorageActions.DetachByDropletID")
 	if m.detachErr != nil {
 		return nil, nil, m.detachErr
 	}
@@ -121,6 +157,13 @@ type recordingActionsClient struct {
 	statusSequence []string
 	defaultStatus  string
 	callCount      int
+
+	log *callLog
+}
+
+func (c *recordingActionsClient) withCallLog(log *callLog) *recordingActionsClient {
+	c.log = log
+	return c
 }
 
 func (m *recordingActionsClient) Get(_ context.Context, _ int) (*godo.Action, *godo.Response, error) {
@@ -131,6 +174,7 @@ func (m *recordingActionsClient) Get(_ context.Context, _ int) (*godo.Action, *g
 		status = m.defaultStatus
 	}
 	m.callCount++
+	m.log.record("Actions.Get")
 	return &godo.Action{Status: status}, nil, nil
 }
 
@@ -138,8 +182,8 @@ func newRecordingActionsClient(seq ...string) *recordingActionsClient {
 	return &recordingActionsClient{statusSequence: seq, defaultStatus: "completed"}
 }
 
-// withDefaultStatus returns a copy of c with the given default status for
-// out-of-sequence polls. Use "in-progress" for timeout-boundary tests.
+// withDefaultStatus returns the receiver after setting the given default
+// status for out-of-sequence polls. Use "in-progress" for timeout tests.
 func (c *recordingActionsClient) withDefaultStatus(status string) *recordingActionsClient {
 	c.defaultStatus = status
 	return c

--- a/internal/drivers/droplet_replace_helpers_test.go
+++ b/internal/drivers/droplet_replace_helpers_test.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,11 +12,16 @@ import (
 
 type fakeActionsClient struct {
 	statusSequence []string
+	defaultStatus  string // returned when callCount >= len(statusSequence); empty → return "ran out" error
 	callCount      int
 }
 
 func (f *fakeActionsClient) Get(_ context.Context, actionID int) (*godo.Action, *godo.Response, error) {
 	if f.callCount >= len(f.statusSequence) {
+		if f.defaultStatus != "" {
+			f.callCount++
+			return &godo.Action{ID: actionID, Status: f.defaultStatus}, nil, nil
+		}
 		return nil, nil, errors.New("ran out of statuses")
 	}
 	s := f.statusSequence[f.callCount]
@@ -53,9 +59,19 @@ func TestWaitForActionComplete_ContextCancelPropagates(t *testing.T) {
 }
 
 func TestWaitForActionComplete_TimeoutBoundary(t *testing.T) {
-	f := &fakeActionsClient{statusSequence: []string{"in-progress", "in-progress", "in-progress", "in-progress"}}
+	// defaultStatus="in-progress" so polls beyond statusSequence keep returning
+	// "in-progress" instead of erroring with "ran out of statuses". This is
+	// what waitForActionComplete needs to actually exercise its timeout path
+	// (it polls one more time after the deadline check before exiting).
+	f := &fakeActionsClient{
+		statusSequence: []string{"in-progress"},
+		defaultStatus:  "in-progress",
+	}
 	err := waitForActionComplete(context.Background(), f, 12345, 200*time.Millisecond, 50*time.Millisecond)
 	if err == nil {
 		t.Fatal("want timeout error")
+	}
+	if !strings.Contains(err.Error(), "timeout after") {
+		t.Errorf("want timeout error, got: %v", err)
 	}
 }

--- a/internal/drivers/droplet_replace_helpers_test.go
+++ b/internal/drivers/droplet_replace_helpers_test.go
@@ -1,0 +1,61 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+type fakeActionsClient struct {
+	statusSequence []string
+	callCount      int
+}
+
+func (f *fakeActionsClient) Get(_ context.Context, actionID int) (*godo.Action, *godo.Response, error) {
+	if f.callCount >= len(f.statusSequence) {
+		return nil, nil, errors.New("ran out of statuses")
+	}
+	s := f.statusSequence[f.callCount]
+	f.callCount++
+	return &godo.Action{ID: actionID, Status: s}, nil, nil
+}
+
+func TestWaitForActionComplete_CompletesQuickly(t *testing.T) {
+	f := &fakeActionsClient{statusSequence: []string{"in-progress", "completed"}}
+	err := waitForActionComplete(context.Background(), f, 12345, 2*time.Second, 100*time.Millisecond)
+	if err != nil {
+		t.Fatalf("want nil, got %v", err)
+	}
+	if f.callCount != 2 {
+		t.Errorf("want 2 polls, got %d", f.callCount)
+	}
+}
+
+func TestWaitForActionComplete_ErroredStatusReturnsError(t *testing.T) {
+	f := &fakeActionsClient{statusSequence: []string{"errored"}}
+	err := waitForActionComplete(context.Background(), f, 12345, 2*time.Second, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+func TestWaitForActionComplete_ContextCancelPropagates(t *testing.T) {
+	f := &fakeActionsClient{statusSequence: []string{"in-progress", "in-progress"}}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := waitForActionComplete(ctx, f, 12345, 2*time.Second, 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("want context cancellation error")
+	}
+}
+
+func TestWaitForActionComplete_TimeoutBoundary(t *testing.T) {
+	f := &fakeActionsClient{statusSequence: []string{"in-progress", "in-progress", "in-progress", "in-progress"}}
+	err := waitForActionComplete(context.Background(), f, 12345, 200*time.Millisecond, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("want timeout error")
+	}
+}

--- a/internal/drivers/droplet_replace_integration_test.go
+++ b/internal/drivers/droplet_replace_integration_test.go
@@ -5,6 +5,7 @@ package drivers_test
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
@@ -23,21 +24,24 @@ import (
 //  5. Create(req)                   → {ID:200}
 //
 // Asserts:
-// - No 422: Delete fires BEFORE Create (detach → delete → create order enforced).
+// - Exact ordering via shared callLog (cross-fake): the load-bearing 422-fix
+//   invariant. A regression that swapped Delete↔Create or skipped detach
+//   shows up as a different events slice.
 // - New Droplet gets ProviderID "200".
-// - Full call sequence recorded: get+detach+wait+delete+create.
+// - DetachByDropletID args are correct (volume + droplet IDs).
 func TestReplaceTC2ScenarioReplay(t *testing.T) {
-	droplets := newRecordingDropletsClient()
+	log := &callLog{}
+	droplets := newRecordingDropletsClient().withCallLog(log)
 	droplets.getResponse = &godo.Droplet{
-		ID:     100,
-		Name:   "coredump-staging-pg",
-		Status: "active",
+		ID:        100,
+		Name:      "coredump-staging-pg",
+		Status:    "active",
 		VolumeIDs: []string{"vol-a"},
-		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
-		Region: &godo.Region{Slug: "nyc1"},
+		Size:      &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region:    &godo.Region{Slug: "nyc1"},
 	}
-	sa := newRecordingStorageActionsClient()
-	actions := newRecordingActionsClient("completed")
+	sa := newRecordingStorageActionsClient().withCallLog(log)
+	actions := newRecordingActionsClient("completed").withCallLog(log)
 
 	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
 		drivers.StorageActionsClient(sa),
@@ -61,10 +65,22 @@ func TestReplaceTC2ScenarioReplay(t *testing.T) {
 		t.Errorf("expected new ProviderID=200, got %q", out.ProviderID)
 	}
 
-	// Assert full call sequence.
-	if !droplets.getCalled {
-		t.Error("Get must be called (phase 1: read old)")
+	// Exact-ordering assertion — strongest defense against the 422 regression.
+	// If a future change swaps Delete↔Create or skips DetachByDropletID, this
+	// slice differs and the test fails. Per-method booleans alone cannot
+	// detect Create-before-Delete.
+	want := []string{
+		"Droplets.Get",
+		"StorageActions.DetachByDropletID",
+		"Actions.Get",
+		"Droplets.Delete",
+		"Droplets.Create",
 	}
+	if !reflect.DeepEqual(log.events, want) {
+		t.Errorf("call sequence wrong:\n  got:  %v\n  want: %v", log.events, want)
+	}
+
+	// Detach call args (the ordering log doesn't carry per-call args).
 	if len(sa.detachCalls) != 1 {
 		t.Errorf("DetachByDropletID: got %d calls, want 1", len(sa.detachCalls))
 	}
@@ -74,17 +90,4 @@ func TestReplaceTC2ScenarioReplay(t *testing.T) {
 	if sa.detachCalls[0].DropletID != 100 {
 		t.Errorf("DetachByDropletID: DropletID=%d, want 100", sa.detachCalls[0].DropletID)
 	}
-	if actions.callCount < 1 {
-		t.Error("Actions.Get must be called at least once (wait for detach)")
-	}
-	if !droplets.deleteCalled {
-		t.Error("Delete must be called (phase 3: delete old); absence means 422 risk")
-	}
-	if !droplets.createCalled {
-		t.Error("Create must be called (phase 4: create new)")
-	}
-	// Assert no 422: Delete fired BEFORE Create (sequence enforced by the
-	// implementation; this test verifies it via call recording, not real API).
-	// Success here implies the sequence completed without the 422 that would
-	// occur if Create were attempted while the old Droplet still held the volume.
 }

--- a/internal/drivers/droplet_replace_integration_test.go
+++ b/internal/drivers/droplet_replace_integration_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+// +build integration
+
+package drivers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// TestReplaceTC2ScenarioReplay replays the TC2 orphan-Droplet scenario using
+// a sequenced godo mock matching the existing DO plugin test pattern.
+//
+// Sequence:
+//  1. Get(100)                      → {ID:100, VolumeIDs:["vol-a"]}
+//  2. DetachByDropletID(vol-a, 100) → action ID 1, status in-progress
+//  3. Actions.Get(1)                → "completed"
+//  4. Delete(100)                   → success
+//  5. Create(req)                   → {ID:200}
+//
+// Asserts:
+// - No 422: Delete fires BEFORE Create (detach → delete → create order enforced).
+// - New Droplet gets ProviderID "200".
+// - Full call sequence recorded: get+detach+wait+delete+create.
+func TestReplaceTC2ScenarioReplay(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID:     100,
+		Name:   "coredump-staging-pg",
+		Status: "active",
+		VolumeIDs: []string{"vol-a"},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+	}
+	sa := newRecordingStorageActionsClient()
+	actions := newRecordingActionsClient("completed")
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageActionsClient(sa),
+		drivers.ActionsClient(actions),
+	)
+
+	spec := interfaces.ResourceSpec{
+		Name: "coredump-staging-pg",
+		Config: map[string]any{
+			"size":   "s-1vcpu-2gb",
+			"region": "nyc1",
+		},
+	}
+	oldRef := interfaces.ResourceRef{Name: "coredump-staging-pg", ProviderID: "100"}
+
+	out, err := d.Replace(context.Background(), oldRef, spec)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if out.ProviderID != "200" {
+		t.Errorf("expected new ProviderID=200, got %q", out.ProviderID)
+	}
+
+	// Assert full call sequence.
+	if !droplets.getCalled {
+		t.Error("Get must be called (phase 1: read old)")
+	}
+	if len(sa.detachCalls) != 1 {
+		t.Errorf("DetachByDropletID: got %d calls, want 1", len(sa.detachCalls))
+	}
+	if sa.detachCalls[0].VolumeID != "vol-a" {
+		t.Errorf("DetachByDropletID: VolumeID=%q, want vol-a", sa.detachCalls[0].VolumeID)
+	}
+	if sa.detachCalls[0].DropletID != 100 {
+		t.Errorf("DetachByDropletID: DropletID=%d, want 100", sa.detachCalls[0].DropletID)
+	}
+	if actions.callCount < 1 {
+		t.Error("Actions.Get must be called at least once (wait for detach)")
+	}
+	if !droplets.deleteCalled {
+		t.Error("Delete must be called (phase 3: delete old); absence means 422 risk")
+	}
+	if !droplets.createCalled {
+		t.Error("Create must be called (phase 4: create new)")
+	}
+	// Assert no 422: Delete fired BEFORE Create (sequence enforced by the
+	// implementation; this test verifies it via call recording, not real API).
+	// Success here implies the sequence completed without the 422 that would
+	// occur if Create were attempted while the old Droplet still held the volume.
+}

--- a/internal/drivers/droplet_replace_test.go
+++ b/internal/drivers/droplet_replace_test.go
@@ -1,0 +1,226 @@
+package drivers_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+func TestDropletDriver_Replace_DetachesVolumesBeforeDelete(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID: 100, VolumeIDs: []string{"vol-a", "vol-b"},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+		Status: "active",
+	}
+	sa := newRecordingStorageActionsClient()
+	actions := newRecordingActionsClient("completed", "completed")
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageClient(newRecordingStorageClient()),
+		drivers.StorageActionsClient(sa),
+		drivers.ActionsClient(actions),
+	)
+
+	spec := interfaces.ResourceSpec{Name: "pg", Config: map[string]any{"size": "s-1vcpu-2gb"}}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	out, err := d.Replace(context.Background(), oldRef, spec)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if len(sa.detachCalls) != 2 {
+		t.Errorf("expected 2 detach calls, got %d", len(sa.detachCalls))
+	}
+	// Assert ordering: Get → 2× DetachByDropletID → 2× Actions.Get → Delete → Create.
+	if !droplets.getCalled || !droplets.deleteCalled || !droplets.createCalled {
+		t.Error("expected Get + Delete + Create on droplet client")
+	}
+	if out.ProviderID == "" {
+		t.Error("expected new ProviderID")
+	}
+}
+
+func TestDropletDriver_Replace_OldNotFound_SkipsDetachAndDelete(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	// Simulate a 404 from godo via *godo.ErrorResponse so WrapGodoError maps
+	// it to interfaces.ErrResourceNotFound and Replace treats it as "orphan state"
+	// (old Droplet already gone) — skip detach + delete, proceed to Create.
+	droplets.getErr = &godo.ErrorResponse{
+		Response: &http.Response{StatusCode: 404},
+		Message:  "droplet not found",
+	}
+	sa := newRecordingStorageActionsClient()
+	actions := newRecordingActionsClient()
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageActionsClient(sa), drivers.ActionsClient(actions),
+	)
+
+	spec := interfaces.ResourceSpec{Name: "pg"}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	out, err := d.Replace(context.Background(), oldRef, spec)
+	if err != nil {
+		t.Fatalf("Replace on 404-old: %v", err)
+	}
+	if len(sa.detachCalls) != 0 {
+		t.Error("detach should NOT fire on 404 old droplet")
+	}
+	if droplets.deleteCalled {
+		t.Error("delete should NOT fire on 404 old droplet")
+	}
+	if !droplets.createCalled {
+		t.Error("create should still fire (recovery path)")
+	}
+	if out == nil {
+		t.Error("expected non-nil output")
+	}
+}
+
+func TestDropletDriver_Replace_NoVolumes_NoDetachCall(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID: 100, VolumeIDs: []string{},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+		Status: "active",
+	}
+	sa := newRecordingStorageActionsClient()
+	actions := newRecordingActionsClient()
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageActionsClient(sa), drivers.ActionsClient(actions),
+	)
+
+	spec := interfaces.ResourceSpec{Name: "pg"}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	_, err := d.Replace(context.Background(), oldRef, spec)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if len(sa.detachCalls) != 0 {
+		t.Errorf("expected zero detach calls; got %d", len(sa.detachCalls))
+	}
+	if !droplets.deleteCalled || !droplets.createCalled {
+		t.Error("expected Delete + Create on no-volumes path")
+	}
+}
+
+func TestDropletDriver_Replace_DetachWaitTimeout_PreservesRecoverable(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID: 100, VolumeIDs: []string{"vol-a"},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+		Status: "active",
+	}
+	sa := newRecordingStorageActionsClient()
+	// Use withDefaultStatus("in-progress") so the client keeps returning
+	// "in-progress" after the sequence runs out, allowing the timeout to fire.
+	actions := newRecordingActionsClient().withDefaultStatus("in-progress")
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageActionsClient(sa), drivers.ActionsClient(actions),
+	)
+	// Override to short bounds so the timeout fires quickly.
+	d.SetReplaceTimeoutsForTest(100*time.Millisecond, 30*time.Millisecond)
+
+	spec := interfaces.ResourceSpec{Name: "pg"}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	_, err := d.Replace(context.Background(), oldRef, spec)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "wait detach action") {
+		t.Errorf("error not wrapped with 'wait detach action': %v", err)
+	}
+	if droplets.deleteCalled || droplets.createCalled {
+		t.Error("delete/create must NOT fire on detach timeout (state preservation)")
+	}
+}
+
+func TestDropletDriver_Replace_NoStorageActions_Errors(t *testing.T) {
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID: 100, VolumeIDs: []string{"vol-a"},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+		Status: "active",
+	}
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1") // no StorageActions
+
+	spec := interfaces.ResourceSpec{Name: "pg"}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	_, err := d.Replace(context.Background(), oldRef, spec)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "storage_actions client not configured") {
+		t.Errorf("error not wrapped with 'storage_actions': %v", err)
+	}
+}
+
+func TestDropletDriver_Replace_BypassesNameResolution(t *testing.T) {
+	// Set up two volumes with the same name in the region; default
+	// Create's resolveDropletVolumes would pick one. Replace MUST
+	// pick the volume previously attached to the old droplet.
+	droplets := newRecordingDropletsClient()
+	droplets.getResponse = &godo.Droplet{
+		ID: 100, VolumeIDs: []string{"vol-PREVIOUSLY-ATTACHED-id"},
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc1"},
+		Status: "active",
+	}
+	sa := newRecordingStorageActionsClient()
+	actions := newRecordingActionsClient("completed")
+	storage := newRecordingStorageClient()
+	// Same-name pollution: ListVolumes by name returns BOTH volumes.
+	storage.listResponse = []godo.Volume{
+		{ID: "vol-OTHER-id", Name: "pg-data"},           // alphabetically first
+		{ID: "vol-PREVIOUSLY-ATTACHED-id", Name: "pg-data"},
+	}
+
+	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
+		drivers.StorageClient(storage),
+		drivers.StorageActionsClient(sa),
+		drivers.ActionsClient(actions),
+	)
+
+	spec := interfaces.ResourceSpec{
+		Name:   "pg",
+		Config: map[string]any{"volumes": []any{"pg-data"}},
+	}
+	oldRef := interfaces.ResourceRef{Name: "pg", ProviderID: "100"}
+
+	_, err := d.Replace(context.Background(), oldRef, spec)
+	if err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	// Replace bypasses name resolution → ListVolumes must NOT be called.
+	if storage.listCalls != 0 {
+		t.Errorf("storage.ListVolumes called %d times; want 0 (Replace must bypass name lookup)", storage.listCalls)
+	}
+	// Inspect droplets.createReq to assert the create request used
+	// vol-PREVIOUSLY-ATTACHED-id, NOT the alphabetically-first vol-OTHER-id.
+	if droplets.createReq == nil {
+		t.Fatal("createReq not recorded")
+	}
+	if len(droplets.createReq.Volumes) != 1 {
+		t.Fatalf("Volumes len = %d, want 1", len(droplets.createReq.Volumes))
+	}
+	if got := droplets.createReq.Volumes[0].ID; got != "vol-PREVIOUSLY-ATTACHED-id" {
+		t.Errorf("Replace.Create used wrong volume ID: got %q, want vol-PREVIOUSLY-ATTACHED-id", got)
+	}
+}

--- a/internal/drivers/droplet_replace_test.go
+++ b/internal/drivers/droplet_replace_test.go
@@ -3,6 +3,7 @@ package drivers_test
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,15 +14,16 @@ import (
 )
 
 func TestDropletDriver_Replace_DetachesVolumesBeforeDelete(t *testing.T) {
-	droplets := newRecordingDropletsClient()
+	log := &callLog{}
+	droplets := newRecordingDropletsClient().withCallLog(log)
 	droplets.getResponse = &godo.Droplet{
 		ID: 100, VolumeIDs: []string{"vol-a", "vol-b"},
 		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
 		Region: &godo.Region{Slug: "nyc1"},
 		Status: "active",
 	}
-	sa := newRecordingStorageActionsClient()
-	actions := newRecordingActionsClient("completed", "completed")
+	sa := newRecordingStorageActionsClient().withCallLog(log)
+	actions := newRecordingActionsClient("completed", "completed").withCallLog(log)
 
 	d := drivers.NewDropletDriverWithClient(droplets, "nyc1",
 		drivers.StorageClient(newRecordingStorageClient()),
@@ -39,9 +41,20 @@ func TestDropletDriver_Replace_DetachesVolumesBeforeDelete(t *testing.T) {
 	if len(sa.detachCalls) != 2 {
 		t.Errorf("expected 2 detach calls, got %d", len(sa.detachCalls))
 	}
-	// Assert ordering: Get → 2× DetachByDropletID → 2× Actions.Get → Delete → Create.
-	if !droplets.getCalled || !droplets.deleteCalled || !droplets.createCalled {
-		t.Error("expected Get + Delete + Create on droplet client")
+	// Exact-ordering assertion via cross-fake call log. Replaces the prior
+	// boolean-based check that couldn't distinguish Create-before-Delete from
+	// Delete-before-Create — the load-bearing 422-fix invariant.
+	want := []string{
+		"Droplets.Get",
+		"StorageActions.DetachByDropletID",
+		"Actions.Get",
+		"StorageActions.DetachByDropletID",
+		"Actions.Get",
+		"Droplets.Delete",
+		"Droplets.Create",
+	}
+	if !reflect.DeepEqual(log.events, want) {
+		t.Errorf("call sequence wrong:\n  got:  %v\n  want: %v", log.events, want)
 	}
 	if out.ProviderID == "" {
 		t.Error("expected new ProviderID")

--- a/internal/drivers/droplet_test.go
+++ b/internal/drivers/droplet_test.go
@@ -3,6 +3,7 @@ package drivers_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
@@ -1270,5 +1271,25 @@ func TestDropletDriver_Diff_IPv6LegacyStateNoSpuriousReplace(t *testing.T) {
 	if r.NeedsReplace || r.NeedsUpdate {
 		t.Errorf("legacy state (no ipv6 key in Outputs) must NOT trigger spurious replace; NeedsReplace=%v changes=%+v",
 			r.NeedsReplace, r.Changes)
+	}
+}
+
+// TestNewDropletDriverWithClient_TypedNilSafe verifies that passing a typed-nil
+// StorageClient to NewDropletDriverWithClient does NOT silently install a
+// nil-method-set dependency that would panic on call — the driver should
+// surface "storage client not configured" when the path that needs storage is
+// exercised, rather than a nil-pointer dereference.
+func TestNewDropletDriverWithClient_TypedNilSafe(t *testing.T) {
+	var nilStorage drivers.StorageClient // typed-nil interface
+	d := drivers.NewDropletDriverWithClient(&mockDropletClient{}, "nyc1", nilStorage)
+	// d.storage must remain nil (not the typed-nil interface).
+	// Trigger the storage-needed path via Create with a volume spec.
+	spec := interfaces.ResourceSpec{
+		Name:   "pg",
+		Config: map[string]any{"volumes": []any{"pg-data"}},
+	}
+	_, err := d.Create(context.Background(), spec)
+	if err == nil || !strings.Contains(err.Error(), "storage client not configured") {
+		t.Errorf("typed-nil StorageClient did not surface 'storage client not configured'; got: %v", err)
 	}
 }

--- a/internal/drivers/droplet_test.go
+++ b/internal/drivers/droplet_test.go
@@ -1274,22 +1274,42 @@ func TestDropletDriver_Diff_IPv6LegacyStateNoSpuriousReplace(t *testing.T) {
 	}
 }
 
-// TestNewDropletDriverWithClient_TypedNilSafe verifies that passing a typed-nil
-// StorageClient to NewDropletDriverWithClient does NOT silently install a
-// nil-method-set dependency that would panic on call — the driver should
-// surface "storage client not configured" when the path that needs storage is
-// exercised, rather than a nil-pointer dereference.
+// TestNewDropletDriverWithClient_TypedNilSafe verifies that passing either
+// a nil-interface OR a typed-nil-pointer wrapped in StorageClient to
+// NewDropletDriverWithClient does NOT silently install a nil-method-set
+// dependency that would panic on call.
+//
+// The TYPED-NIL case is the dangerous one: in Go, an interface holding a
+// nil concrete pointer is a non-nil interface (its type word is set, value
+// word is nil). A naive `if v != nil` check passes; calling a method on
+// such an interface dereferences the nil receiver inside the method body.
+// isNilLike's reflection check handles both forms.
 func TestNewDropletDriverWithClient_TypedNilSafe(t *testing.T) {
-	var nilStorage drivers.StorageClient // typed-nil interface
-	d := drivers.NewDropletDriverWithClient(&mockDropletClient{}, "nyc1", nilStorage)
-	// d.storage must remain nil (not the typed-nil interface).
-	// Trigger the storage-needed path via Create with a volume spec.
-	spec := interfaces.ResourceSpec{
-		Name:   "pg",
-		Config: map[string]any{"volumes": []any{"pg-data"}},
+	cases := []struct {
+		name    string
+		storage drivers.StorageClient
+	}{
+		{
+			name:    "nil interface (var without assignment)",
+			storage: drivers.StorageClient(nil),
+		},
+		{
+			name:    "typed-nil pointer wrapped in interface",
+			storage: (*mockStorageClient)(nil), // satisfies StorageClient via *mockStorageClient
+		},
 	}
-	_, err := d.Create(context.Background(), spec)
-	if err == nil || !strings.Contains(err.Error(), "storage client not configured") {
-		t.Errorf("typed-nil StorageClient did not surface 'storage client not configured'; got: %v", err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := drivers.NewDropletDriverWithClient(&mockDropletClient{}, "nyc1", tc.storage)
+			spec := interfaces.ResourceSpec{
+				Name:   "pg",
+				Config: map[string]any{"volumes": []any{"pg-data"}},
+			}
+			// Must not panic; must return a config error (not nil-pointer deref).
+			_, err := d.Create(context.Background(), spec)
+			if err == nil || !strings.Contains(err.Error(), "storage client not configured") {
+				t.Errorf("expected 'storage client not configured'; got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/drivers/volume.go
+++ b/internal/drivers/volume.go
@@ -19,10 +19,15 @@ type StorageClient interface {
 }
 
 // StorageActionsClient is the subset of godo.StorageActionsService used by
-// VolumeDriver to execute resize actions (the only mutation DO supports on
-// an existing volume without delete + recreate).
+// VolumeDriver (resize) and DropletDriver.Replace (volume detach before
+// delete). Both operations are on the same godo.StorageActionsService so
+// one interface covers both callers.
 type StorageActionsClient interface {
 	Resize(ctx context.Context, volumeID string, sizeGigabytes int, regionSlug string) (*godo.Action, *godo.Response, error)
+	// DetachByDropletID detaches the volume from the given Droplet. Used by
+	// DropletDriver.Replace before deleting the old Droplet so DO does not
+	// reject the new Droplet's create with "422 storage already associated".
+	DetachByDropletID(ctx context.Context, volumeID string, dropletID int) (*godo.Action, *godo.Response, error)
 }
 
 // VolumeDriver manages DigitalOcean Block Storage volumes (infra.volume).

--- a/internal/drivers/volume_test.go
+++ b/internal/drivers/volume_test.go
@@ -29,6 +29,16 @@ func (m *mockStorageActionsClient) Resize(_ context.Context, _ string, sizeGB in
 	return &godo.Action{Status: "completed"}, nil, nil
 }
 
+// DetachByDropletID satisfies StorageActionsClient. VolumeDriver tests
+// never call this; it is required because DropletDriver.Replace uses the
+// same interface. Returns completed action or the configured error.
+func (m *mockStorageActionsClient) DetachByDropletID(_ context.Context, _ string, _ int) (*godo.Action, *godo.Response, error) {
+	if m.err != nil {
+		return nil, nil, m.err
+	}
+	return &godo.Action{Status: "completed"}, nil, nil
+}
+
 func testVolume() *godo.Volume {
 	return &godo.Volume{
 		ID:             "vol-aaaa-bbbb-cccc-dddd-eeeeeeeeeeee",

--- a/testfixture/tc2-equivalent/infra.yaml
+++ b/testfixture/tc2-equivalent/infra.yaml
@@ -1,9 +1,17 @@
-# TC2-equivalent fixture for runtime-launch validation.
-# Tests that wfctl infra plan sees "no changes" when vpc_uuid is resolved
-# from state at plan time (JIT resolver, workflow v0.23.0 PR-1).
+# TC2-equivalent fixture for runtime-launch validation (smoke / wiring only).
+# This fixture mirrors the STRUCTURAL shape of core-dump's infra.yaml without
+# cloud credentials. It exercises:
+#   - wfctl plugin discovery + gRPC handshake against the local DO plugin binary
+#   - wfctl infra plan invocation end-to-end (no panic / SDK-version mismatch)
 #
-# This fixture mirrors the structural shape of core-dump's infra.yaml
-# without cloud-specific secrets or actual credentials.
+# It does NOT validate the JIT resolver's "no changes" outcome: that requires a
+# matching pre-populated state.json discovered by the filesystem state backend,
+# and the path resolution for that backend is operator-environment dependent.
+# The full "0 actions on Droplet because state.vpc_uuid matches resolved
+# config.vpc_uuid" assertion is exercised at the actual TC2 cutover time
+# (core-dump's tc2-cutover.yml Phase 1 plan), where state is populated via
+# tc2-state-import.yml. See docs/runtime-validation/2026-05-07-tc2-equivalent-launch.log
+# for the smoke-validation transcript captured at PR-3 land time.
 
 infra:
   auto_bootstrap: false

--- a/testfixture/tc2-equivalent/infra.yaml
+++ b/testfixture/tc2-equivalent/infra.yaml
@@ -1,0 +1,54 @@
+# TC2-equivalent fixture for runtime-launch validation.
+# Tests that wfctl infra plan sees "no changes" when vpc_uuid is resolved
+# from state at plan time (JIT resolver, workflow v0.23.0 PR-1).
+#
+# This fixture mirrors the structural shape of core-dump's infra.yaml
+# without cloud-specific secrets or actual credentials.
+
+infra:
+  auto_bootstrap: false
+
+secrets:
+  provider: env
+  generate:
+    - key: STAGING_VPC_UUID
+      type: infra_output
+      source: core-dump-vpc.id
+
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      plugin_path: /tmp/do-plugin
+
+  - name: iac-state
+    type: iac.state
+    config:
+      backend: filesystem
+      path: testfixture/tc2-equivalent/state.json
+
+  - name: core-dump-vpc
+    type: infra.vpc
+    config:
+      provider: do-provider
+    environments:
+      staging:
+        config:
+          name: core-dump-vpc
+          region: nyc1
+          ip_range: 10.20.0.0/16
+
+  - name: coredump-staging-pg
+    type: infra.droplet
+    config:
+      provider: do-provider
+    environments:
+      staging:
+        config:
+          name: coredump-staging-pg
+          region: nyc1
+          size: s-1vcpu-2gb
+          image: ubuntu-24-04-x64
+          vpc_uuid: ${STAGING_VPC_UUID}
+          monitoring: true

--- a/testfixture/tc2-equivalent/state.json
+++ b/testfixture/tc2-equivalent/state.json
@@ -1,0 +1,37 @@
+{
+  "resources": {
+    "core-dump-vpc": {
+      "name": "core-dump-vpc",
+      "type": "infra.vpc",
+      "provider_id": "14badc41-1234-5678-abcd-test000000001",
+      "outputs": {
+        "id": "14badc41-1234-5678-abcd-test000000001",
+        "name": "core-dump-vpc",
+        "region": "nyc1",
+        "ip_range": "10.20.0.0/16",
+        "status": "active"
+      },
+      "status": "active"
+    },
+    "coredump-staging-pg": {
+      "name": "coredump-staging-pg",
+      "type": "infra.droplet",
+      "provider_id": "999999",
+      "outputs": {
+        "id": 999999,
+        "public_ip": "1.2.3.4",
+        "private_ip": "10.20.0.10",
+        "size": "s-1vcpu-2gb",
+        "region": "nyc1",
+        "status": "active",
+        "vpc_uuid": "14badc41-1234-5678-abcd-test000000001",
+        "enable_backups": false,
+        "monitoring": true,
+        "tags": [],
+        "volumes": [],
+        "ipv6": false
+      },
+      "status": "active"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements `interfaces.ResourceReplacer` for DigitalOcean Droplets to fix the
"422 storage already associated with another droplet" failure class when
replacing Droplets that have attached Block Storage Volumes (the canonical
TC2-class scenario).

**Plan reference:** `docs/plans/2026-05-07-jit-plan-time-and-replace-detach.md` (in core-dump worktree, manifest sha256 `d19678761ef3aaf5f32ac6617188ab9b8992b889645d69162b788a3252c7f113`).
**ADR:** `decisions/0010-replacer-driver-interface.md` (workflow-side ADR is `0014-resource-replacer-driver-interface.md` — landed in workflow v0.23.0).
**Workflow pin:** v0.23.0 (PR-1 JIT resolver #576 + PR-2 ResourceReplacer interface #577, both merged).

This is **PR-3 of 3**; PR-1 and PR-2 already merged into workflow v0.23.0.

## What changed

`DropletDriver.Replace` orchestrates a 4-phase replace:

1. **Read old**: `client.Get(oldID)`. On `ErrResourceNotFound` (404), treat old as already gone (skip detach + delete, proceed to create).
2. **Detach volumes**: `DetachByDropletID(volID, oldID)` per attached `VolumeID`, then `waitForActionComplete` (60s/2s bounds). Abort on timeout to preserve recoverable state — old Droplet and Volumes survive.
3. **Delete old**: `client.Delete(oldID)`.
4. **Create new**: `createWithResolvedVolumes(spec, detachedVolumeIDs)` — new helper that bypasses `resolveDropletVolumes` name-lookup when resolved IDs are passed, avoiding the same-name-in-region race.

### Tasks shipped (in plan order: 13 → 14 → 15 → 19 → 16 → 17 → 20 → 18)

| Task | Description |
|------|-------------|
| 13 | Bump `go.mod`: workflow v0.22.5 → v0.23.0 (ResourceReplacer + JIT resolver) |
| 14 | `ActionsClient` interface + `storageActions`/`actions` driver fields + variadic constructor (typed-nil safe) |
| 15 | `waitForActionComplete` + `createWithResolvedVolumes` helpers |
| 19 | Recording test fakes: `recordingDropletsClient`, `recordingStorageActionsClient`, `recordingActionsClient` |
| 16 | `DropletDriver.Replace` 4-phase orchestration + `SetReplaceTimeoutsForTest` seam + `var _ ResourceReplacer = ...` |
| 17 | Build-tagged `integration` test: TC2 sequenced-mock replay |
| 20 | TC2-equivalent fixture + launch-validation transcript |
| 18 | CHANGELOG |

## Test plan

- [x] **Unit (`TestDropletDriver_Replace_*`)**: 6 cases — happy path 2-volume detach, 404 old skip, no-volumes no-detach, timeout-preserves-state, no-storage-actions error, name-resolution-bypass
- [x] **Helper unit (`TestWaitForActionComplete_*`)**: 4 cases — quick-completion, errored-status, ctx-cancel, timeout-boundary
- [x] **Integration**: `TestReplaceTC2ScenarioReplay` (sequenced godo mock, build tag `integration`)
- [x] **Typed-nil safety**: `TestNewDropletDriverWithClient_TypedNilSafe`
- [x] **Launch-validation**: TC2-equivalent fixture transcript at `docs/runtime-validation/2026-05-07-tc2-equivalent-launch.log` (plugin builds, loads via wfctl, plan invocation succeeds)
- [x] `go test ./...` clean (default + `-race`)
- [x] `go test -tags=integration ./internal/drivers/` clean
- [x] `go vet ./...` clean

## Operator notes

After a partial Replace failure (e.g., detach action timed out), retry with
`wfctl infra apply --refresh-outputs` to refresh state from cloud truth before
the next plan. Without refresh, persisted state may still claim the Volume is
attached and the next apply will be a no-op.

## structpb boundary

Per `feedback_workflow_plugin_structpb_boundary`: this PR adds **no new typed
slices to driver `Outputs` or dispatch args**. The `DropletCreateVolume` IDs
flow through `req.Volumes` (a typed Go slice on the godo SDK side, never
serialized through structpb at the gRPC plugin boundary). The only new
public-API surface is the `Replace(ctx, oldRef, spec) (*ResourceOutput, error)`
signature on `DropletDriver`, which uses existing `interfaces.ResourceRef` /
`interfaces.ResourceSpec` types already round-trip-tested upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>