### PR TITLE
chore: bump workflow to v0.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.24.0
+	github.com/GoCodeAlone/workflow v0.25.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.24.0 h1:cpFnk/K/huyoywNGTNmTayhT/yqFWWi7rO2cEqRLOBE=
-github.com/GoCodeAlone/workflow v0.24.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.25.0 h1:m+Y+daZswMqUxzq64PBBGrLkoX4dwV1QcLS+jM97sCM=
+github.com/GoCodeAlone/workflow v0.25.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=


### PR DESCRIPTION
## Summary
Pre-release bump for v0.13.0 cut. Pulls in:
- IaC plan-time JIT resolver against state outputs (#576)
- ResourceReplacer optional driver hook + DefaultReplace export (#577)
- ErrImageNotInRegistry sentinel + wfctl render-side actionable hint (#579)
- Plan-time JIT resolver scoped to infra_output (ADR-0014, #578)
- Draft-first release pattern (#580)

## Test plan
- [x] go build ./... clean
- [x] go test ./... clean (all 5 packages green locally, 6.7s drivers + 2.2s internal)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)