### PR TITLE
fix(droplet): wait for active + private_ip after Create

### DIFF
--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -158,7 +158,91 @@ func (d *DropletDriver) createWithResolvedVolumes(
 	if droplet == nil || droplet.ID == 0 {
 		return nil, fmt.Errorf("droplet create %q: API returned droplet with empty ID", spec.Name)
 	}
-	return d.dropletOutput(ctx, droplet), nil
+	// DO Droplets.Create returns 202 Accepted with the droplet record
+	// before networking is provisioned, so the immediate response has
+	// empty Networks.V4 and PrivateIPv4()/PublicIPv4() return "". Poll
+	// Droplets.Get until status="active" AND PrivateIPv4 is non-empty
+	// (private_ip is the canonical Output every downstream consumer reads
+	// for VPC connectivity); without this wait, ResourceOutput.Outputs
+	// gets persisted with empty private_ip and any subsequent
+	// `wfctl infra outputs` / secrets.generate `infra_output: ...
+	// .private_ip` lookup returns empty, breaking deploy chains.
+	//
+	// Skip the poll when Create's response is already ready (covers test
+	// fakes that hand back a fully-populated Droplet, and the production
+	// no-op case where DO has already finished provisioning by the time
+	// the API replies — rare but legal per the godo contract).
+	ready := droplet
+	if !dropletReady(ready) {
+		var waitErr error
+		ready, waitErr = d.waitForDropletReady(ctx, droplet.ID)
+		if waitErr != nil {
+			return nil, fmt.Errorf("droplet create %q: wait ready (id=%d): %w", spec.Name, droplet.ID, waitErr)
+		}
+	}
+	return d.dropletOutput(ctx, ready), nil
+}
+
+// dropletReady reports whether a Droplet is considered fully provisioned
+// for state-output purposes: Status must be "active" AND PrivateIPv4
+// must be non-empty. private_ip is the canonical VPC output downstream
+// consumers depend on; an "active" droplet without a private IP would
+// satisfy a status-only check but still write empty state.
+func dropletReady(d *godo.Droplet) bool {
+	if d == nil || d.Status != "active" {
+		return false
+	}
+	ip, _ := d.PrivateIPv4()
+	return ip != ""
+}
+
+// waitForDropletReady polls Droplets.Get(id) until the droplet's status
+// is "active" AND it has a private IPv4 (in-VPC drivers always assign one
+// at active time). Returns the freshly-read *godo.Droplet so callers can
+// build a fully-populated dropletOutput.
+//
+// Bounds: defaults to 5 minutes / 5 second poll interval — DO Droplet
+// provisioning is normally 30-90s; 5 minutes is the operator-recovery
+// boundary. Override via SetReplaceTimeoutsForTest in tests.
+func (d *DropletDriver) waitForDropletReady(ctx context.Context, id int) (*godo.Droplet, error) {
+	timeout, pollInterval := d.dropletReadyTimeouts()
+	deadline := time.Now().Add(timeout)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		droplet, _, err := d.client.Get(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get: %w", WrapGodoError(err))
+		}
+		if droplet == nil {
+			return nil, fmt.Errorf("API returned nil droplet")
+		}
+		if droplet.Status == "active" {
+			privateIP, _ := droplet.PrivateIPv4()
+			if privateIP != "" {
+				return droplet, nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timeout after %s (status=%s, networks_v4_count=%d)",
+				timeout, droplet.Status, len(droplet.Networks.V4))
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// dropletReadyTimeouts returns the active-readiness wait bounds.
+// SetReplaceTimeoutsForTest also overrides these so tests stay fast.
+func (d *DropletDriver) dropletReadyTimeouts() (time.Duration, time.Duration) {
+	if d.replaceTimeout != 0 {
+		return d.replaceTimeout, d.replacePollInterval
+	}
+	return 5 * time.Minute, 5 * time.Second
 }
 
 func (d *DropletDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/droplet_replace_fakes_test.go
+++ b/internal/drivers/droplet_replace_fakes_test.go
@@ -77,6 +77,16 @@ func newRecordingDropletsClient() *recordingDropletsClient {
 			Status: "active",
 			Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
 			Region: &godo.Region{Slug: "nyc1"},
+			// Networks populated so dropletReady() short-circuits the
+			// post-Create wait poll. Without this, the wait loop hits
+			// recordingDropletsClient.Get (returning the OLD droplet's
+			// getResponse, which lacks Networks) and times out after
+			// the production 5-minute deadline.
+			Networks: &godo.Networks{
+				V4: []godo.NetworkV4{
+					{IPAddress: "10.0.0.200", Type: "private"},
+				},
+			},
 		},
 	}
 }

--- a/internal/drivers/droplet_test.go
+++ b/internal/drivers/droplet_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -1312,4 +1314,83 @@ func TestNewDropletDriverWithClient_TypedNilSafe(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDropletDriver_Create_WaitsForPrivateIP_BeforeReturning is a regression
+// test for the bug where DropletDriver.Create returned immediately after the
+// 202 Accepted from DO's Droplets.Create, persisting ResourceOutput.Outputs
+// with private_ip="" (DO assigns IPs only after the Droplet transitions to
+// "active", typically 30-90s later). Downstream consumers reading
+// `state.Outputs["private_ip"]` (e.g. core-dump deploy.yml's
+// `wfctl infra outputs --module coredump-staging-pg`) then got empty
+// strings, breaking dependency cascade.
+//
+// The fix: post-Create, poll Droplets.Get until status="active" AND
+// PrivateIPv4 is non-empty, then build the ResourceOutput from the
+// freshly-read Droplet record.
+func TestDropletDriver_Create_WaitsForPrivateIP_BeforeReturning(t *testing.T) {
+	// Simulate DO behavior: Create returns "new" droplet with no Networks
+	// (provisioning still in progress). Get is called repeatedly; first 2
+	// calls return the "new" record, third call returns "active" with IP.
+	// The test asserts (a) Get was polled, (b) returned Output has the
+	// post-active private_ip, NOT the empty intermediate value.
+	createReturned := &godo.Droplet{
+		ID: 100, Name: "pg", Status: "new",
+		Size: &godo.Size{Slug: "s-1vcpu-2gb"}, Region: &godo.Region{Slug: "nyc1"},
+	}
+	activeReturned := &godo.Droplet{
+		ID: 100, Name: "pg", Status: "active",
+		Size: &godo.Size{Slug: "s-1vcpu-2gb"}, Region: &godo.Region{Slug: "nyc1"},
+		Networks: &godo.Networks{V4: []godo.NetworkV4{
+			{IPAddress: "10.0.0.5", Type: "private"},
+		}},
+	}
+	mock := &pollingDropletClient{
+		createResp:    createReturned,
+		callsBeforeOK: 2,
+		activeResp:    activeReturned,
+	}
+	d := drivers.NewDropletDriverWithClient(mock, "nyc1")
+	d.SetReplaceTimeoutsForTest(2*time.Second, 10*time.Millisecond)
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "pg",
+		Config: map[string]any{"size": "s-1vcpu-2gb", "image": "docker-20-04"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got, _ := out.Outputs["private_ip"].(string); got != "10.0.0.5" {
+		t.Errorf("private_ip = %q, want %q (driver returned before active state)", got, "10.0.0.5")
+	}
+	if mock.getCalls.Load() < 1 {
+		t.Errorf("expected at least 1 Get call to poll for active status, got %d", mock.getCalls.Load())
+	}
+}
+
+// pollingDropletClient is a fake whose Get returns createResp for the
+// first callsBeforeOK invocations, then activeResp thereafter — modelling
+// the DO API behavior where a freshly-Created Droplet takes several
+// poll cycles to transition to status=active with networking populated.
+type pollingDropletClient struct {
+	createResp    *godo.Droplet
+	activeResp    *godo.Droplet
+	callsBeforeOK int32
+	getCalls      atomic.Int32
+}
+
+func (m *pollingDropletClient) Create(_ context.Context, _ *godo.DropletCreateRequest) (*godo.Droplet, *godo.Response, error) {
+	return m.createResp, nil, nil
+}
+
+func (m *pollingDropletClient) Get(_ context.Context, _ int) (*godo.Droplet, *godo.Response, error) {
+	n := m.getCalls.Add(1)
+	if n <= m.callsBeforeOK {
+		return m.createResp, nil, nil
+	}
+	return m.activeResp, nil, nil
+}
+
+func (m *pollingDropletClient) Delete(_ context.Context, _ int) (*godo.Response, error) {
+	return nil, nil
 }


### PR DESCRIPTION
## Summary
- DO Droplets.Create returns 202 Accepted with the droplet record before networking is provisioned. The driver was returning the immediate response, persisting `ResourceOutput.Outputs.private_ip = ""` to state.
- Same effect on Replace (which goes through `createWithResolvedVolumes`).
- Fix: post-Create, poll `Droplets.Get(id)` until `status="active"` AND `PrivateIPv4` non-empty. Reuses the existing `SetReplaceTimeoutsForTest` seam.

## Why
Surfaced end-to-end on core-dump deploy run 25643560848: Replace ran in 5s (impossible — should be 60-90s), `✓ coredump-staging-pg` emitted, very next deploy step failed with empty STAGING_PG_HOST. `drift-recovery` refresh-outputs masked it by re-Reading from cloud post-IP-assignment, but the next Apply re-overwrote state with the broken empty-IP record.

This is a pre-existing latent bug — pre-cutover deploys evidently never exercised a Droplet replace, so it stayed dormant.

## Test plan
- [x] `TestDropletDriver_Create_WaitsForPrivateIP_BeforeReturning` — passes; asserts polled active record's private_ip lands in Outputs.
- [x] `go test ./internal/drivers/...` — all 6.6s clean.
- [x] `go test ./...` — all packages clean.
- [ ] core-dump deploy.yml re-dispatch against v1.0.2 → state.Outputs.private_ip populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)