### PR TITLE
fix(database): opt in existing DB adoption

### DIFF
--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -136,6 +136,20 @@ func (d *DatabaseDriver) Create(ctx context.Context, spec interfaces.ResourceSpe
 // (empty ProviderID), enabling the ErrResourceAlreadyExists → upsert path.
 func (d *DatabaseDriver) SupportsUpsert() bool { return true }
 
+func (d *DatabaseDriver) AdoptionRef(spec interfaces.ResourceSpec) (interfaces.ResourceRef, bool, error) {
+	if !boolFromConfig(spec.Config, "adopt_existing", false) {
+		return interfaces.ResourceRef{}, false, nil
+	}
+	if strings.TrimSpace(spec.Name) == "" {
+		return interfaces.ResourceRef{}, false, fmt.Errorf("database adoption requires resource name")
+	}
+	resourceType := spec.Type
+	if resourceType == "" {
+		resourceType = "infra.database"
+	}
+	return interfaces.ResourceRef{Name: spec.Name, Type: resourceType}, true, nil
+}
+
 func (d *DatabaseDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
 	if ref.ProviderID == "" {
 		return d.findDatabaseByName(ctx, ref.Name)
@@ -258,12 +272,42 @@ func (d *DatabaseDriver) Diff(_ context.Context, desired interfaces.ResourceSpec
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
 	var changes []interfaces.FieldChange
+	var needsReplace bool
+	for _, field := range []struct {
+		key string
+		def string
+	}{
+		{key: "engine", def: "pg"},
+		{key: "version"},
+		{key: "region", def: d.region},
+	} {
+		desiredValue := strFromConfig(desired.Config, field.key, field.def)
+		if desiredValue == "" {
+			continue
+		}
+		currentValue, _ := current.Outputs[field.key].(string)
+		if currentValue != "" && currentValue != desiredValue {
+			changes = append(changes, interfaces.FieldChange{
+				Path: field.key, Old: currentValue, New: desiredValue, ForceNew: true,
+			})
+			needsReplace = true
+		}
+	}
 	if sz := strFromConfig(desired.Config, "size", ""); sz != "" {
 		if cur, _ := current.Outputs["size"].(string); cur != sz {
 			changes = append(changes, interfaces.FieldChange{Path: "size", Old: cur, New: sz})
 		}
 	}
-	return &interfaces.DiffResult{NeedsUpdate: len(changes) > 0, Changes: changes}, nil
+	if numNodes, ok := intFromConfig(desired.Config, "num_nodes", 0); ok {
+		if cur, _ := current.Outputs["num_nodes"].(int); cur != 0 && cur != numNodes {
+			changes = append(changes, interfaces.FieldChange{Path: "num_nodes", Old: cur, New: numNodes})
+		}
+	}
+	return &interfaces.DiffResult{
+		NeedsUpdate:  len(changes) > 0,
+		NeedsReplace: needsReplace,
+		Changes:      changes,
+	}, nil
 }
 
 func (d *DatabaseDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
@@ -552,10 +596,11 @@ func trustedSourceFirewallRulesFromConfig(cfg map[string]any) ([]*godo.DatabaseF
 
 func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 	outputs := map[string]any{
-		"engine":  db.EngineSlug,
-		"region":  db.RegionSlug,
-		"size":    db.SizeSlug,
-		"version": db.VersionSlug,
+		"engine":    db.EngineSlug,
+		"num_nodes": db.NumNodes,
+		"region":    db.RegionSlug,
+		"size":      db.SizeSlug,
+		"version":   db.VersionSlug,
 	}
 	if db.Connection != nil {
 		outputs["host"] = db.Connection.Host
@@ -574,7 +619,9 @@ func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 	}
 }
 
-func (d *DatabaseDriver) ProviderIDFormat() interfaces.ProviderIDFormat { return interfaces.IDFormatUUID }
+func (d *DatabaseDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatUUID
+}
 
 // buildCreateFirewallRulesExcludingApps builds DatabaseCreateFirewallRules from
 // the "trusted_sources" config, omitting type=app entries that require name

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -299,7 +299,7 @@ func (d *DatabaseDriver) Diff(_ context.Context, desired interfaces.ResourceSpec
 		}
 	}
 	if numNodes, ok := intFromConfig(desired.Config, "num_nodes", 0); ok {
-		if cur, _ := current.Outputs["num_nodes"].(int); cur != 0 && cur != numNodes {
+		if cur, ok := intOutputFromMap(current.Outputs, "num_nodes"); ok && cur != numNodes {
 			changes = append(changes, interfaces.FieldChange{Path: "num_nodes", Old: cur, New: numNodes})
 		}
 	}
@@ -597,7 +597,7 @@ func trustedSourceFirewallRulesFromConfig(cfg map[string]any) ([]*godo.DatabaseF
 func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 	outputs := map[string]any{
 		"engine":    db.EngineSlug,
-		"num_nodes": db.NumNodes,
+		"num_nodes": float64(db.NumNodes),
 		"region":    db.RegionSlug,
 		"size":      db.SizeSlug,
 		"version":   db.VersionSlug,
@@ -621,6 +621,23 @@ func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 
 func (d *DatabaseDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
 	return interfaces.IDFormatUUID
+}
+
+func intOutputFromMap(outputs map[string]any, key string) (int, bool) {
+	switch v := outputs[key].(type) {
+	case int:
+		return v, true
+	case int32:
+		return int(v), true
+	case int64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case float64:
+		return int(v), true
+	default:
+		return 0, false
+	}
 }
 
 // buildCreateFirewallRulesExcludingApps builds DatabaseCreateFirewallRules from

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -360,6 +360,33 @@ func TestDatabaseDriver_Diff_ImmutableShapeChangesForceReplace(t *testing.T) {
 	}
 }
 
+func TestDatabaseDriver_Diff_NumNodesCoercesStructPBNumbers(t *testing.T) {
+	mock := &mockDatabaseClient{}
+	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"size":      "db-s-1vcpu-2gb",
+			"num_nodes": float64(1),
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"size":      "db-s-1vcpu-2gb",
+			"num_nodes": 2,
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true for num_nodes drift")
+	}
+	if len(result.Changes) != 1 || result.Changes[0].Path != "num_nodes" {
+		t.Fatalf("changes = %+v, want num_nodes drift only", result.Changes)
+	}
+}
+
 func TestDatabaseDriver_HealthCheck(t *testing.T) {
 	mock := &mockDatabaseClient{db: testDatabase()}
 	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -320,6 +320,46 @@ func TestDatabaseDriver_Diff_NoChanges(t *testing.T) {
 	}
 }
 
+func TestDatabaseDriver_Diff_ImmutableShapeChangesForceReplace(t *testing.T) {
+	mock := &mockDatabaseClient{}
+	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"engine":  "mysql",
+			"version": "8",
+			"region":  "sfo3",
+			"size":    "db-s-1vcpu-2gb",
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"engine":  "pg",
+			"version": "15",
+			"region":  "nyc3",
+			"size":    "db-s-1vcpu-2gb",
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsReplace {
+		t.Fatal("expected NeedsReplace=true for immutable database shape changes")
+	}
+	for _, path := range []string{"engine", "version", "region"} {
+		found := false
+		for _, change := range result.Changes {
+			if change.Path == path && change.ForceNew {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing ForceNew change for %s: %+v", path, result.Changes)
+		}
+	}
+}
+
 func TestDatabaseDriver_HealthCheck(t *testing.T) {
 	mock := &mockDatabaseClient{db: testDatabase()}
 	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
@@ -379,6 +419,44 @@ func TestDatabaseDriver_Read_NameBased(t *testing.T) {
 	}
 	if out.Name != "my-db" {
 		t.Errorf("Name = %q, want %q", out.Name, "my-db")
+	}
+}
+
+func TestDatabaseDriver_AdoptionRefUsesNameLookup(t *testing.T) {
+	d := drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3")
+	locator := any(d).(interfaces.ResourceAdoptionLocator)
+
+	ref, ok, err := locator.AdoptionRef(interfaces.ResourceSpec{
+		Name: "my-db",
+		Type: "infra.database",
+		Config: map[string]any{
+			"adopt_existing": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("AdoptionRef: %v", err)
+	}
+	if !ok {
+		t.Fatal("AdoptionRef: got ok=false, want true")
+	}
+	if ref.Name != "my-db" || ref.Type != "infra.database" || ref.ProviderID != "" {
+		t.Fatalf("AdoptionRef = %#v, want name/type ref with empty ProviderID", ref)
+	}
+}
+
+func TestDatabaseDriver_AdoptionRefRequiresOptIn(t *testing.T) {
+	d := drivers.NewDatabaseDriverWithClient(&mockDatabaseClient{}, "nyc3")
+	locator := any(d).(interfaces.ResourceAdoptionLocator)
+
+	ref, ok, err := locator.AdoptionRef(interfaces.ResourceSpec{
+		Name: "my-db",
+		Type: "infra.database",
+	})
+	if err != nil {
+		t.Fatalf("AdoptionRef: %v", err)
+	}
+	if ok {
+		t.Fatalf("AdoptionRef = %#v, want ok=false without adopt_existing", ref)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit `adopt_existing: true` database adoption via `ResourceAdoptionLocator`
- mark database engine/version/region drift as ForceNew and persist `num_nodes` in DB outputs
- cover opt-in adoption and immutable shape diff behavior

## Verification
- `GOWORK=off go test ./...`

## Review
- antagonistic/security review approved; residual risk is documented operator assertion via `adopt_existing: true` until provider-owned tags land.