### PR TITLE
fix(release): draft-first pattern to avoid immutability failure on retag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish release (was draft during asset upload)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit ${{ github.ref_name }} --draft=false --repo ${{ github.repository }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,3 +63,4 @@ release:
   github:
     owner: GoCodeAlone
     name: workflow-plugin-digitalocean
+  draft: true


### PR DESCRIPTION
## Summary

- `.goreleaser.yaml`: add `draft: true` to `release:` section so goreleaser creates the GitHub release as a draft while uploading assets
- `.github/workflows/release.yml`: add a final step after goreleaser completes that runs `gh release edit --draft=false` to publish the release

## Why

The `"target_commitish cannot be changed when release is immutable"` error occurs when goreleaser attempts to update an existing (already-published) release for a tag. By starting as a draft, goreleaser can safely create/update the release and upload assets without hitting the immutability gate. The separate publish step only fires after all uploads complete.

## Test plan
- [ ] Tag a new release (e.g. `v0.13.0`) and verify the release starts as draft, assets upload successfully, then the release becomes public
- [ ] Verify that a retry (if a build fails mid-way) does not hit the immutability error

🤖 Generated with [Claude Code](https://claude.com/claude-code)