### PR TITLE
feat: AppPlatform DOCR image-presence pre-flight (Plan + Apply)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to workflow-plugin-digitalocean are documented here.
 
+## v0.12.0 — 2026-05-08
+
+- **feat(drivers/app_platform)**: image-presence pre-flight for DOCR-typed images. `Diff`, `Create`, and `Update` now call `verifyImagePresentInDOCR(ctx, regClient, imageRef)` before mutating the AppSpec. On absence, returns wrapping `interfaces.ErrImageNotInRegistry`. Conservative behavior: any DOCR API error (rate-limit, 5xx, parse failure) returns nil so the underlying `apps.update` surfaces the real issue.
+- **chore(deps)**: bump workflow to v0.24.0; bump godo to v1.189.0.
+
 ## [Unreleased]
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.23.0
+	github.com/GoCodeAlone/workflow v0.24.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
-	github.com/digitalocean/godo v1.178.0
+	github.com/digitalocean/godo v1.189.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.23.0 h1:/n6RF4PbDpChJLt/b/2tJmf3C8YFlqnYaOncrHYMLR4=
-github.com/GoCodeAlone/workflow v0.23.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.24.0 h1:cpFnk/K/huyoywNGTNmTayhT/yqFWWi7rO2cEqRLOBE=
+github.com/GoCodeAlone/workflow v0.24.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
@@ -201,8 +201,8 @@ github.com/deckarep/golang-set/v2 v2.9.0 h1:prva4eP9UysWagLyKrtn074ughi0NnkIf0A4
 github.com/deckarep/golang-set/v2 v2.9.0/go.mod h1:EWknQXbs0mcFpat2QOoXV0Ee57cD+w6ZEN76BR2JVrM=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/digitalocean/godo v1.178.0 h1:+B4xGOaoFwwwpM7TKhoyGHdmFg5eF9zDB1YfOLvNJ2E=
-github.com/digitalocean/godo v1.178.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
+github.com/digitalocean/godo v1.189.0 h1:93hHWsZdbJdkMsfZ21lMkOmd+BPMCTzu/+FIJ5FvAL4=
+github.com/digitalocean/godo v1.189.0/go.mod h1:xQsWpVCCbkDrWisHA72hPzPlnC+4W5w/McZY5ij9uvU=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -49,21 +49,36 @@ type appPlatformMigrationRepairClient interface {
 
 // AppPlatformDriver manages DigitalOcean App Platform (infra.container_service).
 type AppPlatformDriver struct {
-	client AppPlatformClient
-	region string
+	client    AppPlatformClient
+	regClient RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
+	region    string
 }
 
 // NewAppPlatformDriver creates an AppPlatformDriver backed by a real godo client.
 func NewAppPlatformDriver(c *godo.Client, region string) *AppPlatformDriver {
-	return &AppPlatformDriver{client: c.Apps, region: region}
+	return &AppPlatformDriver{client: c.Apps, regClient: c.Registry, region: region}
 }
 
-// NewAppPlatformDriverWithClient creates a driver with an injected client (for tests).
+// NewAppPlatformDriverWithClient creates a driver with an injected apps client (for tests).
+// regClient is nil; image-presence check is skipped.
 func NewAppPlatformDriverWithClient(c AppPlatformClient, region string) *AppPlatformDriver {
 	return &AppPlatformDriver{client: c, region: region}
 }
 
+// NewAppPlatformDriverWithClients creates a driver with both clients injected (for tests).
+func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, region string) *AppPlatformDriver {
+	return &AppPlatformDriver{client: c, regClient: r, region: region}
+}
+
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if d.regClient != nil {
+		if img, _ := spec.Config["image"].(string); img != "" {
+			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	region, _ := spec.Config["region"].(string)
 	if region == "" {
 		region = d.region
@@ -123,6 +138,14 @@ func (d *AppPlatformDriver) findAppByName(ctx context.Context, name string) (*in
 }
 
 func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if d.regClient != nil {
+		if img, _ := spec.Config["image"].(string); img != "" {
+			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	providerID, err := d.resolveProviderID(ctx, ref)
 	if err != nil {
 		return nil, err
@@ -174,7 +197,15 @@ func (d *AppPlatformDriver) resolveProviderID(ctx context.Context, ref interface
 	return out.ProviderID, nil
 }
 
-func (d *AppPlatformDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	if d.regClient != nil {
+		if img, _ := desired.Config["image"].(string); img != "" {
+			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if current == nil {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -72,10 +72,8 @@ func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, regi
 
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	if d.regClient != nil {
-		if img, _ := spec.Config["image"].(string); img != "" {
-			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
-				return nil, err
-			}
+		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, spec.Config); err != nil {
+			return nil, err
 		}
 	}
 
@@ -139,10 +137,8 @@ func (d *AppPlatformDriver) findAppByName(ctx context.Context, name string) (*in
 
 func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	if d.regClient != nil {
-		if img, _ := spec.Config["image"].(string); img != "" {
-			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
-				return nil, err
-			}
+		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, spec.Config); err != nil {
+			return nil, err
 		}
 	}
 
@@ -199,10 +195,8 @@ func (d *AppPlatformDriver) resolveProviderID(ctx context.Context, ref interface
 
 func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
 	if d.regClient != nil {
-		if img, _ := desired.Config["image"].(string); img != "" {
-			if err := verifyImagePresentInDOCR(ctx, d.regClient, img); err != nil {
-				return nil, err
-			}
+		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, desired.Config); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/drivers/app_platform_image_presence.go
+++ b/internal/drivers/app_platform_image_presence.go
@@ -1,0 +1,63 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// verifyImagePresentInDOCR is a conservative pre-flight that returns an
+// interfaces.ErrImageNotInRegistry-wrapping error when imageRef is a DOCR
+// reference whose tag is absent from the registry. For non-DOCR refs,
+// unparseable refs, or DOCR API errors, it returns nil — the apply path
+// will surface any real issue via godo apps.update's own error.
+//
+// The conservative behavior is intentional: false-negatives (mistakenly
+// flagging a present image as missing) would block valid deploys; better
+// to let the real apply error surface.
+func verifyImagePresentInDOCR(ctx context.Context, regClient RegistryClient, imageRef string) error {
+	// ParseImageRef handles the DOCR convention: for
+	// "registry.digitalocean.com/<reg>/<repo>:<tag>" the middle path segment
+	// (registry name) is discarded and spec.Repository is the FINAL path
+	// segment (e.g. "core-dump-server"), which is exactly what
+	// RegistryService.ListRepositoryTags expects as its repository arg.
+	// Registry name is fetched separately via RegistryService.Get below.
+	spec, err := ParseImageRef(imageRef)
+	if err != nil || spec == nil {
+		return nil // unparseable: skip
+	}
+	if spec.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
+		return nil // only DOCR is checked
+	}
+	reg, _, err := regClient.Get(ctx)
+	if err != nil || reg == nil || reg.Name == "" {
+		return nil // conservative: API failure -> let apply surface it
+	}
+	// Paginate through tag list. DOCR returns at most ~200 tags per page.
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		tags, resp, err := regClient.ListRepositoryTags(ctx, reg.Name, spec.Repository, opts)
+		if err != nil {
+			return nil // conservative
+		}
+		for _, t := range tags {
+			if t != nil && t.Tag == spec.Tag {
+				return nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+		if opts.Page > 10 {
+			// Safety cap: 10 pages * 200/page = 2k tags. Beyond this, fail-open
+			// (any real DOCR repo holds far fewer; cap protects against an
+			// accidentally infinite loop from a misbehaving Links header).
+			return nil
+		}
+	}
+	return fmt.Errorf("image %q not found in DOCR repo %q: %w",
+		imageRef, spec.Repository, interfaces.ErrImageNotInRegistry)
+}

--- a/internal/drivers/app_platform_image_presence.go
+++ b/internal/drivers/app_platform_image_presence.go
@@ -28,6 +28,26 @@ func verifyImagePresentInDOCR(ctx context.Context, regClient RegistryClient, ima
 	if err != nil || spec == nil {
 		return nil // unparseable: skip
 	}
+	return verifyImageSpecPresentInDOCR(ctx, regClient, spec, imageRef)
+}
+
+// verifyImageConfigPresentInDOCR accepts spec.Config and checks image presence
+// for both string and map[string]any image config forms. This covers the full
+// config surface that imageSpecFromConfig handles (see app_platform_buildspec.go).
+// Returns nil for non-DOCR images, config parse errors, and DOCR API errors
+// (conservative / fail-open).
+func verifyImageConfigPresentInDOCR(ctx context.Context, regClient RegistryClient, cfg map[string]any) error {
+	spec, err := imageSpecFromConfig(cfg)
+	if err != nil || spec == nil {
+		return nil // no parseable image config: skip
+	}
+	return verifyImageSpecPresentInDOCR(ctx, regClient, spec, "")
+}
+
+// verifyImageSpecPresentInDOCR performs the actual DOCR tag-list lookup for a
+// pre-parsed godo.ImageSourceSpec. imageRef is used only for the error message
+// (pass "" when imageRef is unavailable; the repo+tag context is still surfaced).
+func verifyImageSpecPresentInDOCR(ctx context.Context, regClient RegistryClient, spec *godo.ImageSourceSpec, imageRef string) error {
 	if spec.RegistryType != godo.ImageSourceSpecRegistryType_DOCR {
 		return nil // only DOCR is checked
 	}
@@ -58,6 +78,10 @@ func verifyImagePresentInDOCR(ctx context.Context, regClient RegistryClient, ima
 			return nil
 		}
 	}
+	label := imageRef
+	if label == "" {
+		label = fmt.Sprintf("%s:%s", spec.Repository, spec.Tag)
+	}
 	return fmt.Errorf("image %q not found in DOCR repo %q: %w",
-		imageRef, spec.Repository, interfaces.ErrImageNotInRegistry)
+		label, spec.Repository, interfaces.ErrImageNotInRegistry)
 }

--- a/internal/drivers/app_platform_image_presence_test.go
+++ b/internal/drivers/app_platform_image_presence_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/digitalocean/godo"
 )
 
+// internalMockAppClient is a minimal AppPlatformClient for image-presence wiring tests.
+// It is intentionally minimal — only Create and Update are called by the image-presence
+// path; the other methods are no-ops that return empty results.
+type internalMockAppClient struct {
+	app    *godo.App
+	appErr error
+	listApps []*godo.App
+}
+
+func (m *internalMockAppClient) Create(_ context.Context, _ *godo.AppCreateRequest) (*godo.App, *godo.Response, error) {
+	return m.app, nil, m.appErr
+}
+func (m *internalMockAppClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return m.app, nil, m.appErr
+}
+func (m *internalMockAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return m.listApps, &godo.Response{}, nil
+}
+func (m *internalMockAppClient) Update(_ context.Context, _ string, _ *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	return m.app, nil, m.appErr
+}
+func (m *internalMockAppClient) CreateDeployment(_ context.Context, _ string, _ ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
+	return nil, nil, nil
+}
+func (m *internalMockAppClient) ListDeployments(_ context.Context, _ string, _ *godo.ListOptions) ([]*godo.Deployment, *godo.Response, error) {
+	return nil, &godo.Response{}, nil
+}
+func (m *internalMockAppClient) Delete(_ context.Context, _ string) (*godo.Response, error) {
+	return nil, nil
+}
+func (m *internalMockAppClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return nil, nil, nil
+}
+
 // internalMockRegistryClient is a package-internal mock used for testing
 // verifyImagePresentInDOCR and the AppPlatformDriver image-presence wiring.
 // (The registry_test.go mock lives in package drivers_test and is not
@@ -103,5 +137,117 @@ func TestVerifyImagePresentInDOCR_ParseFailure_ReturnsNil(t *testing.T) {
 	err := verifyImagePresentInDOCR(context.Background(), mock, "garbage::not-a-ref")
 	if err != nil {
 		t.Fatalf("unparseable ref must skip presence check; got %v", err)
+	}
+}
+
+// --- AppPlatformDriver wiring tests ---
+
+func TestAppPlatformDriver_Diff_RejectsAbsentDOCRImage(t *testing.T) {
+	appsMock := &internalMockAppClient{}
+	regMock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{"core-dump-server": {{Tag: "old"}}},
+	}
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+
+	desired := interfaces.ResourceSpec{
+		Type: "infra.container_service",
+		Name: "test-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/coredump-registry/core-dump-server:newgone",
+		},
+	}
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{"image": "registry.digitalocean.com/coredump-registry/core-dump-server:old"},
+	}
+	_, err := d.Diff(context.Background(), desired, current)
+	if err == nil || !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("expected ErrImageNotInRegistry; got %v", err)
+	}
+}
+
+func TestAppPlatformDriver_Diff_AcceptsPresentDOCRImage(t *testing.T) {
+	appsMock := &internalMockAppClient{}
+	regMock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{"core-dump-server": {{Tag: "newpresent"}}},
+	}
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+
+	desired := interfaces.ResourceSpec{
+		Type: "infra.container_service",
+		Name: "test-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/coredump-registry/core-dump-server:newpresent",
+		},
+	}
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{"image": "registry.digitalocean.com/coredump-registry/core-dump-server:old"},
+	}
+	diff, err := d.Diff(context.Background(), desired, current)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if diff == nil || !diff.NeedsUpdate {
+		t.Fatalf("expected NeedsUpdate=true; got %#v", diff)
+	}
+}
+
+func TestAppPlatformDriver_Diff_SkipsNonDOCRImage(t *testing.T) {
+	appsMock := &internalMockAppClient{}
+	regMock := &internalMockRegistryClient{} // no tags configured; presence check would fail if invoked
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+
+	desired := interfaces.ResourceSpec{
+		Type: "infra.container_service", Name: "x",
+		Config: map[string]any{"image": "ghcr.io/gocodealone/core-dump-server:abc"},
+	}
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{"image": "ghcr.io/gocodealone/core-dump-server:old"},
+	}
+	_, err := d.Diff(context.Background(), desired, current)
+	if err != nil {
+		t.Fatalf("non-DOCR images must not invoke presence check: %v", err)
+	}
+}
+
+func TestAppPlatformDriver_Create_RejectsAbsentDOCRImage(t *testing.T) {
+	appsMock := &internalMockAppClient{}
+	regMock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{"core-dump-server": {}},
+	}
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+	spec := interfaces.ResourceSpec{
+		Type: "infra.container_service", Name: "test-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/coredump-registry/core-dump-server:gone",
+		},
+	}
+	_, err := d.Create(context.Background(), spec)
+	if !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("Create must reject absent DOCR image; got %v", err)
+	}
+}
+
+func TestAppPlatformDriver_Update_RejectsAbsentDOCRImage(t *testing.T) {
+	appsMock := &internalMockAppClient{
+		app: &godo.App{ID: "app-uuid-123"},
+	}
+	regMock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{"core-dump-server": {}},
+	}
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+	spec := interfaces.ResourceSpec{
+		Type: "infra.container_service", Name: "test-app",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/coredump-registry/core-dump-server:gone",
+		},
+	}
+	ref := interfaces.ResourceRef{Name: "test-app", ProviderID: "app-uuid-123"}
+	_, err := d.Update(context.Background(), ref, spec)
+	if !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("Update must reject absent DOCR image; got %v", err)
 	}
 }

--- a/internal/drivers/app_platform_image_presence_test.go
+++ b/internal/drivers/app_platform_image_presence_test.go
@@ -14,8 +14,8 @@ import (
 // It is intentionally minimal — only Create and Update are called by the image-presence
 // path; the other methods are no-ops that return empty results.
 type internalMockAppClient struct {
-	app    *godo.App
-	appErr error
+	app      *godo.App
+	appErr   error
 	listApps []*godo.App
 }
 
@@ -73,7 +73,7 @@ func (m *internalMockRegistryClient) ListRepositoryTags(_ context.Context, _ str
 
 func TestVerifyImagePresentInDOCR_PresentTag(t *testing.T) {
 	mock := &internalMockRegistryClient{
-		reg:  &godo.Registry{Name: "coredump-registry"},
+		reg: &godo.Registry{Name: "coredump-registry"},
 		tags: map[string][]*godo.RepositoryTag{
 			"core-dump-server": {{Tag: "abc123"}, {Tag: "def456"}},
 		},
@@ -87,7 +87,7 @@ func TestVerifyImagePresentInDOCR_PresentTag(t *testing.T) {
 
 func TestVerifyImagePresentInDOCR_AbsentTag(t *testing.T) {
 	mock := &internalMockRegistryClient{
-		reg:  &godo.Registry{Name: "coredump-registry"},
+		reg: &godo.Registry{Name: "coredump-registry"},
 		tags: map[string][]*godo.RepositoryTag{
 			"core-dump-server": {{Tag: "def456"}},
 		},

--- a/internal/drivers/app_platform_image_presence_test.go
+++ b/internal/drivers/app_platform_image_presence_test.go
@@ -251,3 +251,31 @@ func TestAppPlatformDriver_Update_RejectsAbsentDOCRImage(t *testing.T) {
 		t.Fatalf("Update must reject absent DOCR image; got %v", err)
 	}
 }
+
+// TestAppPlatformDriver_Diff_MapFormImageConfig verifies that structured image
+// config (map[string]any) is also checked by the image-presence pre-flight.
+// This covers the Copilot finding that only string-form images were checked.
+func TestAppPlatformDriver_Diff_MapFormImageConfig_RejectsAbsent(t *testing.T) {
+	appsMock := &internalMockAppClient{}
+	regMock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{"core-dump-server": {}}, // empty: all tags absent
+	}
+	d := NewAppPlatformDriverWithClients(appsMock, regMock, "nyc3")
+
+	desired := interfaces.ResourceSpec{
+		Type: "infra.container_service", Name: "test-app",
+		Config: map[string]any{
+			"image": map[string]any{
+				"registry_type": "DOCR",
+				"repository":    "core-dump-server",
+				"tag":           "gone",
+			},
+		},
+	}
+	current := &interfaces.ResourceOutput{Outputs: map[string]any{}}
+	_, err := d.Diff(context.Background(), desired, current)
+	if !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("Diff must reject absent DOCR image in map-form config; got %v", err)
+	}
+}

--- a/internal/drivers/app_platform_image_presence_test.go
+++ b/internal/drivers/app_platform_image_presence_test.go
@@ -1,0 +1,107 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// internalMockRegistryClient is a package-internal mock used for testing
+// verifyImagePresentInDOCR and the AppPlatformDriver image-presence wiring.
+// (The registry_test.go mock lives in package drivers_test and is not
+// accessible here.)
+type internalMockRegistryClient struct {
+	reg     *godo.Registry
+	err     error
+	tags    map[string][]*godo.RepositoryTag
+	tagsErr error
+}
+
+func (m *internalMockRegistryClient) Create(_ context.Context, _ *godo.RegistryCreateRequest) (*godo.Registry, *godo.Response, error) {
+	return m.reg, nil, m.err
+}
+func (m *internalMockRegistryClient) Get(_ context.Context) (*godo.Registry, *godo.Response, error) {
+	return m.reg, nil, m.err
+}
+func (m *internalMockRegistryClient) Delete(_ context.Context) (*godo.Response, error) {
+	return nil, m.err
+}
+func (m *internalMockRegistryClient) ListRepositoryTags(_ context.Context, _ string, repo string, _ *godo.ListOptions) ([]*godo.RepositoryTag, *godo.Response, error) {
+	if m.tagsErr != nil {
+		return nil, nil, m.tagsErr
+	}
+	return m.tags[repo], &godo.Response{}, nil
+}
+
+func TestVerifyImagePresentInDOCR_PresentTag(t *testing.T) {
+	mock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{
+			"core-dump-server": {{Tag: "abc123"}, {Tag: "def456"}},
+		},
+	}
+	err := verifyImagePresentInDOCR(context.Background(), mock,
+		"registry.digitalocean.com/coredump-registry/core-dump-server:abc123")
+	if err != nil {
+		t.Fatalf("expected nil; got %v", err)
+	}
+}
+
+func TestVerifyImagePresentInDOCR_AbsentTag(t *testing.T) {
+	mock := &internalMockRegistryClient{
+		reg:  &godo.Registry{Name: "coredump-registry"},
+		tags: map[string][]*godo.RepositoryTag{
+			"core-dump-server": {{Tag: "def456"}},
+		},
+	}
+	err := verifyImagePresentInDOCR(context.Background(), mock,
+		"registry.digitalocean.com/coredump-registry/core-dump-server:abc123")
+	if err == nil {
+		t.Fatalf("expected ErrImageNotInRegistry; got nil")
+	}
+	if !errors.Is(err, interfaces.ErrImageNotInRegistry) {
+		t.Fatalf("expected wrap of ErrImageNotInRegistry; got %v", err)
+	}
+}
+
+func TestVerifyImagePresentInDOCR_NonDOCRImage_ReturnsNil(t *testing.T) {
+	mock := &internalMockRegistryClient{} // intentionally empty; should never be called
+	err := verifyImagePresentInDOCR(context.Background(), mock,
+		"ghcr.io/gocodealone/core-dump-server:abc123")
+	if err != nil {
+		t.Fatalf("non-DOCR images must skip presence check; got %v", err)
+	}
+}
+
+func TestVerifyImagePresentInDOCR_RegistryGetError_ReturnsNil(t *testing.T) {
+	mock := &internalMockRegistryClient{err: fmt.Errorf("rate limited")}
+	err := verifyImagePresentInDOCR(context.Background(), mock,
+		"registry.digitalocean.com/coredump-registry/core-dump-server:abc123")
+	if err != nil {
+		t.Fatalf("conservative behavior: registry-get error must NOT block apply; got %v", err)
+	}
+}
+
+func TestVerifyImagePresentInDOCR_ListTagsError_ReturnsNil(t *testing.T) {
+	mock := &internalMockRegistryClient{
+		reg:     &godo.Registry{Name: "coredump-registry"},
+		tagsErr: fmt.Errorf("list-tags 502"),
+	}
+	err := verifyImagePresentInDOCR(context.Background(), mock,
+		"registry.digitalocean.com/coredump-registry/core-dump-server:abc123")
+	if err != nil {
+		t.Fatalf("conservative behavior: list-tags error must NOT block apply; got %v", err)
+	}
+}
+
+func TestVerifyImagePresentInDOCR_ParseFailure_ReturnsNil(t *testing.T) {
+	mock := &internalMockRegistryClient{}
+	err := verifyImagePresentInDOCR(context.Background(), mock, "garbage::not-a-ref")
+	if err != nil {
+		t.Fatalf("unparseable ref must skip presence check; got %v", err)
+	}
+}

--- a/internal/drivers/registry.go
+++ b/internal/drivers/registry.go
@@ -134,4 +134,6 @@ func registryOutput(reg *godo.Registry, name string) *interfaces.ResourceOutput 
 
 func (d *RegistryDriver) SensitiveKeys() []string { return nil }
 
-func (d *RegistryDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatFreeform }
+func (d *RegistryDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatFreeform
+}

--- a/internal/drivers/registry.go
+++ b/internal/drivers/registry.go
@@ -13,6 +13,9 @@ type RegistryClient interface {
 	Create(ctx context.Context, req *godo.RegistryCreateRequest) (*godo.Registry, *godo.Response, error)
 	Get(ctx context.Context) (*godo.Registry, *godo.Response, error)
 	Delete(ctx context.Context) (*godo.Response, error)
+	// ListRepositoryTags lists tags for a repository under the named registry.
+	// Used by AppPlatformDriver image-presence pre-flight.
+	ListRepositoryTags(ctx context.Context, registry, repository string, opts *godo.ListOptions) ([]*godo.RepositoryTag, *godo.Response, error)
 }
 
 // RegistryDriver manages the DigitalOcean Container Registry (infra.registry).

--- a/internal/drivers/registry_test.go
+++ b/internal/drivers/registry_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 type mockRegistryClient struct {
-	reg *godo.Registry
-	err error
+	reg     *godo.Registry
+	err     error
+	// tags maps repository name -> tag list; used by ListRepositoryTags.
+	tags    map[string][]*godo.RepositoryTag
+	tagsErr error
 }
 
 func (m *mockRegistryClient) Create(_ context.Context, _ *godo.RegistryCreateRequest) (*godo.Registry, *godo.Response, error) {
@@ -23,6 +26,12 @@ func (m *mockRegistryClient) Get(_ context.Context) (*godo.Registry, *godo.Respo
 }
 func (m *mockRegistryClient) Delete(_ context.Context) (*godo.Response, error) {
 	return nil, m.err
+}
+func (m *mockRegistryClient) ListRepositoryTags(_ context.Context, _ string, repo string, _ *godo.ListOptions) ([]*godo.RepositoryTag, *godo.Response, error) {
+	if m.tagsErr != nil {
+		return nil, nil, m.tagsErr
+	}
+	return m.tags[repo], &godo.Response{}, nil
 }
 
 func testRegistry() *godo.Registry {
@@ -163,5 +172,22 @@ func TestRegistryDriver_HealthCheck_Unhealthy(t *testing.T) {
 	}
 	if result.Healthy {
 		t.Errorf("expected unhealthy when get fails")
+	}
+}
+
+// TestMockRegistryClient_ListRepositoryTags verifies the mock correctly
+// returns canned tags for the image-presence pre-flight tests.
+func TestMockRegistryClient_ListRepositoryTags(t *testing.T) {
+	mock := &mockRegistryClient{
+		tags: map[string][]*godo.RepositoryTag{
+			"core-dump-server": {{Tag: "abc123"}, {Tag: "def456"}},
+		},
+	}
+	tags, _, err := mock.ListRepositoryTags(context.Background(), "coredump-registry", "core-dump-server", nil)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if len(tags) != 2 || tags[0].Tag != "abc123" {
+		t.Fatalf("unexpected tags: %#v", tags)
 	}
 }

--- a/internal/drivers/registry_test.go
+++ b/internal/drivers/registry_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 type mockRegistryClient struct {
-	reg     *godo.Registry
-	err     error
+	reg *godo.Registry
+	err error
 	// tags maps repository name -> tag list; used by ListRepositoryTags.
 	tags    map[string][]*godo.RepositoryTag
 	tagsErr error

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.10.0",
+  "version": "0.12.0",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
@@ -14,22 +14,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.10.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.10.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.10.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.10.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ],
   "iacProvider": {


### PR DESCRIPTION
## Summary
- AppPlatformDriver.Diff / Create / Update call verifyImagePresentInDOCR before mutating AppSpec; reject with wrapping interfaces.ErrImageNotInRegistry when the DOCR-typed image SHA is not present.
- Conservative on API errors (rate-limit, 5xx) — falls through to apply so the real error surfaces.
- Non-DOCR images (GHCR / DockerHub / etc.) are unaffected.
- Bumps workflow to v0.24.0 + godo to v1.189.0.

Wave 1 of DOCR retention + image-presence design.

## Test plan
- [x] go test ./internal/drivers/ -run TestVerifyImagePresentInDOCR — 6 cases (present, absent, non-DOCR, registry-error, list-error, parse-fail)
- [x] go test ./internal/drivers/ -run TestAppPlatformDriver_.*DOCRImage — 5 wiring cases (Diff present/absent/non-DOCR, Create absent, Update absent)
- [x] go test ./... — full repo no regressions
- [x] go vet ./... clean
- [x] go fmt ./... clean