### PR TITLE
Pass App Platform registry credentials

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -1075,17 +1075,24 @@ func ParseImageRef(imageStr string) (*godo.ImageSourceSpec, error) {
 // Accepts either a flat string (parsed by ParseImageRef) or an already-nested
 // map[string]any with keys registry_type, repository, tag, registry.
 func imageSpecFromConfig(cfg map[string]any) (*godo.ImageSourceSpec, error) {
+	var img *godo.ImageSourceSpec
+	var err error
 	switch v := cfg["image"].(type) {
 	case string:
 		if v == "" {
 			return nil, fmt.Errorf("image config is empty")
 		}
-		return ParseImageRef(v)
+		img, err = ParseImageRef(v)
 	case map[string]any:
-		return imageSpecFromMap(v)
+		img, err = imageSpecFromMap(v)
 	default:
 		return nil, fmt.Errorf("image config must be a string or map[string]any, got %T", cfg["image"])
 	}
+	if err != nil {
+		return nil, err
+	}
+	applyRegistryCredentialsFromConfig(img, cfg)
+	return img, nil
 }
 
 func imageSpecFromMap(m map[string]any) (*godo.ImageSourceSpec, error) {
@@ -1102,12 +1109,35 @@ func imageSpecFromMap(m map[string]any) (*godo.ImageSourceSpec, error) {
 		tag = "latest"
 	}
 	registry, _ := m["registry"].(string)
+	registryCredentials, _ := m["registry_credentials"].(string)
 	return &godo.ImageSourceSpec{
-		RegistryType: godo.ImageSourceSpecRegistryType(regType),
-		Registry:     registry,
-		Repository:   repo,
-		Tag:          tag,
+		RegistryType:        godo.ImageSourceSpecRegistryType(regType),
+		Registry:            registry,
+		Repository:          repo,
+		Tag:                 tag,
+		RegistryCredentials: registryCredentials,
 	}, nil
+}
+
+func applyRegistryCredentialsFromConfig(img *godo.ImageSourceSpec, cfg map[string]any) {
+	if img == nil || img.RegistryCredentials != "" {
+		return
+	}
+	if credentials, ok := cfg["registry_credentials"].(string); ok && credentials != "" {
+		img.RegistryCredentials = credentials
+		return
+	}
+	ps, ok := cfg["provider_specific"].(map[string]any)
+	if !ok {
+		return
+	}
+	do, ok := ps["digitalocean"].(map[string]any)
+	if !ok {
+		return
+	}
+	if credentials, ok := do["registry_credentials"].(string); ok && credentials != "" {
+		img.RegistryCredentials = credentials
+	}
 }
 
 // envVarsFromConfig converts the "env_vars" map in spec config to App Platform

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -88,6 +88,41 @@ func TestBuildAppSpec_RepresentativeCanonicalConfig(t *testing.T) {
 	}
 }
 
+func TestBuildAppSpec_ImageRegistryCredentialsProviderSpecific(t *testing.T) {
+	cfg := map[string]any{
+		"image": "ghcr.io/gocodealone/workflow-compute-server:abc123",
+		"provider_specific": map[string]any{
+			"digitalocean": map[string]any{
+				"registry_credentials": "gocodealone:ghp_secret",
+			},
+		},
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	img := spec.Services[0].Image
+	if img.RegistryType != godo.ImageSourceSpecRegistryType_Ghcr {
+		t.Fatalf("RegistryType = %q, want GHCR", img.RegistryType)
+	}
+	if img.RegistryCredentials != "gocodealone:ghp_secret" {
+		t.Fatalf("RegistryCredentials = %q, want provider-specific credential", img.RegistryCredentials)
+	}
+}
+
+func TestBuildAppSpec_ImageMapRegistryCredentials(t *testing.T) {
+	cfg := map[string]any{
+		"image": map[string]any{
+			"registry_type":        "GHCR",
+			"registry":             "gocodealone",
+			"repository":           "workflow-compute-server",
+			"tag":                  "abc123",
+			"registry_credentials": "gocodealone:ghp_secret",
+		},
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Services[0].Image.RegistryCredentials; got != "gocodealone:ghp_secret" {
+		t.Fatalf("RegistryCredentials = %q, want image-map credential", got)
+	}
+}
+
 // ── instanceSizeSlug ────────────────────────────────────────────────────────
 
 func TestBuildAppSpec_InstanceSizeSlug_AbstractSize(t *testing.T) {


### PR DESCRIPTION
## Summary
- pass `registry_credentials` into App Platform image specs for GHCR/Docker Hub pulls
- support provider-specific DigitalOcean config and structured image maps
- add driver coverage for private GHCR pull credentials

## Verification
- `GOWORK=off go test ./...`

## Review
- antagonistic/security pass: credential is only passed to DO image spec, not emitted in resource outputs or image formatting; app config should reference it via secret interpolation.