### PR TITLE
ci: add IaC host conformance gate

### DIFF
--- a/.github/workflows/iac-host-conformance.yml
+++ b/.github/workflows/iac-host-conformance.yml
@@ -1,0 +1,82 @@
+name: IaC Host Conformance
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  GOPRIVATE: github.com/GoCodeAlone/*
+
+jobs:
+  workflow-engine-range:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure Git for private repos
+        env:
+          RELEASES_TOKEN: ${{ secrets.RELEASES_TOKEN }}
+        run: |
+          if [ -n "${RELEASES_TOKEN}" ]; then
+            git config --global url."https://x-access-token:${RELEASES_TOKEN}@github.com/".insteadOf "https://github.com/"
+          fi
+
+      - name: Determine Workflow engine versions
+        id: versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_CURRENT_VERSION: ${{ vars.WORKFLOW_CURRENT_VERSION }}
+        run: |
+          set -euo pipefail
+          min="$(jq -r '.minEngineVersion // empty' plugin.json)"
+          if [ -z "${min}" ]; then
+            echo "::error::plugin.json must declare minEngineVersion"
+            exit 1
+          fi
+          case "${min}" in
+            v*) min_version="${min}" ;;
+            *) min_version="v${min}" ;;
+          esac
+          current="${WORKFLOW_CURRENT_VERSION}"
+          if [ -z "${current}" ]; then
+            current="$(gh release view --repo GoCodeAlone/workflow --json tagName --jq '.tagName')"
+          fi
+          if [ -z "${current}" ]; then
+            echo "::error::could not determine current Workflow engine release"
+            exit 1
+          fi
+          first="$(printf '%s\n%s\n' "${current}" "${min_version}" | sort -V | head -n1)"
+          if [ "${first}" = "${current}" ] && [ "${current}" != "${min_version}" ]; then
+            echo "::notice::current Workflow release ${current} is older than declared minimum ${min_version}; testing minimum as current"
+            current="${min_version}"
+          fi
+          echo "min=${min_version}" >> "${GITHUB_OUTPUT}"
+          echo "current=${current}" >> "${GITHUB_OUTPUT}"
+          echo "Declared min engine: ${min_version}"
+          echo "Current engine release: ${current}"
+
+      # The declared minimum is intentionally executable, not just metadata.
+      # For this strict-cutover plugin it is v0.51.2 because v0.51.0/v0.51.1
+      # start the plugin but reject its intentionally unimplemented GetManifest RPC.
+      - name: Conformance against declared minimum engine
+        run: ./scripts/workflow-iac-host-conformance.sh "${{ steps.versions.outputs.min }}" min
+
+      - name: Conformance against current engine release
+        if: steps.versions.outputs.current != steps.versions.outputs.min
+        run: ./scripts/workflow-iac-host-conformance.sh "${{ steps.versions.outputs.current }}" current
+
+      - name: Remove private repo Git credential rewrite
+        if: always()
+        env:
+          RELEASES_TOKEN: ${{ secrets.RELEASES_TOKEN }}
+        run: |
+          if [ -n "${RELEASES_TOKEN}" ]; then
+            git config --global --unset-all url."https://x-access-token:${RELEASES_TOKEN}@github.com/".insteadOf || true
+          fi

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.51.0
+	github.com/GoCodeAlone/workflow v0.51.2
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.51.0 h1:dsxKtTgIi+SIPsH6Yr7oNjU0YgTS0FPhNVLBzzX6UB4=
-github.com/GoCodeAlone/workflow v0.51.0/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
+github.com/GoCodeAlone/workflow v0.51.2 h1:TXnb3L+HUAU+eUp25Nev1Fj6PBuKK7NtMkAumTTVx1Y=
+github.com/GoCodeAlone/workflow v0.51.2/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/host_conformance_test.go
+++ b/internal/host_conformance_test.go
@@ -1,0 +1,120 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/plugin/external"
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+)
+
+func TestWorkflowHostConformance_LoadsTypedIaCPlugin(t *testing.T) {
+	if os.Getenv("WORKFLOW_IAC_HOST_CONFORMANCE") != "1" {
+		t.Skip("set WORKFLOW_IAC_HOST_CONFORMANCE=1 to run host compatibility smoke")
+	}
+
+	repoRoot := testRepoRoot(t)
+	pluginName := readPluginName(t, filepath.Join(repoRoot, "plugin.json"))
+
+	pluginsDir := filepath.Join(t.TempDir(), "data", "plugins")
+	pluginDir := filepath.Join(pluginsDir, pluginName)
+	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
+		t.Fatalf("mkdir plugin dir: %v", err)
+	}
+	copyFile(t, filepath.Join(repoRoot, "plugin.json"), filepath.Join(pluginDir, "plugin.json"))
+	copyFile(t, filepath.Join(repoRoot, "plugin.contracts.json"), filepath.Join(pluginDir, "plugin.contracts.json"))
+
+	build := exec.Command("go", "build", "-o", filepath.Join(pluginDir, pluginName), "./cmd/plugin")
+	build.Dir = repoRoot
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build plugin binary: %v\n%s", err, out)
+	}
+
+	mgr := external.NewExternalPluginManager(pluginsDir, nil)
+	t.Cleanup(mgr.Shutdown)
+
+	adapter, err := mgr.LoadPlugin(pluginName)
+	if err != nil {
+		t.Fatalf("load plugin through Workflow external host: %v", err)
+	}
+
+	registry := adapter.ContractRegistry()
+	if registry == nil {
+		t.Fatal("contract registry is nil")
+	}
+	if !registryHasService(registry, pb.IaCProviderRequired_ServiceDesc.ServiceName) {
+		t.Fatalf("contract registry missing required service %q: %v", pb.IaCProviderRequired_ServiceDesc.ServiceName, registry.GetContracts())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	required := pb.NewIaCProviderRequiredClient(adapter.Conn())
+	name, err := required.Name(ctx, &pb.NameRequest{})
+	if err != nil {
+		t.Fatalf("call typed IaCProviderRequired.Name: %v", err)
+	}
+	if name.GetName() != "digitalocean" {
+		t.Fatalf("provider name = %q, want digitalocean", name.GetName())
+	}
+
+	capabilities, err := required.Capabilities(ctx, &pb.CapabilitiesRequest{})
+	if err != nil {
+		t.Fatalf("call typed IaCProviderRequired.Capabilities: %v", err)
+	}
+	if !capabilitiesHasResource(capabilities, "infra.container_service") {
+		t.Fatalf("provider capabilities missing infra.container_service: %v", capabilities.GetCapabilities())
+	}
+}
+
+func readPluginName(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read plugin manifest: %v", err)
+	}
+	var manifest struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse plugin manifest: %v", err)
+	}
+	if manifest.Name == "" {
+		t.Fatal("plugin manifest missing name")
+	}
+	return manifest.Name
+}
+
+func copyFile(t *testing.T, src, dst string) {
+	t.Helper()
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(dst, data, 0o644); err != nil {
+		t.Fatalf("write %s: %v", dst, err)
+	}
+}
+
+func registryHasService(registry *pb.ContractRegistry, serviceName string) bool {
+	for _, contract := range registry.GetContracts() {
+		if contract.GetKind() == pb.ContractKind_CONTRACT_KIND_SERVICE && contract.GetServiceName() == serviceName {
+			return true
+		}
+	}
+	return false
+}
+
+func capabilitiesHasResource(capabilities *pb.CapabilitiesResponse, resourceType string) bool {
+	for _, capability := range capabilities.GetCapabilities() {
+		if capability.GetResourceType() == resourceType {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.20.1",
+  "minEngineVersion": "0.51.2",
   "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis"],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",

--- a/scripts/workflow-iac-host-conformance.sh
+++ b/scripts/workflow-iac-host-conformance.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+engine_version="${1:?usage: workflow-iac-host-conformance.sh <workflow-engine-version> [label]}"
+label="${2:-${engine_version}}"
+
+case "${engine_version}" in
+  v*) ;;
+  *) engine_version="v${engine_version}" ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+work_dir="${tmp_dir}/repo"
+mkdir -p "${work_dir}"
+
+rsync -a \
+  --exclude '.git' \
+  --exclude '.worktrees' \
+  --exclude '_worktrees' \
+  --exclude 'data' \
+  "${repo_root}/" "${work_dir}/"
+
+cd "${work_dir}"
+
+echo "==> workflow IaC host conformance (${label}): github.com/GoCodeAlone/workflow@${engine_version}"
+go mod edit -require "github.com/GoCodeAlone/workflow@${engine_version}"
+GOWORK=off go mod tidy
+WORKFLOW_IAC_HOST_CONFORMANCE=1 GOWORK=off go test ./internal -run TestWorkflowHostConformance_LoadsTypedIaCPlugin -count=1 -v


### PR DESCRIPTION
## Summary
- add an IaC host conformance workflow that runs the plugin against its declared minimum Workflow engine and the current Workflow release
- add a gated Go smoke test that builds the plugin binary, loads it through Workflow's external plugin manager, asserts typed IaC service registration, and calls required typed RPCs
- bump the DO plugin Workflow dependency and `minEngineVersion` to v0.51.2, the first engine version that can load strict-cutover IaC plugins with intentionally unimplemented `GetManifest`

## Why
Best practice for provider compatibility is to test the real host/plugin boundary, not just compile the provider. This follows the same shape as provider acceptance/smoke tests: build the provider artifact, load it via the host harness, and run the matrix against the declared minimum plus current engine.

Red/green proof:

With the new conformance test against v0.51.0:
```
$ ./scripts/workflow-iac-host-conformance.sh v0.51.0 current-red
FAIL — get manifest from plugin workflow-plugin-digitalocean: rpc error: code = Unimplemented desc = method GetManifest not implemented
```

With Workflow v0.51.2:
```
$ ./scripts/workflow-iac-host-conformance.sh v0.51.2 current
PASS
```

Antagonistic review: Mendel requested changes for release metadata scope and token cleanup. Release URL/version churn was removed; the token rewrite now has an `always()` cleanup step. Follow-up review verdict: SHIP-IT.

## Verification
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/workflow-iac-host-conformance.sh v0.51.2 current`
- `wfctl plugin validate --file plugin.json --strict-contracts` via Workflow v0.51.2
