### PR TITLE
fix(droplet): detect enable_backups via Features slice (not BackupIDs)

### DIFF
--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -554,11 +554,22 @@ func (d *DropletDriver) dropletOutput(ctx context.Context, droplet *godo.Droplet
 	}
 }
 
-// dropletBackupsEnabled returns true when DO reports any backup IDs on the
-// droplet — godo.Droplet has no dedicated EnableBackups field on Read, so
-// presence of BackupIDs is the only reliable read-side signal.
+// dropletBackupsEnabled returns true when DO reports the "backups" feature
+// is enabled on the droplet. Uses droplet.Features (the canonical read-side
+// source — same path as monitoring/ipv6) rather than BackupIDs.
+//
+// Why not BackupIDs: DO populates BackupIDs only AFTER the first scheduled
+// snapshot is taken (backups run on a weekly cadence). A freshly-created
+// Droplet with `Backups: true` in the create request returns Features
+// containing "backups" but BackupIDs=[] until the first weekly snapshot.
+// Reading enable_backups via BackupIDs therefore false-negatives for the
+// entire interval between create and first backup, which (a) writes
+// state.Outputs.enable_backups=false despite desired=true, and (b)
+// triggers an unnecessary ForceNew on every subsequent Plan because
+// DropletDriver.Diff sees state ≠ desired. Surfaced end-to-end on
+// core-dump deploy run 25648072116 (perpetual replace cycle).
 func dropletBackupsEnabled(droplet *godo.Droplet) bool {
-	return len(droplet.BackupIDs) > 0
+	return dropletHasFeature(droplet, "backups")
 }
 
 // dropletHasFeature returns true when the named feature string is present in

--- a/internal/drivers/droplet_test.go
+++ b/internal/drivers/droplet_test.go
@@ -1394,3 +1394,76 @@ func (m *pollingDropletClient) Get(_ context.Context, _ int) (*godo.Droplet, *go
 func (m *pollingDropletClient) Delete(_ context.Context, _ int) (*godo.Response, error) {
 	return nil, nil
 }
+
+// TestDropletDriver_Create_BackupsEnabled_ViaFeaturesSlice asserts
+// dropletOutput correctly reports enable_backups=true when the DO API
+// returns the "backups" feature in droplet.Features but BackupIDs=[]
+// (the actual scenario for any freshly-created Droplet with backups
+// enabled — backups don't appear in BackupIDs until the first weekly
+// snapshot is taken).
+//
+// Regression: the prior implementation used len(BackupIDs)>0, which
+// false-negatived for the entire interval between Droplet create and
+// first backup, causing DropletDriver.Diff to flag enable_backups
+// drift on every Plan and triggering an infinite Replace cycle.
+// Surfaced on core-dump deploy run 25648072116.
+func TestDropletDriver_Create_BackupsEnabled_ViaFeaturesSlice(t *testing.T) {
+	dropletWithBackupsEnabled := &godo.Droplet{
+		ID:     43,
+		Name:   "with-backups",
+		Status: "active",
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc3"},
+		Networks: &godo.Networks{V4: []godo.NetworkV4{
+			{IPAddress: "10.0.0.10", Type: "private"},
+		}},
+		Features:  []string{"backups", "monitoring"},
+		BackupIDs: nil, // explicitly empty — first backup hasn't run yet
+	}
+	mock := &mockDropletClient{droplet: dropletWithBackupsEnabled}
+	d := drivers.NewDropletDriverWithClient(mock, "nyc3")
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "with-backups",
+		Config: map[string]any{"size": "s-1vcpu-2gb", "image": "ubuntu-24-04-x64", "enable_backups": true},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := out.Outputs["enable_backups"].(bool)
+	if !got {
+		t.Errorf("enable_backups = %v, want true (Features contains 'backups' even though BackupIDs is empty)", got)
+	}
+}
+
+// TestDropletDriver_Create_BackupsDisabled_NoFeaturesEntry asserts that
+// dropletOutput reports enable_backups=false when "backups" is absent
+// from droplet.Features (matching DO's behavior when backups are
+// disabled — the feature string is omitted entirely).
+func TestDropletDriver_Create_BackupsDisabled_NoFeaturesEntry(t *testing.T) {
+	dropletNoBackups := &godo.Droplet{
+		ID:     44,
+		Name:   "no-backups",
+		Status: "active",
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc3"},
+		Networks: &godo.Networks{V4: []godo.NetworkV4{
+			{IPAddress: "10.0.0.11", Type: "private"},
+		}},
+		Features: []string{"monitoring"}, // no "backups"
+	}
+	mock := &mockDropletClient{droplet: dropletNoBackups}
+	d := drivers.NewDropletDriverWithClient(mock, "nyc3")
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "no-backups",
+		Config: map[string]any{"size": "s-1vcpu-2gb", "image": "ubuntu-24-04-x64"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := out.Outputs["enable_backups"].(bool)
+	if got {
+		t.Errorf("enable_backups = %v, want false (Features does not contain 'backups')", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `dropletBackupsEnabled` was checking `len(droplet.BackupIDs) > 0`, but DO populates BackupIDs only after the first scheduled snapshot (weekly cadence).
- Freshly-created Droplets with backups enabled return Features=[\"backups\"] + BackupIDs=[] for up to a week.
- Fix: use `dropletHasFeature(droplet, \"backups\")` (same canonical path as monitoring/ipv6).

## Why
Surfaced end-to-end on core-dump deploy run 25648072116 — perpetual Droplet replace cycle. Captured staging state confirms divergence: `state.outputs.enable_backups=false` despite `state.config.enable_backups=true`.

Each Plan flagged enable_backups drift → ForceNew → Replace → new Droplet → cloud-init not done → App Platform migrate timeout → loop.

## Test plan
- [x] `TestDropletDriver_Create_BackupsEnabled_ViaFeaturesSlice` — passes; Features=[\"backups\"], BackupIDs=[] → output=true.
- [x] `TestDropletDriver_Create_BackupsDisabled_NoFeaturesEntry` — passes; Features lacks \"backups\" → output=false.
- [x] `go test ./...` clean.
- [ ] Bump core-dump pin v1.0.2 → v1.0.3, re-dispatch deploy → Plan no-op (or just firewall update), no Droplet replace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)