### PR TITLE
feat(internal): typed pb.ResourceDriverServer per-type CRUD router (Task 11)

### DIFF
--- a/internal/iacserver.go
+++ b/internal/iacserver.go
@@ -49,6 +49,12 @@ type doIaCServer struct {
 	pb.UnimplementedIaCProviderMigrationRepairerServer
 	pb.UnimplementedIaCProviderValidatorServer
 	pb.UnimplementedIaCProviderDriftConfigDetectorServer
+	// pb.UnimplementedResourceDriverServer satisfies the
+	// mustEmbedUnimplementedResourceDriverServer() forward-compat
+	// requirement on pb.ResourceDriverServer; the per-type CRUD
+	// dispatch methods are declared in resourcedriver_server.go
+	// (Task 11 of the strict-contracts force-cutover plan).
+	pb.UnimplementedResourceDriverServer
 
 	provider *DOProvider
 }

--- a/internal/resourcedriver_server.go
+++ b/internal/resourcedriver_server.go
@@ -1,0 +1,296 @@
+// Package internal — typed pb.ResourceDriverServer implementation
+// (Task 11 of the strict-contracts force-cutover plan,
+// docs/plans/2026-05-10-strict-contracts-force-cutover.md, rev5).
+//
+// The pb.ResourceDriverServer surface is a single gRPC service that
+// dispatches per-resource-type CRUD by carrying resource_type on
+// every RPC. This file extends *doIaCServer (declared in iacserver.go)
+// with the 9 RPC methods Required by the interface; routing happens by
+// looking up the per-type interfaces.ResourceDriver via
+// *DOProvider.ResourceDriver(resourceType) and forwarding the call.
+//
+// Once *doIaCServer satisfies pb.ResourceDriverServer at the Go type
+// level, sdk.RegisterAllIaCProviderServices auto-registers it
+// (iacserver.go: type-assertion gate). No manual Register* call needed.
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+)
+
+// Embed pb.UnimplementedResourceDriverServer on doIaCServer so the
+// gRPC forward-compat contract is satisfied AND the SDK type-assert
+// in sdk.RegisterAllIaCProviderServices succeeds. Declared in this
+// file rather than iacserver.go to keep the optional-service embed
+// co-located with the methods that override it — same pattern the
+// pb codegen documents on the Unimplemented*Server types.
+//
+// (The base struct is doIaCServer in iacserver.go; the embed is added
+// by Go's struct-extension rules at the field level. Cannot embed
+// types in two struct definitions, so this file uses an interface
+// satisfaction check + method definitions; the embed lives in
+// iacserver.go as part of the doIaCServer composite.)
+
+// Compile-time guard: doIaCServer satisfies pb.ResourceDriverServer.
+// A signature drift in iac.proto fails the build at this line rather
+// than at first RPC dispatch.
+var _ pb.ResourceDriverServer = (*doIaCServer)(nil)
+
+// resolveResourceDriver looks up the per-type driver registered on
+// the underlying *DOProvider. Returns a typed gRPC error with
+// codes.NotFound when the resource_type is not registered, so
+// callers see the same wire-shape regardless of whether the type
+// is unknown or the provider has not been initialized.
+func (s *doIaCServer) resolveResourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
+	if resourceType == "" {
+		return nil, status.Error(codes.InvalidArgument, "digitalocean ResourceDriver: resource_type is required")
+	}
+	d, err := s.provider.ResourceDriver(resourceType)
+	if err != nil {
+		// Surface as NotFound so the wfctl host can distinguish
+		// "no such resource type" from "driver crashed".
+		return nil, status.Errorf(codes.NotFound, "digitalocean ResourceDriver: %v", err)
+	}
+	return d, nil
+}
+
+// Create dispatches the typed RPC to the per-type driver's
+// interfaces.ResourceDriver.Create. The provider-specific config is
+// JSON-encoded in spec.config_json (per iac.proto §Hard invariants);
+// specFromPB unmarshals it into the map[string]any the driver expects.
+func (s *doIaCServer) Create(ctx context.Context, req *pb.ResourceCreateRequest) (*pb.ResourceCreateResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	spec, err := specFromPB(req.GetSpec())
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Create: decode spec: %w", req.GetResourceType(), err)
+	}
+	out, err := driver.Create(ctx, spec)
+	if err != nil {
+		return nil, err
+	}
+	pbOut, err := outputToPB(out)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Create: encode response: %w", req.GetResourceType(), err)
+	}
+	return &pb.ResourceCreateResponse{Output: pbOut}, nil
+}
+
+// Read dispatches to interfaces.ResourceDriver.Read.
+func (s *doIaCServer) Read(ctx context.Context, req *pb.ResourceReadRequest) (*pb.ResourceReadResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	out, err := driver.Read(ctx, refFromPB(req.GetRef()))
+	if err != nil {
+		return nil, err
+	}
+	pbOut, err := outputToPB(out)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Read: encode response: %w", req.GetResourceType(), err)
+	}
+	return &pb.ResourceReadResponse{Output: pbOut}, nil
+}
+
+// Update dispatches to interfaces.ResourceDriver.Update.
+func (s *doIaCServer) Update(ctx context.Context, req *pb.ResourceUpdateRequest) (*pb.ResourceUpdateResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	spec, err := specFromPB(req.GetSpec())
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Update: decode spec: %w", req.GetResourceType(), err)
+	}
+	out, err := driver.Update(ctx, refFromPB(req.GetRef()), spec)
+	if err != nil {
+		return nil, err
+	}
+	pbOut, err := outputToPB(out)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Update: encode response: %w", req.GetResourceType(), err)
+	}
+	return &pb.ResourceUpdateResponse{Output: pbOut}, nil
+}
+
+// Delete dispatches to interfaces.ResourceDriver.Delete. The pb
+// response is empty (the only reportable signal is the error).
+func (s *doIaCServer) Delete(ctx context.Context, req *pb.ResourceDeleteRequest) (*pb.ResourceDeleteResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	if err := driver.Delete(ctx, refFromPB(req.GetRef())); err != nil {
+		return nil, err
+	}
+	return &pb.ResourceDeleteResponse{}, nil
+}
+
+// Diff dispatches to interfaces.ResourceDriver.Diff.
+func (s *doIaCServer) Diff(ctx context.Context, req *pb.ResourceDiffRequest) (*pb.ResourceDiffResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	desired, err := specFromPB(req.GetDesired())
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Diff: decode desired: %w", req.GetResourceType(), err)
+	}
+	current, err := outputFromPB(req.GetCurrent())
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Diff: decode current: %w", req.GetResourceType(), err)
+	}
+	result, err := driver.Diff(ctx, desired, current)
+	if err != nil {
+		return nil, err
+	}
+	pbResult, err := diffResultToPB(result)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Diff: encode response: %w", req.GetResourceType(), err)
+	}
+	return &pb.ResourceDiffResponse{Result: pbResult}, nil
+}
+
+// Scale dispatches to interfaces.ResourceDriver.Scale. The replicas
+// pb field is int32; the Go interface accepts int. Sign-extension
+// is safe because replicas is always non-negative in practice.
+func (s *doIaCServer) Scale(ctx context.Context, req *pb.ResourceScaleRequest) (*pb.ResourceScaleResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	out, err := driver.Scale(ctx, refFromPB(req.GetRef()), int(req.GetReplicas()))
+	if err != nil {
+		return nil, err
+	}
+	pbOut, err := outputToPB(out)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean ResourceDriver(%s).Scale: encode response: %w", req.GetResourceType(), err)
+	}
+	return &pb.ResourceScaleResponse{Output: pbOut}, nil
+}
+
+// HealthCheck dispatches to interfaces.ResourceDriver.HealthCheck.
+func (s *doIaCServer) HealthCheck(ctx context.Context, req *pb.ResourceHealthCheckRequest) (*pb.ResourceHealthCheckResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	result, err := driver.HealthCheck(ctx, refFromPB(req.GetRef()))
+	if err != nil {
+		return nil, err
+	}
+	pbResult := healthResultToPB(result)
+	return &pb.ResourceHealthCheckResponse{Result: pbResult}, nil
+}
+
+// SensitiveKeys dispatches to interfaces.ResourceDriver.SensitiveKeys.
+// The Go interface signature returns []string — no error path; any
+// per-type lookup failure surfaces here at the resolveResourceDriver
+// gate.
+func (s *doIaCServer) SensitiveKeys(_ context.Context, req *pb.SensitiveKeysRequest) (*pb.SensitiveKeysResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	keys := driver.SensitiveKeys()
+	return &pb.SensitiveKeysResponse{Keys: append([]string(nil), keys...)}, nil
+}
+
+// Troubleshoot dispatches to interfaces.Troubleshooter.Troubleshoot
+// when the per-type driver implements that optional interface.
+// Drivers that don't satisfy Troubleshooter surface a typed gRPC
+// codes.Unimplemented — the legitimate negative signal callers
+// translate into interfaces.ErrProviderMethodUnimplemented (per
+// cmd/wfctl/iac_typed_adapter.go's translateRPCErr) so the original
+// failure message is preserved.
+func (s *doIaCServer) Troubleshoot(ctx context.Context, req *pb.TroubleshootRequest) (*pb.TroubleshootResponse, error) {
+	driver, err := s.resolveResourceDriver(req.GetResourceType())
+	if err != nil {
+		return nil, err
+	}
+	tr, ok := driver.(interfaces.Troubleshooter)
+	if !ok {
+		return nil, status.Errorf(codes.Unimplemented,
+			"digitalocean ResourceDriver(%s).Troubleshoot: driver does not implement interfaces.Troubleshooter",
+			req.GetResourceType())
+	}
+	diags, err := tr.Troubleshoot(ctx, refFromPB(req.GetRef()), req.GetFailureMsg())
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*pb.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		out = append(out, &pb.Diagnostic{
+			Id:     d.ID,
+			Phase:  d.Phase,
+			Cause:  d.Cause,
+			At:     timeToPB(d.At),
+			Detail: d.Detail,
+		})
+	}
+	return &pb.TroubleshootResponse{Diagnostics: out}, nil
+}
+
+// ── Marshalling helpers specific to ResourceDriver responses ────────────────
+
+func diffResultToPB(r *interfaces.DiffResult) (*pb.DiffResult, error) {
+	if r == nil {
+		return nil, nil
+	}
+	pbChanges, err := changesToPB(r.Changes)
+	if err != nil {
+		return nil, err
+	}
+	return &pb.DiffResult{
+		NeedsUpdate:  r.NeedsUpdate,
+		NeedsReplace: r.NeedsReplace,
+		Changes:      pbChanges,
+	}, nil
+}
+
+func healthResultToPB(r *interfaces.HealthResult) *pb.HealthResult {
+	if r == nil {
+		return nil
+	}
+	return &pb.HealthResult{
+		Healthy: r.Healthy,
+		Message: r.Message,
+	}
+}
+
+// outputFromPB is the inverse of outputToPB (which lives in iacserver.go).
+// Used by the Diff RPC to decode the typed pb.ResourceOutput.current
+// into the Go-side *interfaces.ResourceOutput the driver expects.
+func outputFromPB(o *pb.ResourceOutput) (*interfaces.ResourceOutput, error) {
+	if o == nil {
+		return nil, nil
+	}
+	outputs, err := unmarshalJSONMap(o.GetOutputsJson())
+	if err != nil {
+		return nil, err
+	}
+	sensitive := make(map[string]bool, len(o.GetSensitive()))
+	for k, v := range o.GetSensitive() {
+		sensitive[k] = v
+	}
+	return &interfaces.ResourceOutput{
+		Name:       o.GetName(),
+		Type:       o.GetType(),
+		ProviderID: o.GetProviderId(),
+		Outputs:    outputs,
+		Sensitive:  sensitive,
+		Status:     o.GetStatus(),
+	}, nil
+}
+

--- a/internal/resourcedriver_server_test.go
+++ b/internal/resourcedriver_server_test.go
@@ -1,0 +1,200 @@
+package internal
+
+// resourcedriver_server_test.go — typed pb.ResourceDriverServer smoke
+// test (Task 11 of the strict-contracts force-cutover plan,
+// docs/plans/2026-05-10-strict-contracts-force-cutover.md, rev5).
+//
+// Stands up an in-process gRPC server with sdk.RegisterAllIaCProviderServices,
+// dials it via bufconn, and exercises the typed ResourceDriver RPCs that
+// doIaCServer must satisfy. Asserts:
+//
+//   - SensitiveKeys for a known type ("infra.spaces_key") routes to
+//     SpacesKeyDriver and returns the documented sensitive-output list
+//     ([access_key, secret_key]).
+//   - SensitiveKeys for an unknown type ("infra.unknown_for_test")
+//     surfaces a non-Unimplemented error — proving the dispatcher
+//     hit the Go-side router rather than missing-service-registration
+//     at the gRPC layer.
+//   - Troubleshoot for a non-Troubleshooter driver
+//     ("infra.spaces_key") returns codes.Unimplemented — preserves the
+//     legacy iterate-and-skip semantics callers depend on.
+//
+// The test fails to compile until resourcedriver_server.go declares the
+// ResourceDriver methods on doIaCServer. Per the TDD contract:
+// red (this file) → green (resourcedriver_server.go).
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+// TestDOResourceDriverServer_RoutesByResourceType is the Task 11 smoke
+// test. The fake-token Initialize populates the per-type driver map
+// without issuing any DO API calls; SensitiveKeys + Troubleshoot are
+// non-network methods that exercise the routing layer end-to-end
+// through a real gRPC channel (bufconn).
+func TestDOResourceDriverServer_RoutesByResourceType(t *testing.T) {
+	provider := NewDOProvider()
+	if err := provider.Initialize(context.Background(), map[string]any{
+		"token":  "fake-token-for-test",
+		"region": "nyc3",
+	}); err != nil {
+		t.Fatalf("DOProvider.Initialize: %v", err)
+	}
+
+	listener := bufconn.Listen(iacServerTestBufSize)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	srv := grpc.NewServer()
+	if err := sdk.RegisterAllIaCProviderServices(srv, newDOIaCServer(provider)); err != nil {
+		t.Fatalf("RegisterAllIaCProviderServices: %v", err)
+	}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), iacServerTestRPCDeadline)
+	t.Cleanup(cancel)
+
+	client := pb.NewResourceDriverClient(conn)
+
+	// 1. Known resource type — SensitiveKeys delegates to SpacesKeyDriver.
+	keysResp, err := client.SensitiveKeys(ctx, &pb.SensitiveKeysRequest{
+		ResourceType: "infra.spaces_key",
+	})
+	if err != nil {
+		t.Fatalf("SensitiveKeys(infra.spaces_key): %v", err)
+	}
+	keys := keysResp.GetKeys()
+	if len(keys) != 2 || keys[0] != "access_key" || keys[1] != "secret_key" {
+		t.Errorf("SensitiveKeys = %v, want [access_key secret_key]", keys)
+	}
+
+	// 2. Unknown resource type — error surfaces at the dispatcher,
+	//    NOT as transport-level Unimplemented.
+	if _, err := client.SensitiveKeys(ctx, &pb.SensitiveKeysRequest{
+		ResourceType: "infra.unknown_for_test",
+	}); err == nil {
+		t.Fatalf("SensitiveKeys(infra.unknown_for_test): expected error, got nil")
+	} else if status.Code(err) == codes.Unimplemented {
+		t.Errorf("SensitiveKeys(unknown): error code = Unimplemented; "+
+			"want a per-type dispatcher error (the optional ResourceDriver "+
+			"service appears unregistered): %v", err)
+	} else if !strings.Contains(err.Error(), "infra.unknown_for_test") &&
+		!strings.Contains(err.Error(), "unsupported resource type") {
+		t.Errorf("SensitiveKeys(unknown) error %q should mention the unknown type", err.Error())
+	}
+
+	// 3. Optional Troubleshoot interface — SpacesKeyDriver does not
+	//    implement interfaces.Troubleshooter, so the typed RPC must
+	//    return codes.Unimplemented (the legitimate negative signal
+	//    callers translate to ErrProviderMethodUnimplemented and
+	//    fall back to the original failure message).
+	_, err = client.Troubleshoot(ctx, &pb.TroubleshootRequest{
+		ResourceType: "infra.spaces_key",
+		Ref: &pb.ResourceRef{
+			Name:       "test-key",
+			Type:       "infra.spaces_key",
+			ProviderId: "FAKE",
+		},
+		FailureMsg: "test failure",
+	})
+	if err == nil {
+		t.Fatalf("Troubleshoot(spaces_key): expected codes.Unimplemented, got nil")
+	}
+	if got := status.Code(err); got != codes.Unimplemented {
+		t.Errorf("Troubleshoot(spaces_key): code = %v, want Unimplemented (driver does not implement Troubleshooter); err=%v", got, err)
+	}
+}
+
+// TestDOResourceDriverServer_TroubleshootsAppPlatform asserts the
+// Troubleshooter optional interface IS reachable through the typed
+// RPC for drivers that DO implement it. AppPlatformDriver implements
+// Troubleshoot — the typed dispatch must NOT short-circuit to
+// codes.Unimplemented for this driver. We don't drive a real DO API
+// (no app exists at FAKE provider id), so we accept any non-
+// Unimplemented error from the underlying driver as proof the routing
+// reached the live Troubleshoot method rather than the optional-
+// service-not-registered short-circuit.
+func TestDOResourceDriverServer_TroubleshootsAppPlatform(t *testing.T) {
+	provider := NewDOProvider()
+	if err := provider.Initialize(context.Background(), map[string]any{
+		"token":  "fake-token-for-test",
+		"region": "nyc3",
+	}); err != nil {
+		t.Fatalf("DOProvider.Initialize: %v", err)
+	}
+
+	listener := bufconn.Listen(iacServerTestBufSize)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	srv := grpc.NewServer()
+	if err := sdk.RegisterAllIaCProviderServices(srv, newDOIaCServer(provider)); err != nil {
+		t.Fatalf("RegisterAllIaCProviderServices: %v", err)
+	}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), iacServerTestRPCDeadline)
+	t.Cleanup(cancel)
+
+	client := pb.NewResourceDriverClient(conn)
+
+	// AppPlatformDriver DOES implement Troubleshooter — the typed RPC
+	// should reach the live driver. Empty providerID returns a
+	// driver-side error (per AppPlatformDriver.Troubleshoot's docstring),
+	// which is fine — we just need to assert the error code is NOT
+	// Unimplemented (which would mean dispatch dropped the call).
+	resp, err := client.Troubleshoot(ctx, &pb.TroubleshootRequest{
+		ResourceType: "infra.container_service",
+		Ref: &pb.ResourceRef{
+			Name: "test-app",
+			Type: "infra.container_service",
+			// ProviderID intentionally empty — driver returns
+			// nil + nil per its empty-id guard, exercised below.
+		},
+		FailureMsg: "test failure",
+	})
+	if err != nil && status.Code(err) == codes.Unimplemented {
+		t.Errorf("Troubleshoot(container_service): code = Unimplemented; "+
+			"AppPlatformDriver implements interfaces.Troubleshooter, the typed "+
+			"RPC must NOT short-circuit to Unimplemented for it: %v", err)
+	}
+	// Either way (resp+nil err for the empty-id guard, OR a
+	// driver-side error string) is acceptable — both prove the typed
+	// dispatch reached the live AppPlatformDriver.Troubleshoot method.
+	_ = resp
+	_ = err
+}


### PR DESCRIPTION
## Summary

Strict-contracts force-cutover **Task 11** for the DO plugin. Adds the
typed `pb.ResourceDriverServer` surface to `doIaCServer`, dispatching
per-resource-type CRUD via the existing `*DOProvider.ResourceDriver(type)`
lookup → existing per-driver `interfaces.ResourceDriver` Go method.

- **Task 11 / red** (`1c513fb`): Failing tests for the typed
  `pb.ResourceDriverClient` over bufconn — `SensitiveKeys` known/unknown
  routing + `Troubleshoot` Unimplemented vs live dispatch.
- **Task 11 / green** (`8f4a1ef`): `internal/resourcedriver_server.go`
  implements all 9 RPCs (`Create`, `Read`, `Update`, `Delete`, `Diff`,
  `Scale`, `HealthCheck`, `SensitiveKeys`, `Troubleshoot`) plus
  `pb.UnimplementedResourceDriverServer` embed in `doIaCServer` and
  compile-time guard `var _ pb.ResourceDriverServer = (*doIaCServer)(nil)`.

The 16 DO resource types (`infra.container_service`, `k8s_cluster`,
`database`, `cache`, `load_balancer`, `vpc`, `firewall`, `dns`, `storage`,
`spaces_key`, `registry`, `certificate`, `droplet`, `volume`, `iam_role`,
`api_gateway`) are auto-routed via the existing `DOProvider.drivers` map.
Adding a new resource type still requires only a registry entry — no per-
type code in `resourcedriver_server.go`.

> Note: the Task 11 brief estimated **14** drivers; actual count is **16**
> (matches `DOProvider.Capabilities()`). The implementation is type-agnostic
> (string lookup, not hand-written switch cases) so the discrepancy has zero
> functional impact.

## Optional `Troubleshoot` handling

The typed `Troubleshoot` RPC type-asserts the resolved driver against
`interfaces.Troubleshooter` at call time:

- Drivers that DO satisfy it (today: `AppPlatformDriver`) → live dispatch.
- Drivers that don't (today: 15 of 16) → `codes.Unimplemented`, the
  legitimate negative signal callers translate into
  `interfaces.ErrProviderMethodUnimplemented` per `cmd/wfctl/iac_typed_adapter.go`'s
  `translateRPCErr`.

## Verification

```
GOWORK=off go test ./... -count=1                  PASS
GOWORK=off go test ./... -race -count=1            PASS
GOWORK=off go vet ./...                            clean
GOWORK=off golangci-lint run ./internal/           no NEW findings (7 pre-existing)
```

## Scope

- IN: Task 11 `pb.ResourceDriverServer` cutover (16 drivers via
  type-routing) per
  `docs/plans/2026-05-10-strict-contracts-force-cutover.md` rev5.
- OUT: Task 13 `v1.0.0` tag — lands after this PR merges.

## Test plan

- [x] Build clean (`GOWORK=off go build ./...`)
- [x] Unit tests pass (incl. race)
- [x] Vet clean
- [x] Lint introduces zero new findings
- [x] `resourcedriver_server_test.go` exercises typed
      `pb.ResourceDriverClient` through real gRPC (bufconn) for both a
      non-Troubleshooter driver (`SpacesKey`) and a Troubleshooter
      driver (`AppPlatform`)
- [ ] Cross-plugin-build CI in workflow (post-merge) exercises the
      shipped binary against `wfctl`'s `typedResourceDriver` adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)