### PR TITLE
fix(dispatch): add IaCProvider.EnumerateAll dispatcher case + strict-coverage test (v0.14.2)

### DIFF
--- a/internal/dispatcher_coverage_test.go
+++ b/internal/dispatcher_coverage_test.go
@@ -1,0 +1,209 @@
+package internal
+
+// dispatcher_coverage_test.go closes the CI gap that allowed the
+// IaCProvider.EnumerateAll dispatch case to be missed during the v0.14.0
+// EnumeratorAll satisfaction work.
+//
+// Background
+// ──────────
+// The DO plugin satisfies optional IaCProvider sub-interfaces (Enumerator,
+// EnumeratorAll, ProviderMigrationRepairer, ProviderCredentialRevoker) at the
+// Go-type level via methods on *DOProvider. The plugin/host gRPC boundary
+// does NOT discover these methods reflectively — it routes calls through
+// doModuleInstance.InvokeMethod, a hardcoded switch keyed on method-name
+// strings ("IaCProvider.EnumerateAll"). When a new optional interface is
+// added to *DOProvider but the corresponding switch case is forgotten, wfctl
+// receives "unknown method" at runtime against staging, bypassing every
+// compile-time check.
+//
+// Per the user's strict-mode mandate ("force strict, no fallbacks"), this
+// regression class must be caught at CI time. The wfctl-side
+// remoteIaCProvider only validates the Go-type-level bridge; it has no way
+// to introspect plugin-side dispatch coverage. This test does that
+// introspection from the plugin side via reflection over the IaCProvider
+// optional sub-interfaces *DOProvider claims to satisfy.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+)
+
+// optionalProviderInterfaces enumerates every IaCProvider sub-interface
+// upstream workflow defines that the DO plugin's *DOProvider may satisfy.
+// New optional interfaces added in workflow MUST be appended here so this
+// test continues to enforce dispatcher coverage. Forgetting to add an entry
+// silently weakens the gate; consider that part of the upstream-interface
+// adoption checklist.
+//
+// Includes both IaCProvider sub-interfaces (provider methods) and
+// ResourceDriver sub-interfaces (driver methods). The same dispatcher in
+// module_instance.go routes both, so coverage must extend to both.
+func optionalProviderInterfaces() []reflect.Type {
+	return []reflect.Type{
+		// IaCProvider optional sub-interfaces.
+		reflect.TypeOf((*interfaces.Enumerator)(nil)).Elem(),
+		reflect.TypeOf((*interfaces.EnumeratorAll)(nil)).Elem(),
+		reflect.TypeOf((*interfaces.ProviderMigrationRepairer)(nil)).Elem(),
+		reflect.TypeOf((*interfaces.ProviderCredentialRevoker)(nil)).Elem(),
+		reflect.TypeOf((*interfaces.DriftConfigDetector)(nil)).Elem(),
+		reflect.TypeOf((*interfaces.ProviderValidator)(nil)).Elem(),
+	}
+}
+
+// methodSurfacePrefixes maps a reflected interface to the method-name prefix
+// used by the dispatcher switch. IaCProvider sub-interfaces use the
+// "IaCProvider." prefix; ResourceDriver sub-interfaces use "ResourceDriver.".
+// Currently every entry is "IaCProvider." because the listed optional
+// interfaces are all provider-scoped. Driver-scoped entries (Troubleshooter,
+// ResourceReplacer, etc.) are dispatched on the driver returned by
+// ResourceDriver(type), not on the provider directly, so they don't fit this
+// switch-case pattern; they're covered by the per-driver test surface.
+const providerMethodPrefix = "IaCProvider."
+
+// dispatcherExceptions lists method names whose *interface name* is
+// IaCProvider sub-interface but whose corresponding switch case intentionally
+// does NOT exist in InvokeMethod because the host calls a different code
+// path (e.g. DetectDriftWithSpecs is dispatched via "IaCProvider.DetectDrift"
+// + a "specs" arg in the args map, not via a separate
+// "IaCProvider.DetectDriftWithSpecs" case).
+//
+// Adding to this list is a deliberate, audited weakening of the gate. Each
+// entry MUST include a comment explaining why no separate case is required,
+// and reference the alternate dispatch site so reviewers can verify.
+var dispatcherExceptions = map[string]string{
+	// DriftConfigDetector.DetectDriftWithSpecs is dispatched via the existing
+	// "IaCProvider.DetectDrift" case in module_instance.go: the dispatch reads
+	// args["specs"] and, when present, type-asserts the provider against
+	// specsDetector and routes to DetectDriftWithSpecs. See
+	// invokeProviderDetectDrift.
+	"DetectDriftWithSpecs": "dispatched via IaCProvider.DetectDrift + specs arg (see invokeProviderDetectDrift)",
+
+	// ProviderValidator.ValidatePlan is invoked in-process by wfctl's plan
+	// pipeline, not via the gRPC InvokeMethod boundary. The DO plugin's
+	// validate_plan.go satisfies the interface for in-process callers; no
+	// remote dispatch case is needed because wfctl never crosses the gRPC
+	// boundary for this method. Revisit if the workflow planner adopts a
+	// remote-validate dispatch.
+	"ValidatePlan": "in-process only; wfctl planner does not cross the gRPC boundary",
+}
+
+// TestDispatcherCoversEveryProviderInterfaceMethod asserts: for every method
+// declared by an optionalProviderInterfaces type that *DOProvider satisfies,
+// internal/module_instance.go MUST have a corresponding
+// `case "IaCProvider.<Method>":` in its InvokeMethod switch — unless the
+// method is in dispatcherExceptions with a documented reason.
+//
+// Without this assertion, plugin-side dispatcher coverage is invisible to
+// CI and only surfaces at runtime against live cloud (the bug that motivated
+// this test: IaCProvider.EnumerateAll case missing in v0.14.0; wfctl received
+// "unknown method" against staging).
+//
+// Methodology: parse module_instance.go via go/ast and walk every CaseClause
+// in the file, collecting the string literals that key each case. AST
+// parsing (not raw string scanning) is required because raw scanning matches
+// commented-out cases — the original implementation passed even when the
+// EnumerateAll case was commented out, which would have masked the bug this
+// test exists to catch.
+func TestDispatcherCoversEveryProviderInterfaceMethod(t *testing.T) {
+	caseLiterals, err := collectDispatcherCaseLiterals(filepath.Join(".", "module_instance.go"))
+	if err != nil {
+		t.Fatalf("collectDispatcherCaseLiterals: %v", err)
+	}
+
+	// reflect on *DOProvider concrete type so the coverage gate is anchored
+	// to the actual production provider, not a fake.
+	providerType := reflect.TypeOf((*DOProvider)(nil))
+
+	var failures []string
+	for _, iface := range optionalProviderInterfaces() {
+		// Skip if *DOProvider doesn't satisfy this interface — that's an
+		// intentional "we don't implement this yet" stance, not a bug.
+		if !providerType.Implements(iface) {
+			t.Logf("note: *DOProvider does not satisfy %s — skipping coverage check for its methods",
+				iface.String())
+			continue
+		}
+		for i := 0; i < iface.NumMethod(); i++ {
+			method := iface.Method(i)
+			if reason, excepted := dispatcherExceptions[method.Name]; excepted {
+				t.Logf("note: %s.%s is in dispatcherExceptions — %s",
+					iface.String(), method.Name, reason)
+				continue
+			}
+			expected := providerMethodPrefix + method.Name
+			if !caseLiterals[expected] {
+				failures = append(failures, formatMissingCase(iface, method.Name, `case "`+expected+`":`))
+			}
+		}
+	}
+	if len(failures) > 0 {
+		t.Fatalf("module_instance.go missing dispatcher cases:\n\n%s\n",
+			strings.Join(failures, "\n\n"))
+	}
+}
+
+// collectDispatcherCaseLiterals parses path as a Go source file and returns
+// a set of string literals used as case keys in any CaseClause, including
+// nested switches. Comments are not parsed as case clauses, so commented-out
+// cases are correctly excluded.
+//
+// Returns the set as a map[string]bool with `true` for present literals so
+// callers can use a one-liner membership check. Empty literals (the
+// `default:` clause has no expressions) are not in the set.
+func collectDispatcherCaseLiterals(path string) (map[string]bool, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+	literals := make(map[string]bool)
+	ast.Inspect(file, func(n ast.Node) bool {
+		cc, ok := n.(*ast.CaseClause)
+		if !ok {
+			return true
+		}
+		for _, expr := range cc.List {
+			lit, ok := expr.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				continue
+			}
+			// lit.Value includes surrounding quotes — strip them.
+			s := lit.Value
+			if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+				s = s[1 : len(s)-1]
+			}
+			literals[s] = true
+		}
+		return true
+	})
+	return literals, nil
+}
+
+// formatMissingCase returns a multi-line, copy-pasteable error message that
+// names the missing interface method, the runtime symptom (wfctl error
+// string), and the exact line to add.
+func formatMissingCase(iface reflect.Type, method, caseStmt string) string {
+	return strings.Join([]string{
+		"  " + iface.String() + "." + method + ":",
+		"    *DOProvider satisfies " + iface.String() + " at the Go-type level,",
+		"    but the gRPC dispatch switch in module_instance.go has no case for this method.",
+		"    wfctl will receive 'unknown method \"IaCProvider." + method + "\"' at runtime",
+		"    once it dispatches this call across the plugin boundary.",
+		"",
+		"    Add to InvokeMethodContext switch:",
+		"        " + caseStmt,
+		"            return m.invokeProvider" + method + "(ctx, args)",
+		"",
+		"    Then implement invokeProvider" + method + " in the same file,",
+		"    mirroring the pattern of invokeProviderEnumerateByTag or invokeProviderRevokeCredential",
+		"    (codes.Unimplemented when the provider doesn't satisfy the interface,",
+		"    structToMap for the response).",
+	}, "\n")
+}

--- a/internal/module_instance.go
+++ b/internal/module_instance.go
@@ -86,6 +86,9 @@ func (m *doModuleInstance) InvokeMethodContext(ctx context.Context, method strin
 	case "IaCProvider.EnumerateByTag":
 		return m.invokeProviderEnumerateByTag(ctx, args)
 
+	case "IaCProvider.EnumerateAll":
+		return m.invokeProviderEnumerateAll(ctx, args)
+
 	case "IaCProvider.RevokeProviderCredential":
 		return m.invokeProviderRevokeCredential(ctx, args)
 
@@ -315,6 +318,49 @@ func (m *doModuleInstance) invokeProviderEnumerateByTag(ctx context.Context, arg
 		refList[i] = rm
 	}
 	return map[string]any{"refs": refList}, nil
+}
+
+// invokeProviderEnumerateAll routes the "IaCProvider.EnumerateAll" method to
+// the underlying provider when it implements the opt-in
+// interfaces.EnumeratorAll (workflow v0.26.0+). Mirrors invokeProviderEnumerateByTag
+// in shape: codes.Unimplemented when the provider doesn't satisfy the
+// interface, so wfctl's remoteIaCProvider.EnumerateAll bridge can translate
+// it into interfaces.ErrProviderMethodUnimplemented (cmd/wfctl/deploy_providers.go).
+//
+// args contract: {"resource_type": <string>} — the resource type to enumerate
+// (e.g. "infra.spaces_key"). Empty / missing falls through to provider's own
+// validation.
+//
+// response shape: {"outputs": [<ResourceOutput JSON>, ...]}. Each output is
+// encoded via structToMap so the host's remoteIaCProvider can decode with
+// anyToStruct (the symmetric helper used in deploy_providers.go).
+//
+// Without this dispatch case, wfctl's IaCProvider.EnumerateAll calls hit the
+// default branch of InvokeMethod and return an "unknown method" error, which
+// the wfctl-side bridge then surfaces as a generic dispatch failure rather
+// than the expected EnumeratorAll proxy. Type-assertion against EnumeratorAll
+// at the wfctl level cannot catch this because the bridge is compile-time
+// satisfied; only the runtime InvokeMethod switch decides whether the call
+// reaches the provider.
+func (m *doModuleInstance) invokeProviderEnumerateAll(ctx context.Context, args map[string]any) (map[string]any, error) {
+	enum, ok := m.provider.(interfaces.EnumeratorAll)
+	if !ok {
+		return nil, status.Error(codes.Unimplemented, "provider does not implement EnumeratorAll")
+	}
+	resourceType := stringArg(args, "resource_type")
+	outs, err := enum.EnumerateAll(ctx, resourceType)
+	if err != nil {
+		return nil, err
+	}
+	outList := make([]any, len(outs))
+	for i, o := range outs {
+		om, mErr := structToMap(o)
+		if mErr != nil {
+			return nil, fmt.Errorf("IaCProvider.EnumerateAll: serialize output: %w", mErr)
+		}
+		outList[i] = om
+	}
+	return map[string]any{"outputs": outList}, nil
 }
 
 func (m *doModuleInstance) invokeProviderRepairDirtyMigration(ctx context.Context, args map[string]any) (map[string]any, error) {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -41,7 +41,9 @@ type DOProvider struct {
 var _ interfaces.IaCProvider = (*DOProvider)(nil)
 var _ interfaces.ProviderMigrationRepairer = (*DOProvider)(nil)
 var _ interfaces.Enumerator = (*DOProvider)(nil)
+var _ interfaces.EnumeratorAll = (*DOProvider)(nil)
 var _ interfaces.DriftConfigDetector = (*DOProvider)(nil)
+var _ interfaces.ProviderCredentialRevoker = (*DOProvider)(nil)
 
 // NewDOProvider creates an uninitialised DOProvider.
 func NewDOProvider() *DOProvider {

--- a/internal/provider_enumerator_test.go
+++ b/internal/provider_enumerator_test.go
@@ -333,3 +333,115 @@ func TestDOModuleInstance_InvokeMethod_EnumerateByTag_NonEnumeratorProvider(t *t
 		t.Errorf("error %q should mention Enumerator", err.Error())
 	}
 }
+
+// fakeEnumeratorAllProvider is an IaCProvider that ALSO implements
+// EnumeratorAll, used by the dispatch-level test to verify the
+// doModuleInstance.InvokeMethod proxy reaches the provider's typed
+// EnumerateAll(ctx, resourceType) method. Embeds fakeIaCProvider for the
+// bulk of the IaCProvider surface.
+type fakeEnumeratorAllProvider struct {
+	fakeIaCProvider
+	enumerateAllCalled       bool
+	enumerateAllResourceType string
+	enumerateAllOuts         []*interfaces.ResourceOutput
+	enumerateAllErr          error
+}
+
+func (f *fakeEnumeratorAllProvider) EnumerateAll(_ context.Context, resourceType string) ([]*interfaces.ResourceOutput, error) {
+	f.enumerateAllCalled = true
+	f.enumerateAllResourceType = resourceType
+	return f.enumerateAllOuts, f.enumerateAllErr
+}
+
+// TestDOModuleInstance_InvokeMethod_EnumerateAll pins the dispatcher case
+// added in v0.14.2 fixing the runtime "unknown method
+// IaCProvider.EnumerateAll" failure that surfaced against staging. The
+// doModuleInstance.InvokeMethod dispatch table must route
+// "IaCProvider.EnumerateAll" through to the underlying provider's typed
+// EnumerateAll(ctx, resourceType) when it implements interfaces.EnumeratorAll.
+//
+// This complements TestDispatcherCoversEveryProviderInterfaceMethod (the
+// CI-time strict-coverage test): coverage asserts the case exists; this test
+// asserts the case behavior matches the wfctl-side bridge contract
+// (deploy_providers.go's remoteIaCProvider.EnumerateAll).
+func TestDOModuleInstance_InvokeMethod_EnumerateAll(t *testing.T) {
+	prov := &fakeEnumeratorAllProvider{
+		enumerateAllOuts: []*interfaces.ResourceOutput{
+			{
+				Name:       "bmw-deploy-key",
+				Type:       "infra.spaces_key",
+				ProviderID: "DOACCESS123",
+				Status:     "active",
+				Outputs: map[string]any{
+					"name":       "bmw-deploy-key",
+					"access_key": "DOACCESS123",
+				},
+				Sensitive: map[string]bool{"access_key": true},
+			},
+			{
+				Name:       "bmw-state-key",
+				Type:       "infra.spaces_key",
+				ProviderID: "DOACCESS456",
+				Status:     "active",
+			},
+		},
+	}
+	mi := &doModuleInstance{provider: prov}
+
+	out, err := mi.InvokeMethod("IaCProvider.EnumerateAll", map[string]any{
+		"resource_type": "infra.spaces_key",
+	})
+	if err != nil {
+		t.Fatalf("InvokeMethod EnumerateAll: %v", err)
+	}
+	if !prov.enumerateAllCalled {
+		t.Fatal("provider.EnumerateAll was not called via dispatch — case missing or routed to wrong impl")
+	}
+	if prov.enumerateAllResourceType != "infra.spaces_key" {
+		t.Errorf("enumerateAllResourceType = %q, want %q",
+			prov.enumerateAllResourceType, "infra.spaces_key")
+	}
+	// Response shape MUST be {"outputs": [<map>, ...]} so wfctl's
+	// remoteIaCProvider.EnumerateAll (deploy_providers.go) can decode via
+	// res["outputs"] + anyToStruct. Mismatch here is the runtime symptom
+	// against staging the v0.14.2 fix closed.
+	rawOuts, ok := out["outputs"].([]any)
+	if !ok {
+		t.Fatalf(`out["outputs"] type = %T, want []any`, out["outputs"])
+	}
+	if len(rawOuts) != 2 {
+		t.Fatalf("outputs length = %d, want 2: %+v", len(rawOuts), rawOuts)
+	}
+	// Sample the first output — keys match interfaces.ResourceOutput JSON tags.
+	first, ok := rawOuts[0].(map[string]any)
+	if !ok {
+		t.Fatalf("outputs[0] type = %T, want map[string]any", rawOuts[0])
+	}
+	if first["name"] != "bmw-deploy-key" ||
+		first["type"] != "infra.spaces_key" ||
+		first["provider_id"] != "DOACCESS123" {
+		t.Errorf("outputs[0] = %+v, want name=bmw-deploy-key type=infra.spaces_key provider_id=DOACCESS123",
+			first)
+	}
+}
+
+// TestDOModuleInstance_InvokeMethod_EnumerateAll_NonEnumeratorAllProvider
+// pins the codes.Unimplemented branch for EnumerateAll. When the underlying
+// provider does NOT implement interfaces.EnumeratorAll, the dispatcher must
+// surface an Unimplemented gRPC error so wfctl's remoteIaCProvider.EnumerateAll
+// can translate it into interfaces.ErrProviderMethodUnimplemented (preserving
+// the iterate-and-skip semantics in cmd/wfctl/infra_audit_keys.go and
+// infra_prune.go).
+func TestDOModuleInstance_InvokeMethod_EnumerateAll_NonEnumeratorAllProvider(t *testing.T) {
+	mi := &doModuleInstance{provider: &fakeIaCProvider{}}
+
+	_, err := mi.InvokeMethod("IaCProvider.EnumerateAll", map[string]any{
+		"resource_type": "infra.spaces_key",
+	})
+	if err == nil {
+		t.Fatal("expected Unimplemented error from non-EnumeratorAll provider; got nil")
+	}
+	if !strings.Contains(err.Error(), "EnumeratorAll") {
+		t.Errorf("error %q should mention EnumeratorAll", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- **Bug:** `*DOProvider` satisfies `interfaces.EnumeratorAll` at the Go-type level via `EnumerateAll(ctx, resourceType)` (Task 15, v0.14.0) but `internal/module_instance.go`'s hardcoded switch never gained the corresponding `case "IaCProvider.EnumerateAll":`. wfctl received `unknown method` at runtime against staging, bypassing workflow v0.27.1's `remoteIaCProvider.EnumerateAll` bridge entirely.
- **Fix:** Added the missing dispatch case + sister `invokeProviderEnumerateAll` helper mirroring `invokeProviderEnumerateByTag` exactly (codes.Unimplemented when interface unsatisfied, `{"outputs": [...]}` response shape per `cmd/wfctl/deploy_providers.go` `remoteIaCProvider.EnumerateAll`).
- **Strict-coverage test:** `TestDispatcherCoversEveryProviderInterfaceMethod` (new, in `internal/dispatcher_coverage_test.go`) uses `go/ast` + reflection to assert every method on every IaCProvider sub-interface `*DOProvider` satisfies has a matching dispatch case. Catches this class of bug at CI time, not runtime against live cloud. **Verified pre-fix:** with the case commented out, the test fails with an actionable, paste-ready error message.

## Why AST parsing (not raw string scan)?

The first iteration of the test used `strings.Contains` against the source file. It silently passed when the case was commented out — masking the bug the test exists to catch. AST parsing (`go/ast` `CaseClause` walk) skips comments correctly. Documented in the test file.

## Audited dispatcher exceptions

Two methods are intentionally absent from the switch and registered in `dispatcherExceptions` with documented reasons:
- `DriftConfigDetector.DetectDriftWithSpecs` — dispatched via `IaCProvider.DetectDrift` + a `specs` arg (see `invokeProviderDetectDrift`).
- `ProviderValidator.ValidatePlan` — in-process only; wfctl planner does not cross the gRPC boundary.

## Files

- `internal/module_instance.go` — new switch case + helper.
- `internal/provider.go` — `var _ interfaces.EnumeratorAll = (*DOProvider)(nil)` and `var _ interfaces.ProviderCredentialRevoker = (*DOProvider)(nil)` compile-time satisfaction (belt-and-suspenders).
- `internal/dispatcher_coverage_test.go` — new strict-coverage test.
- `internal/provider_enumerator_test.go` — runtime dispatch tests `TestDOModuleInstance_InvokeMethod_EnumerateAll` and `_NonEnumeratorAllProvider` mirroring the EnumerateByTag pattern; pin the wfctl-side `{"outputs": [...]}` response-shape contract.

## Test plan

- [x] `GOWORK=off go build ./...` — clean
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `GOWORK=off go test ./internal -run TestDispatcherCoversEveryProviderInterfaceMethod -v` — passes with fix; **fails with actionable message when fix reverted**
- [x] `GOWORK=off go test ./internal -run TestDOModuleInstance_InvokeMethod_EnumerateAll -v` — both sub-tests pass
- [x] `GOWORK=off go vet ./...` — clean
- [x] `golangci-lint run --new-from-rev=origin/main ./...` — 0 new issues