### PR TITLE
feat(debug): WFCTL_DEBUG_API logging round-tripper for DigitalOcean API calls

### DIFF
--- a/internal/api_logger.go
+++ b/internal/api_logger.go
@@ -1,0 +1,96 @@
+package internal
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	// debugAPIBodyLimit caps the number of bytes logged from request/response
+	// bodies to keep output scannable even for large payloads.
+	debugAPIBodyLimit = 500
+
+	// EnvDebugAPI is the environment variable that enables API call logging.
+	// Set to any non-empty value (e.g. WFCTL_DEBUG_API=1) to activate.
+	EnvDebugAPI = "WFCTL_DEBUG_API"
+)
+
+// debugAPIEnabled returns true when WFCTL_DEBUG_API is set to a non-empty value.
+func debugAPIEnabled() bool {
+	return os.Getenv(EnvDebugAPI) != ""
+}
+
+// loggingRoundTripper wraps an http.RoundTripper and logs every request
+// and response to stderr. Request/response bodies are captured,
+// re-injected, and — for error responses (4xx/5xx) — included in the log
+// output truncated to debugAPIBodyLimit bytes.
+//
+// When WFCTL_DEBUG_API is set, the godo client's HTTP transport is wrapped
+// with this type so that every DigitalOcean API call is visible in the
+// operator's terminal. This is intentionally low-level: it shows the raw
+// HTTP method, URL, status code, and body excerpts, which is the most
+// actionable information when diagnosing unexpected DO API failures (e.g.
+// "404 Image tag or digest not found" from POST /v2/apps).
+type loggingRoundTripper struct {
+	base http.RoundTripper
+}
+
+// newLoggingRoundTripper wraps base with request/response logging.
+// If base is nil, http.DefaultTransport is used.
+func newLoggingRoundTripper(base http.RoundTripper) *loggingRoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &loggingRoundTripper{base: base}
+}
+
+// RoundTrip logs the outbound request and inbound response, then returns.
+// Errors from the underlying transport are logged and returned unmodified.
+func (l *loggingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var reqExcerpt string
+	if req.Body != nil && req.Body != http.NoBody {
+		body, err := io.ReadAll(req.Body)
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			reqExcerpt = truncate(string(body), debugAPIBodyLimit)
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "[WFCTL_DEBUG_API] → %s %s\n", req.Method, req.URL)
+	if reqExcerpt != "" {
+		fmt.Fprintf(os.Stderr, "[WFCTL_DEBUG_API]   req body: %s\n", reqExcerpt)
+	}
+
+	resp, err := l.base.RoundTrip(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[WFCTL_DEBUG_API] ✗ transport error: %v\n", err)
+		return nil, err
+	}
+
+	fmt.Fprintf(os.Stderr, "[WFCTL_DEBUG_API] ← %d %s\n", resp.StatusCode, req.URL)
+
+	// For error responses, capture and log the body excerpt.
+	if resp.StatusCode >= 400 {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr == nil {
+			resp.Body = io.NopCloser(bytes.NewReader(body))
+			fmt.Fprintf(os.Stderr, "[WFCTL_DEBUG_API]   resp body: %s\n", truncate(string(body), debugAPIBodyLimit))
+		}
+	}
+
+	return resp, nil
+}
+
+// truncate returns s truncated to n bytes. If s is longer than n, an
+// ellipsis suffix is appended to indicate truncation.
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/api_logger_test.go
+++ b/internal/api_logger_test.go
@@ -1,0 +1,62 @@
+package internal
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestLoggingRoundTripperSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	lrt := newLoggingRoundTripper(http.DefaultTransport)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	resp, err := lrt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}
+
+func TestLoggingRoundTripperErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"id":"not_found","message":"Image tag or digest not found"}`))
+	}))
+	defer srv.Close()
+
+	lrt := newLoggingRoundTripper(http.DefaultTransport)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader(`{"spec":{"name":"test-app"}}`))
+	resp, err := lrt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+	// body must still be readable after logging
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "not_found") {
+		t.Fatalf("response body not readable after logging: %q", body)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	long := strings.Repeat("a", 600)
+	result := truncate(long, debugAPIBodyLimit)
+	if len(result) > debugAPIBodyLimit+5 {
+		t.Fatalf("truncate returned too long string: len=%d", len(result))
+	}
+	if !strings.HasSuffix(result, "…") {
+		t.Fatalf("expected ellipsis suffix, got: %s", result[len(result)-3:])
+	}
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -81,6 +81,12 @@ func (p *DOProvider) Initialize(ctx context.Context, config map[string]any) erro
 	spacesSecretKey, _ := config["spaces_secret_key"].(string)
 
 	oauthClient := oauth2.NewClient(ctx, &tokenSource{token: token})
+	if debugAPIEnabled() {
+		// Wrap the transport so every DigitalOcean API call is logged to
+		// stderr. The oauth2 client owns the transport; we replace it with a
+		// loggingRoundTripper that delegates to the existing transport.
+		oauthClient.Transport = newLoggingRoundTripper(oauthClient.Transport)
+	}
 	p.client = godo.NewClient(oauthClient)
 
 	p.drivers = map[string]interfaces.ResourceDriver{


### PR DESCRIPTION
## Summary

- `internal/api_logger.go`: new `loggingRoundTripper` that wraps an `http.RoundTripper`; activated when `WFCTL_DEBUG_API` env var is non-empty
- `internal/provider.go`: wire the transport into `DOProvider.Initialize` — wraps the oauth2 client's transport before passing to `godo.NewClient`
- `internal/api_logger_test.go`: 3 tests (success path, error-response body preservation, truncation)

## What it logs

When `WFCTL_DEBUG_API=1`:
```
[WFCTL_DEBUG_API] → POST https://api.digitalocean.com/v2/apps
[WFCTL_DEBUG_API]   req body: {"spec":{"name":"core-dump","services":[{"name":"app","image":{"registry_type":"DOCR","repository":"core-dump","tag":"sha-abc1234"}}]}}
[WFCTL_DEBUG_API] ← 404 https://api.digitalocean.com/v2/apps
[WFCTL_DEBUG_API]   resp body: {"id":"not_found","message":"Image tag or digest not found"}
```

Request/response bodies are truncated to 500 chars to keep output scannable. Body is captured, re-injected, so the godo client continues to work normally.

## Test plan
- [ ] `GOWORK=off go test ./internal/... -run TestLogging` passes (3 tests)
- [ ] Set `WFCTL_DEBUG_API=1` during a `wfctl infra apply` run and confirm API calls appear in stderr
- [ ] Confirm no output when `WFCTL_DEBUG_API` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)