### PR TITLE
chore(deps): bump workflow to v0.27.1 for EnumerateAll SDK dispatcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.27.0
+	github.com/GoCodeAlone/workflow v0.27.1
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.27.0 h1:oufPjwWTuwbZw5PckBEDrIah+w7JJcj51nKQzLe5io0=
-github.com/GoCodeAlone/workflow v0.27.0/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.27.1 h1:stgxB5m2/iVMjYmtUuIdtumtPDBZEzen6wObFWkYgv8=
+github.com/GoCodeAlone/workflow v0.27.1/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=


### PR DESCRIPTION
## Summary

Pure dependency bump: workflow v0.27.0 -> v0.27.1.

Workflow v0.27.1 (GoCodeAlone/workflow#589) adds dispatcher cases in `plugin/external/sdk/grpc_server.go` for the bulk `IaCProvider` methods (`EnumerateAll`, `EnumerateByTag`, `ValidatePlan`). DO plugin v0.14.0 already implements `EnumerateAll` on `DOProvider` (Tasks 14 + 15) but the embedded SDK shipped in v0.14.0 was built against workflow v0.27.0 which lacked the dispatcher case — so the gRPC server returned:

```
remote invoke IaCProvider.EnumerateAll: digitalocean plugin: unknown method "IaCProvider.EnumerateAll"
```

This bump pulls in the new SDK so the plugin's server-side dispatcher routes `IaCProvider.EnumerateAll` to the underlying provider method, unblocking `wfctl infra audit-keys --type infra.spaces_key` against external plugins.

Will tag as DO plugin v0.14.1 once merged.

## Diff

- `go.mod`: `github.com/GoCodeAlone/workflow v0.27.0` -> `v0.27.1`
- `go.sum`: hash refresh for the bumped module

No source changes.

## Test plan

- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test -race ./...` all pkgs PASS
- [x] `GOWORK=off go vet ./...` clean
- [x] `wfctl@v0.27.1 plugin validate --file plugin.json --strict-contracts` -> OK