### PR TITLE
build(deps): bump workflow v0.50.0 → v0.51.0 (PluginService bridge fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.50.0
+	github.com/GoCodeAlone/workflow v0.51.0
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.50.0 h1:ai+3P1mWWNf0Q9KjB9tHtpn0uBuISCv0PdOpQSK0HVE=
-github.com/GoCodeAlone/workflow v0.50.0/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
+github.com/GoCodeAlone/workflow v0.51.0 h1:dsxKtTgIi+SIPsH6Yr7oNjU0YgTS0FPhNVLBzzX6UB4=
+github.com/GoCodeAlone/workflow v0.51.0/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=


### PR DESCRIPTION
Closes the load-failure introduced by DO v1.0.0 + workflow v0.50.0 sdk.ServeIaCPlugin gap. Workflow PR #623 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)