### PR TITLE
feat(app): plan-time validation for App Platform region

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -71,6 +71,12 @@ func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, regi
 }
 
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if region, _ := spec.Config["region"].(string); region != "" {
+		if err := validateAppPlatformRegion(region); err != nil {
+			return nil, fmt.Errorf("app platform create %q: %w", spec.Name, err)
+		}
+	}
+
 	if d.regClient != nil {
 		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, spec.Config); err != nil {
 			return nil, err
@@ -136,6 +142,12 @@ func (d *AppPlatformDriver) findAppByName(ctx context.Context, name string) (*in
 }
 
 func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	if region, _ := spec.Config["region"].(string); region != "" {
+		if err := validateAppPlatformRegion(region); err != nil {
+			return nil, fmt.Errorf("app platform update %q: %w", spec.Name, err)
+		}
+	}
+
 	if d.regClient != nil {
 		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, spec.Config); err != nil {
 			return nil, err
@@ -194,6 +206,16 @@ func (d *AppPlatformDriver) resolveProviderID(ctx context.Context, ref interface
 }
 
 func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	// Plan-time region validation: surface invalid App Platform region slugs
+	// (e.g. Droplet datacenter "nyc1" used where regional "nyc" is required)
+	// here, BEFORE Apply forwards the request to the DO API and gets back a
+	// misleading "404 Image tag or digest not found".
+	if region, _ := desired.Config["region"].(string); region != "" {
+		if err := validateAppPlatformRegion(region); err != nil {
+			return nil, fmt.Errorf("app platform diff %q: %w", desired.Name, err)
+		}
+	}
+
 	if d.regClient != nil {
 		if err := verifyImageConfigPresentInDOCR(ctx, d.regClient, desired.Config); err != nil {
 			return nil, err

--- a/internal/drivers/app_platform_integration_test.go
+++ b/internal/drivers/app_platform_integration_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 // bmwSpec is a minimal valid ResourceSpec that mirrors BMW staging config.
+// Region uses the App Platform regional slug "nyc" (NOT the Droplet/VPC
+// datacenter slug "nyc3" — those are invalid for App Platform's AppSpec.Region
+// and now rejected at plan time by validateAppPlatformRegion).
 func bmwSpec(name string) interfaces.ResourceSpec {
 	return interfaces.ResourceSpec{
 		Name: name,
 		Type: "infra.app_platform",
 		Config: map[string]any{
-			"region": "nyc3",
+			"region": "nyc",
 			"image":  "docker.io/myorg/bmw:latest",
 		},
 	}

--- a/internal/drivers/app_platform_region.go
+++ b/internal/drivers/app_platform_region.go
@@ -1,0 +1,64 @@
+package drivers
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validAppPlatformRegions is the set of valid `region` slug values for an
+// App Platform AppSpec.Region (and equivalently spec.Config["region"] on
+// infra.container_service modules).
+//
+// IMPORTANT: App Platform uses REGIONAL slugs (e.g. "nyc", "sfo") — not the
+// Droplet/VPC DATACENTER slugs (e.g. "nyc1", "nyc3", "sfo3"). Sending a
+// datacenter slug to the App Platform API yields a misleading
+// "404 Image tag or digest not found" rather than a clear validation error,
+// so we surface a useful message at plan time.
+//
+// Source: https://docs.digitalocean.com/products/app-platform/details/limits/
+// (Available regions table). Slugs covered as of 2026-05.
+var validAppPlatformRegions = map[string]struct{}{
+	"ams": {}, // Amsterdam
+	"blr": {}, // Bangalore
+	"fra": {}, // Frankfurt
+	"lon": {}, // London
+	"nyc": {}, // New York
+	"sfo": {}, // San Francisco
+	"sgp": {}, // Singapore
+	"syd": {}, // Sydney
+	"tor": {}, // Toronto
+	"tlv": {}, // Tel Aviv
+}
+
+// validateAppPlatformRegion checks `region` against the set of valid App
+// Platform regional slugs. Empty input is permitted (caller falls back to
+// the driver default). Whitespace is trimmed; comparison is case-insensitive.
+//
+// On invalid input, the error message names every valid region and explicitly
+// calls out the datacenter-slug mistake (the most common one), so the operator
+// can fix their config without round-tripping the DO docs.
+func validateAppPlatformRegion(region string) error {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return nil
+	}
+	if _, ok := validAppPlatformRegions[strings.ToLower(region)]; ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"invalid App Platform region %q: must be one of %s "+
+			"(datacenter slugs like 'nyc1'/'nyc3'/'sfo3' are NOT valid for App Platform — those are Droplet/VPC slugs)",
+		region, sortedAppPlatformRegions())
+}
+
+// sortedAppPlatformRegions returns the valid region slugs as a deterministic
+// sorted slice for inclusion in error messages.
+func sortedAppPlatformRegions() []string {
+	out := make([]string, 0, len(validAppPlatformRegions))
+	for k := range validAppPlatformRegions {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/drivers/app_platform_region_test.go
+++ b/internal/drivers/app_platform_region_test.go
@@ -1,0 +1,92 @@
+package drivers
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateAppPlatformRegion_ValidSlugs verifies that every documented App
+// Platform regional slug passes validation. Mirrors the source-of-truth list
+// from DigitalOcean's App Platform regional limits page.
+func TestValidateAppPlatformRegion_ValidSlugs(t *testing.T) {
+	valid := []string{"ams", "blr", "fra", "lon", "nyc", "sfo", "sgp", "syd", "tor", "tlv"}
+	for _, r := range valid {
+		t.Run(r, func(t *testing.T) {
+			if err := validateAppPlatformRegion(r); err != nil {
+				t.Errorf("validateAppPlatformRegion(%q) returned error: %v", r, err)
+			}
+		})
+	}
+}
+
+// TestValidateAppPlatformRegion_ValidSlugs_CaseAndWhitespace confirms that
+// the validator normalises input — leading/trailing whitespace and uppercase
+// (e.g. yaml that quoted "NYC " or " sfo") still resolve cleanly.
+func TestValidateAppPlatformRegion_ValidSlugs_CaseAndWhitespace(t *testing.T) {
+	cases := []string{"NYC", "Sfo", "  fra  ", "AMS"}
+	for _, r := range cases {
+		t.Run(r, func(t *testing.T) {
+			if err := validateAppPlatformRegion(r); err != nil {
+				t.Errorf("validateAppPlatformRegion(%q) returned error: %v", r, err)
+			}
+		})
+	}
+}
+
+// TestValidateAppPlatformRegion_EmptyAccepted confirms that an empty region
+// passes (caller falls back to driver default; the driver default is itself
+// not validated because it can come from environment defaults the user did
+// not author).
+func TestValidateAppPlatformRegion_EmptyAccepted(t *testing.T) {
+	if err := validateAppPlatformRegion(""); err != nil {
+		t.Errorf("validateAppPlatformRegion(\"\") should accept empty: %v", err)
+	}
+	if err := validateAppPlatformRegion("   "); err != nil {
+		t.Errorf("validateAppPlatformRegion(whitespace) should accept whitespace: %v", err)
+	}
+}
+
+// TestValidateAppPlatformRegion_DatacenterSlugRejected covers the user-facing
+// bug: passing a Droplet/VPC datacenter slug (nyc1, nyc3, sfo3, ams3, fra1)
+// must fail at plan time with a clear message rather than silently forwarding
+// to the DO API and surfacing as "404 Image tag or digest not found".
+func TestValidateAppPlatformRegion_DatacenterSlugRejected(t *testing.T) {
+	bad := []string{"nyc1", "nyc3", "sfo2", "sfo3", "ams3", "fra1", "lon1", "sgp1", "tor1", "blr1", "syd1"}
+	for _, r := range bad {
+		t.Run(r, func(t *testing.T) {
+			err := validateAppPlatformRegion(r)
+			if err == nil {
+				t.Fatalf("validateAppPlatformRegion(%q): expected error, got nil", r)
+			}
+			msg := err.Error()
+			// Must name the offending slug.
+			if !strings.Contains(msg, r) {
+				t.Errorf("error message must include %q: %s", r, msg)
+			}
+			// Must enumerate valid regions so the operator can self-correct.
+			for _, want := range []string{"ams", "blr", "fra", "lon", "nyc", "sfo", "sgp", "syd", "tor", "tlv"} {
+				if !strings.Contains(msg, want) {
+					t.Errorf("error message must include valid region %q: %s", want, msg)
+				}
+			}
+			// Must call out the datacenter-slug confusion (the actual bug).
+			if !strings.Contains(strings.ToLower(msg), "datacenter") {
+				t.Errorf("error message must explain that datacenter slugs are invalid for App Platform: %s", msg)
+			}
+		})
+	}
+}
+
+// TestValidateAppPlatformRegion_GarbageRejected covers non-DO inputs (e.g.
+// AWS region copied by mistake, typos, empty-with-letters).
+func TestValidateAppPlatformRegion_GarbageRejected(t *testing.T) {
+	bad := []string{"us-east-1", "europe-west2", "newyork", "nycc", "x"}
+	for _, r := range bad {
+		t.Run(r, func(t *testing.T) {
+			if err := validateAppPlatformRegion(r); err == nil {
+				t.Fatalf("validateAppPlatformRegion(%q): expected error, got nil", r)
+			}
+		})
+	}
+}
+

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -375,20 +375,24 @@ func TestAppPlatformDriver_Diff_NoChanges(t *testing.T) {
 // App Platform region is a Create-only field on godo.AppSpec — UpdateApp
 // does not accept region changes. Region drift must surface as ForceNew so
 // dependents (vpc_ref to a region-locked VPC) get correctly recreated too.
+//
+// Region values use App Platform regional slugs ("nyc", "sfo") rather than
+// Droplet/VPC datacenter slugs ("nyc1", "nyc3", "sfo3"); the latter now fail
+// validateAppPlatformRegion at plan-time.
 func TestAppPlatformDriver_Diff_RegionChangeForcesReplace(t *testing.T) {
 	mock := &mockAppClient{}
-	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
 
 	current := &interfaces.ResourceOutput{
 		Outputs: map[string]any{
 			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
-			"region": "nyc3",
+			"region": "nyc",
 		},
 	}
 	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
 		Config: map[string]any{
 			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
-			"region": "nyc1",
+			"region": "sfo",
 		},
 	}, current)
 	if err != nil {
@@ -399,13 +403,13 @@ func TestAppPlatformDriver_Diff_RegionChangeForcesReplace(t *testing.T) {
 	}
 	var found bool
 	for _, c := range result.Changes {
-		if c.Path == "region" && c.Old == "nyc3" && c.New == "nyc1" && c.ForceNew {
+		if c.Path == "region" && c.Old == "nyc" && c.New == "sfo" && c.ForceNew {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected FieldChange{Path:region, Old:nyc3, New:nyc1, ForceNew:true}; got %+v", result.Changes)
+		t.Errorf("expected FieldChange{Path:region, Old:nyc, New:sfo, ForceNew:true}; got %+v", result.Changes)
 	}
 }
 
@@ -415,7 +419,7 @@ func TestAppPlatformDriver_Diff_RegionChangeForcesReplace(t *testing.T) {
 // plan after upgrade — they'll Read on next apply to populate the field.
 func TestAppPlatformDriver_Diff_RegionEmptyCurrentSkipped(t *testing.T) {
 	mock := &mockAppClient{}
-	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
 
 	current := &interfaces.ResourceOutput{
 		Outputs: map[string]any{
@@ -426,7 +430,7 @@ func TestAppPlatformDriver_Diff_RegionEmptyCurrentSkipped(t *testing.T) {
 	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
 		Config: map[string]any{
 			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
-			"region": "nyc1",
+			"region": "sfo",
 		},
 	}, current)
 	if err != nil {
@@ -1818,5 +1822,79 @@ func TestAppHealthResult_AllSlotsNilListDeploymentsError(t *testing.T) {
 	}
 	if !strings.Contains(result.Message, "no deployment found") {
 		t.Errorf("Message = %q, want 'no deployment found'", result.Message)
+	}
+}
+
+// TestAppPlatformDriver_Diff_RejectsInvalidRegionAtPlanTime confirms the
+// validator is wired into Diff() so an invalid App Platform region surfaces
+// during plan (NOT apply). User-facing fix for the "App platform 'nyc1'"
+// case where the DO API returns a misleading "404 Image tag or digest not
+// found" instead of an actionable validation error.
+func TestAppPlatformDriver_Diff_RejectsInvalidRegionAtPlanTime(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "my-app",
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc1", // datacenter slug — invalid for App Platform
+		},
+	}, nil)
+	if err == nil {
+		t.Fatal("Diff with invalid App Platform region must error at plan time")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "nyc1") {
+		t.Errorf("error must name the offending region: %s", msg)
+	}
+	if !strings.Contains(msg, "my-app") {
+		t.Errorf("error must name the resource: %s", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "datacenter") {
+		t.Errorf("error must explain datacenter-slug confusion: %s", msg)
+	}
+}
+
+// TestAppPlatformDriver_Create_RejectsInvalidRegion gives symmetric Create-
+// path coverage so a direct caller (not via Plan) gets the same protection,
+// before the request hits the DO API.
+func TestAppPlatformDriver_Create_RejectsInvalidRegion(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "my-app",
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "sfo3",
+		},
+	})
+	if err == nil {
+		t.Fatal("Create with invalid App Platform region must error")
+	}
+	if !strings.Contains(err.Error(), "sfo3") {
+		t.Errorf("error must name the offending region: %v", err)
+	}
+	if mock.lastCreateReq != nil {
+		t.Error("Create API must not be called when region validation fails")
+	}
+}
+
+// TestAppPlatformDriver_Diff_AcceptsValidRegion confirms the validation
+// only rejects bad inputs — a valid region passes through cleanly.
+func TestAppPlatformDriver_Diff_AcceptsValidRegion(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "my-app",
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "fra",
+		},
+	}, nil)
+	if err != nil {
+		t.Errorf("Diff with valid App Platform region must not error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

User caught: \"App platform 'nyc', that should have been caught by wfctl validate, DO plugin, etc.\" — the AppPlatform driver was silently forwarding datacenter slugs (e.g. `nyc1`, `nyc3`, `sfo3`) to the DO API, which returned a misleading **\"404 Image tag or digest not found\"** instead of a clear validation error. Operators got pointed at the wrong root cause.

App Platform uses **regional slugs** (`ams blr fra lon nyc sfo sgp syd tor tlv`) — NOT the Droplet/VPC datacenter slugs.

## Changes

- New `validateAppPlatformRegion` in `internal/drivers/app_platform_region.go`:
  - Enumerates the 10 valid regional slugs (App Platform docs as of 2026-05)
  - Case-insensitive, whitespace-tolerant
  - Empty region passes (caller falls back to driver default; driver default not validated since it can come from env defaults the user didn't author)
  - Error message names the offending slug, enumerates valid options, AND explicitly calls out the datacenter-slug confusion (the actual user mistake)
- Wired into `AppPlatformDriver.Diff()` (the plan-time hook — user-facing fix), `Create()`, and `Update()` for symmetric protection
- Updated `bmwSpec` integration helper + 2 Diff_Region* unit tests that previously used `nyc1`/`nyc3` in spec.Config — those were always wrong for App Platform; this PR is also the test-correctness fix

## Test plan

- [x] 25 new unit tests in `app_platform_region_test.go` (valid slugs, case/whitespace, datacenter rejection, garbage rejection)
- [x] 3 new integration tests in `app_platform_test.go` (Diff plan-time rejection, Create rejection without API call, valid region accepted)
- [x] Existing test suite green (`go test ./...` clean — 6.5s drivers + 2.0s root + 0.8s internal)
- [x] `go vet ./...` clean
- [ ] CI green

## Why Diff and not just buildAppSpec

`buildAppSpec` is invoked from Create/Update — too late for plan-time feedback. `Diff()` runs during `wfctl infra plan` *before* Apply, so the operator sees the error at plan time when it's cheap to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)