### PR TITLE
build(deps): bump workflow v0.27.1 → v0.50.0 + grpc-version-sync CI gate (Task 7)

### DIFF
--- a/.github/workflows/grpc-version-sync.yml
+++ b/.github/workflows/grpc-version-sync.yml
@@ -1,0 +1,74 @@
+name: grpc-version-sync
+
+# Per ADR 0024 (workflow strict-contracts force-cutover) + Task 7:
+# downstream plugins MUST keep their google.golang.org/grpc version in
+# lockstep with the workflow release that defines the proto wire format.
+# Mismatched grpc-go versions break gRPC service-method dispatch silently
+# at runtime (the bug class the strict-contracts cutover eliminated for
+# wfctl ↔ workflow but which can still bite plugin ↔ workflow).
+#
+# This gate asserts that the plugin's resolved grpc-go version matches
+# the version recorded in the workflow release's grpc-versions.txt
+# artifact (workflow Task 2). Mismatch = block merge until lockfile bump.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  GOPRIVATE: github.com/GoCodeAlone/*
+
+jobs:
+  grpc-version-sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Configure Git for private repos
+        env:
+          RELEASES_TOKEN: ${{ secrets.RELEASES_TOKEN }}
+        run: |
+          if [ -n "${RELEASES_TOKEN}" ]; then
+            git config --global url."https://x-access-token:${RELEASES_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+      - name: Resolve plugin's workflow dep version
+        id: workflow_version
+        run: |
+          set -euo pipefail
+          WORKFLOW_VERSION=$(go list -m -f '{{.Version}}' github.com/GoCodeAlone/workflow)
+          echo "workflow=${WORKFLOW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Plugin pins workflow ${WORKFLOW_VERSION}"
+      - name: Fetch grpc-versions.txt from workflow release
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || secrets.GITHUB_TOKEN }}
+          WORKFLOW_VERSION: ${{ steps.workflow_version.outputs.workflow }}
+        run: |
+          set -euo pipefail
+          # Download grpc-versions.txt from the workflow release tagged at
+          # ${WORKFLOW_VERSION}. The artifact is published by workflow's
+          # release pipeline (Task 2) and lists the canonical grpc-go +
+          # protobuf + protoc-gen-* versions for that release.
+          gh release download "${WORKFLOW_VERSION}" \
+            --repo GoCodeAlone/workflow \
+            --pattern grpc-versions.txt \
+            --output workflow-grpc-versions.txt
+          echo "--- workflow-grpc-versions.txt ---"
+          cat workflow-grpc-versions.txt
+      - name: Compare grpc-go versions
+        run: |
+          set -euo pipefail
+          PLUGIN_GRPC=$(go list -m -f '{{.Version}}' google.golang.org/grpc)
+          WORKFLOW_GRPC=$(grep '^grpc=' workflow-grpc-versions.txt | cut -d= -f2)
+          echo "Plugin grpc-go: ${PLUGIN_GRPC}"
+          echo "Workflow grpc-go: ${WORKFLOW_GRPC}"
+          if [ "${PLUGIN_GRPC}" != "${WORKFLOW_GRPC}" ]; then
+            echo "::error::grpc-go version mismatch: plugin=${PLUGIN_GRPC} vs workflow=${WORKFLOW_GRPC}. Bump go.mod or sync workflow dep."
+            exit 1
+          fi
+          echo "OK: grpc-go versions match"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.27.1
+	github.com/GoCodeAlone/workflow v0.50.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2
@@ -221,6 +221,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.27.1 h1:stgxB5m2/iVMjYmtUuIdtumtPDBZEzen6wObFWkYgv8=
-github.com/GoCodeAlone/workflow v0.27.1/go.mod h1:Ue+5YDScTZgtA36q6r/kDaIRxGJFkyxXbeyJVNVJ0Cc=
+github.com/GoCodeAlone/workflow v0.50.0 h1:ai+3P1mWWNf0Q9KjB9tHtpn0uBuISCv0PdOpQSK0HVE=
+github.com/GoCodeAlone/workflow v0.50.0/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
@@ -847,6 +847,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.80.0 h1:Xr6m2WmWZLETvUNvIUmeD5OAagMw3FiKmMlTdViWsHM=
 google.golang.org/grpc v1.80.0/go.mod h1:ho/dLnxwi3EDJA4Zghp7k2Ec1+c2jqup0bFkw07bwF4=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1 h1:/WILD1UcXj/ujCxgoL/DvRgt2CP3txG8+FwkUbb9110=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.1/go.mod h1:YNKnb2OAApgYn2oYY47Rn7alMr1zWjb2U8Q0aoGWiNc=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
Phase 2 / Task 7 — workflow dep bump + grpc-version-sync gate. Build clean. Subsequent PRs (Tasks 8-13) implement typed pb.IaCProvider*Server + DELETE module_instance.go + tag v1.0.0.