### PR TITLE
fix(app_platform): Diff detects env_vars / jobs / workers / vpc drift

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -275,11 +275,135 @@ func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.Resourc
 		}
 	}
 
+	// env_vars / jobs / workers env_vars drift — critical for cascade
+	// propagation when an `infra_output:` secret resolves to a new value
+	// (e.g. Droplet replace bumping STAGING_PG_HOST → all components
+	// referencing it via env_vars need a new rollout). Without these
+	// comparisons the App's state.config froze with the first-resolved
+	// value and Plan stayed at 0 changes on subsequent Applies.
+	//
+	// Guards: skip comparison when the corresponding current.Outputs key
+	// is absent (state predates this driver version) so a stale state
+	// from before doesn't false-positive on the first Plan after upgrade
+	// — same pattern Droplet's monitoring/ipv6 comparisons use. Outputs
+	// will be populated on the next Read.
+	if desiredEnvs, ok := desired.Config["env_vars"].(map[string]any); ok {
+		if _, hasKey := current.Outputs["env_vars"]; hasKey {
+			curEnvs, _ := current.Outputs["env_vars"].(map[string]any)
+			if !envVarsEqual(desiredEnvs, curEnvs) {
+				changes = append(changes, interfaces.FieldChange{
+					Path: "env_vars", Old: curEnvs, New: desiredEnvs,
+				})
+			}
+		}
+	}
+	if desiredJobs, ok := desired.Config["jobs"].([]any); ok {
+		if _, hasKey := current.Outputs["jobs"]; hasKey {
+			curJobs, _ := current.Outputs["jobs"].([]any)
+			if !componentEnvVarsEqual(desiredJobs, curJobs) {
+				changes = append(changes, interfaces.FieldChange{
+					Path: "jobs", Old: curJobs, New: desiredJobs,
+				})
+			}
+		}
+	}
+	if desiredWorkers, ok := desired.Config["workers"].([]any); ok {
+		if _, hasKey := current.Outputs["workers"]; hasKey {
+			curWorkers, _ := current.Outputs["workers"].([]any)
+			if !componentEnvVarsEqual(desiredWorkers, curWorkers) {
+				changes = append(changes, interfaces.FieldChange{
+					Path: "workers", Old: curWorkers, New: desiredWorkers,
+				})
+			}
+		}
+	}
+
+	// vpc_uuid / vpc_ref drift — App Platform Update accepts VPC
+	// attachment changes in-place (not ForceNew). vpc_ref is the
+	// canonical config key (matches Droplet's vpc_uuid alias pattern);
+	// also accept vpc_uuid for symmetry.
+	desiredVPC := strFromConfig(desired.Config, "vpc_ref", "")
+	if desiredVPC == "" {
+		desiredVPC = strFromConfig(desired.Config, "vpc_uuid", "")
+	}
+	if _, hasKey := current.Outputs["vpc_uuid"]; hasKey {
+		curVPC, _ := current.Outputs["vpc_uuid"].(string)
+		if curVPC != desiredVPC {
+			changes = append(changes, interfaces.FieldChange{
+				Path: "vpc_uuid", Old: curVPC, New: desiredVPC,
+			})
+		}
+	}
+
 	return &interfaces.DiffResult{
 		NeedsUpdate:  len(changes) > 0,
 		NeedsReplace: needsReplace,
 		Changes:      changes,
 	}, nil
+}
+
+// envVarsEqual compares two env_vars maps for value equality, ignoring nil
+// vs empty distinctions and coercing all values to strings (matching how
+// envVarsFromConfig converts `any` to string via fmt.Sprintf).
+func envVarsEqual(desired, current map[string]any) bool {
+	if len(desired) != len(current) {
+		return false
+	}
+	for k, dv := range desired {
+		cv, ok := current[k]
+		if !ok {
+			return false
+		}
+		if fmt.Sprintf("%v", dv) != fmt.Sprintf("%v", cv) {
+			return false
+		}
+	}
+	return true
+}
+
+// componentEnvVarsEqual compares two []any of jobs/workers entries on
+// `name` + `env_vars` only. Other component fields (image, instance_count,
+// kind) are intentionally not compared here — the existing image/expose
+// comparisons handle the per-component image drift via the top-level
+// service path, and the env_vars drift is the unique gap this guards.
+func componentEnvVarsEqual(desired, current []any) bool {
+	if len(desired) != len(current) {
+		return false
+	}
+	// Index by name for order-independent comparison. App Platform allows
+	// reordering jobs/workers, so a re-Read may shuffle them.
+	dByName := componentEnvVarsByName(desired)
+	cByName := componentEnvVarsByName(current)
+	if len(dByName) != len(cByName) {
+		return false
+	}
+	for name, dEnv := range dByName {
+		cEnv, ok := cByName[name]
+		if !ok {
+			return false
+		}
+		if !envVarsEqual(dEnv, cEnv) {
+			return false
+		}
+	}
+	return true
+}
+
+func componentEnvVarsByName(comps []any) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(comps))
+	for _, c := range comps {
+		m, _ := c.(map[string]any)
+		if m == nil {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			continue
+		}
+		envs, _ := m["env_vars"].(map[string]any)
+		out[name] = envs
+	}
+	return out
 }
 
 // canonicalExpose returns the canonical `expose` value for a desired-spec
@@ -843,6 +967,24 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 			// surface it as ForceNew (App Platform's UpdateApp does not
 			// accept region changes — region is a Create-only field).
 			"region": app.Spec.Region,
+			// `env_vars` (first service component) + per-component
+			// `jobs` / `workers` env_vars carry the JIT-resolved values
+			// that DO is actually running with. Without these in Outputs,
+			// Diff cannot detect drift when a referenced `infra_output:`
+			// secret (e.g. STAGING_PG_HOST sourced from
+			// coredump-staging-pg.private_ip) resolves to a new value on
+			// the next Apply — the App keeps its stale env_vars in
+			// state.config and Plan stays at 0 changes despite the
+			// Droplet's IP having moved. Surfaced on core-dump deploy run
+			// 25653219644: state.config DATABASE_URL pinned to a long-
+			// gone 10.20.0.2 while the live Droplet had moved to 10.20.0.6.
+			"env_vars": serviceEnvVarsFromSpec(app.Spec),
+			"jobs":     jobsCanonicalFromSpec(app.Spec),
+			"workers":  workersCanonicalFromSpec(app.Spec),
+			// `vpc_uuid` records the App's VPC attachment so Diff can
+			// detect attachment drift. App Platform Update accepts VPC
+			// changes in-place; ForceNew not required.
+			"vpc_uuid": vpcUUIDFromSpec(app.Spec),
 		},
 		Status: "running",
 	}
@@ -850,6 +992,92 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 		out.Status = "pending"
 	}
 	return out
+}
+
+// serviceEnvVarsFromSpec returns the first service component's Envs as a
+// canonical map[string]any so Diff can compare against the desired
+// `env_vars` config map. Returns nil when the spec has no services or the
+// first service has no Envs. Sensitive vars are included as their
+// godo-stored value (which is the ${SECRET_REF} placeholder for type=SECRET).
+func serviceEnvVarsFromSpec(spec *godo.AppSpec) map[string]any {
+	if spec == nil || len(spec.Services) == 0 || spec.Services[0] == nil {
+		return nil
+	}
+	return envVarsToCanonicalMap(spec.Services[0].Envs)
+}
+
+// jobsCanonicalFromSpec converts AppSpec.Jobs to a canonical
+// `[]any` of `map[string]any{"name": ..., "env_vars": ...}` shape so Diff
+// can compare against the desired `jobs:` config. Critical for migrate-job
+// DATABASE_URL drift detection — pre_deploy jobs carry their own env_vars
+// which can independently go stale when an infra_output: ref resolves to
+// a new value (e.g. Droplet replace updating STAGING_PG_HOST).
+func jobsCanonicalFromSpec(spec *godo.AppSpec) []any {
+	if spec == nil || len(spec.Jobs) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(spec.Jobs))
+	for _, j := range spec.Jobs {
+		if j == nil {
+			continue
+		}
+		out = append(out, map[string]any{
+			"name":     j.Name,
+			"kind":     string(j.Kind),
+			"env_vars": envVarsToCanonicalMap(j.Envs),
+		})
+	}
+	return out
+}
+
+// workersCanonicalFromSpec mirrors jobsCanonicalFromSpec for AppSpec.Workers.
+// Workers don't run migrate steps but can also reference Droplet outputs in
+// their env_vars (NATS_URL, MESH_ENDPOINT, etc.), so symmetric Diff coverage
+// avoids the same silent-drift bug class.
+func workersCanonicalFromSpec(spec *godo.AppSpec) []any {
+	if spec == nil || len(spec.Workers) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(spec.Workers))
+	for _, w := range spec.Workers {
+		if w == nil {
+			continue
+		}
+		out = append(out, map[string]any{
+			"name":     w.Name,
+			"env_vars": envVarsToCanonicalMap(w.Envs),
+		})
+	}
+	return out
+}
+
+// envVarsToCanonicalMap converts []*godo.AppVariableDefinition to a
+// map[string]any{"KEY": "value"} so the structpb-encoded Outputs round-trip
+// preserves equality semantics with the desired-side `env_vars:` YAML map.
+// Sensitive vars surface their godo-side value verbatim (which is the
+// ${SECRET_REF} placeholder DO API stores for type=SECRET, kept stable
+// across reads — Diff would otherwise see masked vs unmasked).
+func envVarsToCanonicalMap(envs []*godo.AppVariableDefinition) map[string]any {
+	if len(envs) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(envs))
+	for _, e := range envs {
+		if e == nil {
+			continue
+		}
+		out[e.Key] = e.Value
+	}
+	return out
+}
+
+// vpcUUIDFromSpec extracts the App's attached VPC UUID. Empty string when
+// the App is not VPC-attached (DO's default — public-network only).
+func vpcUUIDFromSpec(spec *godo.AppSpec) string {
+	if spec == nil || spec.Vpc == nil {
+		return ""
+	}
+	return spec.Vpc.ID
 }
 
 // deriveImageFromAppSpec returns a canonical user-facing image ref string for

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -1898,3 +1898,153 @@ func TestAppPlatformDriver_Diff_AcceptsValidRegion(t *testing.T) {
 		t.Errorf("Diff with valid App Platform region must not error: %v", err)
 	}
 }
+
+// TestAppPlatformDriver_Diff_DetectsEnvVarsDrift is the regression test for
+// the silent-stale-DATABASE_URL bug: when an `infra_output:` secret
+// reference (e.g. STAGING_PG_HOST sourced from coredump-staging-pg.private_ip)
+// resolves to a NEW value on Apply (Droplet replace bumps the IP), the
+// App's env_vars need to be re-pushed to DO. Prior Diff only compared
+// image/expose/region, missing env_vars entirely → state.config DATABASE_URL
+// froze with the first-resolved IP, every subsequent Plan returned 0
+// changes, and the migrate job kept dialing the long-gone IP.
+//
+// Surfaced on core-dump deploy run 25653219644: state.config DATABASE_URL
+// pinned to 10.20.0.2 while the live Droplet had moved to 10.20.0.6.
+func TestAppPlatformDriver_Diff_DetectsEnvVarsDrift(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars": map[string]any{
+				"DATABASE_URL": "postgres://u:p@10.20.0.2:5432/db",
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars": map[string]any{
+				"DATABASE_URL": "postgres://u:p@10.20.0.6:5432/db", // newly-resolved IP
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatalf("expected NeedsUpdate=true when env_vars DATABASE_URL changed")
+	}
+	if result.NeedsReplace {
+		t.Errorf("env_vars change must NOT force replace (in-place Update suffices)")
+	}
+}
+
+// TestAppPlatformDriver_Diff_DetectsJobEnvVarsDrift covers the migrate-job
+// case specifically — pre_deploy jobs carry their own env_vars that can
+// independently go stale.
+func TestAppPlatformDriver_Diff_DetectsJobEnvVarsDrift(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"jobs": []any{
+				map[string]any{
+					"name": "migrate",
+					"kind": "PRE_DEPLOY",
+					"env_vars": map[string]any{
+						"DATABASE_URL": "postgres://u:p@10.20.0.2:5432/db",
+					},
+				},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"jobs": []any{
+				map[string]any{
+					"name": "migrate",
+					"kind": "pre_deploy",
+					"env_vars": map[string]any{
+						"DATABASE_URL": "postgres://u:p@10.20.0.6:5432/db",
+					},
+				},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true when job env_vars DATABASE_URL changed")
+	}
+}
+
+// TestAppPlatformDriver_Diff_NoSpurious_EnvVarsChange_OnEmptyState guards
+// the upgrade path: state from a prior plugin version (no env_vars in
+// Outputs) must NOT false-positive on the first Plan post-upgrade.
+func TestAppPlatformDriver_Diff_NoSpurious_EnvVarsChange_OnEmptyState(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			// env_vars key intentionally absent — state predates this version
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars": map[string]any{
+				"DATABASE_URL": "postgres://u:p@10.20.0.6:5432/db",
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Errorf("expected NeedsUpdate=false when current.Outputs lacks env_vars key (upgrade path)")
+	}
+}
+
+// TestAppPlatformDriver_Diff_DetectsVPCDrift covers VPC attachment change.
+func TestAppPlatformDriver_Diff_DetectsVPCDrift(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":    "registry.digitalocean.com/myrepo/myapp:v1",
+			"region":   "nyc",
+			"vpc_uuid": "", // App was created outside VPC
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":   "registry.digitalocean.com/myrepo/myapp:v1",
+			"region":  "nyc",
+			"vpc_ref": "14badc41-c954-4dfd-b1e2-87b72eb8a147",
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true when vpc_ref differs from current vpc_uuid")
+	}
+	if result.NeedsReplace {
+		t.Errorf("VPC attachment change must NOT force replace (in-place Update suffices)")
+	}
+}

--- a/internal/drivers/droplet.go
+++ b/internal/drivers/droplet.go
@@ -554,11 +554,22 @@ func (d *DropletDriver) dropletOutput(ctx context.Context, droplet *godo.Droplet
 	}
 }
 
-// dropletBackupsEnabled returns true when DO reports any backup IDs on the
-// droplet — godo.Droplet has no dedicated EnableBackups field on Read, so
-// presence of BackupIDs is the only reliable read-side signal.
+// dropletBackupsEnabled returns true when DO reports the "backups" feature
+// is enabled on the droplet. Uses droplet.Features (the canonical read-side
+// source — same path as monitoring/ipv6) rather than BackupIDs.
+//
+// Why not BackupIDs: DO populates BackupIDs only AFTER the first scheduled
+// snapshot is taken (backups run on a weekly cadence). A freshly-created
+// Droplet with `Backups: true` in the create request returns Features
+// containing "backups" but BackupIDs=[] until the first weekly snapshot.
+// Reading enable_backups via BackupIDs therefore false-negatives for the
+// entire interval between create and first backup, which (a) writes
+// state.Outputs.enable_backups=false despite desired=true, and (b)
+// triggers an unnecessary ForceNew on every subsequent Plan because
+// DropletDriver.Diff sees state ≠ desired. Surfaced end-to-end on
+// core-dump deploy run 25648072116 (perpetual replace cycle).
 func dropletBackupsEnabled(droplet *godo.Droplet) bool {
-	return len(droplet.BackupIDs) > 0
+	return dropletHasFeature(droplet, "backups")
 }
 
 // dropletHasFeature returns true when the named feature string is present in

--- a/internal/drivers/droplet_test.go
+++ b/internal/drivers/droplet_test.go
@@ -1394,3 +1394,76 @@ func (m *pollingDropletClient) Get(_ context.Context, _ int) (*godo.Droplet, *go
 func (m *pollingDropletClient) Delete(_ context.Context, _ int) (*godo.Response, error) {
 	return nil, nil
 }
+
+// TestDropletDriver_Create_BackupsEnabled_ViaFeaturesSlice asserts
+// dropletOutput correctly reports enable_backups=true when the DO API
+// returns the "backups" feature in droplet.Features but BackupIDs=[]
+// (the actual scenario for any freshly-created Droplet with backups
+// enabled — backups don't appear in BackupIDs until the first weekly
+// snapshot is taken).
+//
+// Regression: the prior implementation used len(BackupIDs)>0, which
+// false-negatived for the entire interval between Droplet create and
+// first backup, causing DropletDriver.Diff to flag enable_backups
+// drift on every Plan and triggering an infinite Replace cycle.
+// Surfaced on core-dump deploy run 25648072116.
+func TestDropletDriver_Create_BackupsEnabled_ViaFeaturesSlice(t *testing.T) {
+	dropletWithBackupsEnabled := &godo.Droplet{
+		ID:     43,
+		Name:   "with-backups",
+		Status: "active",
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc3"},
+		Networks: &godo.Networks{V4: []godo.NetworkV4{
+			{IPAddress: "10.0.0.10", Type: "private"},
+		}},
+		Features:  []string{"backups", "monitoring"},
+		BackupIDs: nil, // explicitly empty — first backup hasn't run yet
+	}
+	mock := &mockDropletClient{droplet: dropletWithBackupsEnabled}
+	d := drivers.NewDropletDriverWithClient(mock, "nyc3")
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "with-backups",
+		Config: map[string]any{"size": "s-1vcpu-2gb", "image": "ubuntu-24-04-x64", "enable_backups": true},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := out.Outputs["enable_backups"].(bool)
+	if !got {
+		t.Errorf("enable_backups = %v, want true (Features contains 'backups' even though BackupIDs is empty)", got)
+	}
+}
+
+// TestDropletDriver_Create_BackupsDisabled_NoFeaturesEntry asserts that
+// dropletOutput reports enable_backups=false when "backups" is absent
+// from droplet.Features (matching DO's behavior when backups are
+// disabled — the feature string is omitted entirely).
+func TestDropletDriver_Create_BackupsDisabled_NoFeaturesEntry(t *testing.T) {
+	dropletNoBackups := &godo.Droplet{
+		ID:     44,
+		Name:   "no-backups",
+		Status: "active",
+		Size:   &godo.Size{Slug: "s-1vcpu-2gb"},
+		Region: &godo.Region{Slug: "nyc3"},
+		Networks: &godo.Networks{V4: []godo.NetworkV4{
+			{IPAddress: "10.0.0.11", Type: "private"},
+		}},
+		Features: []string{"monitoring"}, // no "backups"
+	}
+	mock := &mockDropletClient{droplet: dropletNoBackups}
+	d := drivers.NewDropletDriverWithClient(mock, "nyc3")
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name:   "no-backups",
+		Config: map[string]any{"size": "s-1vcpu-2gb", "image": "ubuntu-24-04-x64"},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := out.Outputs["enable_backups"].(bool)
+	if got {
+		t.Errorf("enable_backups = %v, want false (Features does not contain 'backups')", got)
+	}
+}

--- a/internal/drivers/firewall.go
+++ b/internal/drivers/firewall.go
@@ -359,10 +359,29 @@ func inboundRulesFromConfig(cfg map[string]any) []godo.InboundRule {
 			PortRange: strFromConfig(m, "ports", "all"),
 			Sources:   &godo.Sources{},
 		}
-		if srcs, ok := m["sources"].([]any); ok {
+		// Accept both canonical shapes:
+		//   sources: ["10.20.0.0/16"]                    (flat list)
+		//   sources: {addresses: ["10.20.0.0/16"]}       (DO-native, structured)
+		// The structured form mirrors godo.Sources, which is the shape DO API
+		// returns on Read, and is the form most operators reach for first.
+		// Without the structured-form parser the type assertion fails silently,
+		// rule.Sources.Addresses stays nil, and the firewall ships with no
+		// inbound allowlist — surfaced on core-dump deploy run 25651563717
+		// (App Platform → Droplet:5432 connection timeouts despite the
+		// firewall apparently "applying").
+		switch srcs := m["sources"].(type) {
+		case []any:
 			for _, s := range srcs {
 				if addr, ok := s.(string); ok {
 					rule.Sources.Addresses = append(rule.Sources.Addresses, addr)
+				}
+			}
+		case map[string]any:
+			if addrs, ok := srcs["addresses"].([]any); ok {
+				for _, s := range addrs {
+					if addr, ok := s.(string); ok {
+						rule.Sources.Addresses = append(rule.Sources.Addresses, addr)
+					}
 				}
 			}
 		}
@@ -389,10 +408,21 @@ func outboundRulesFromConfig(cfg map[string]any) []godo.OutboundRule {
 			PortRange:    strFromConfig(m, "ports", "all"),
 			Destinations: &godo.Destinations{},
 		}
-		if dsts, ok := m["destinations"].([]any); ok {
+		// Same dual-shape acceptance as inboundRulesFromConfig — see comment
+		// there for rationale.
+		switch dsts := m["destinations"].(type) {
+		case []any:
 			for _, s := range dsts {
 				if addr, ok := s.(string); ok {
 					rule.Destinations.Addresses = append(rule.Destinations.Addresses, addr)
+				}
+			}
+		case map[string]any:
+			if addrs, ok := dsts["addresses"].([]any); ok {
+				for _, s := range addrs {
+					if addr, ok := s.(string); ok {
+						rule.Destinations.Addresses = append(rule.Destinations.Addresses, addr)
+					}
 				}
 			}
 		}

--- a/internal/drivers/firewall_test.go
+++ b/internal/drivers/firewall_test.go
@@ -1111,3 +1111,106 @@ func TestFirewallDriver_DropletIDs_FractionalFloat_Rejected(t *testing.T) {
 		}
 	})
 }
+
+// TestFirewallDriver_Create_AcceptsStructuredSourcesShape is a regression
+// test for the silent-empty-Sources bug where infra.yaml using DO-native
+// structured `sources: {addresses: [...]}` shape (mirroring godo.Sources)
+// type-assertion-failed in the driver's flat-list parser, leaving
+// rule.Sources.Addresses empty and shipping a firewall with no inbound
+// allowlist.
+//
+// Surfaced on core-dump deploy run 25651563717: state.outputs.sources=null
+// post-Apply despite state.config.inbound_rules[0].sources={"addresses":
+// ["10.20.0.0/16"]} → App Platform → Droplet:5432 connection timed out.
+func TestFirewallDriver_Create_AcceptsStructuredSourcesShape(t *testing.T) {
+	mock := &mockFirewallClient{fw: testFirewall()}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "fw-structured",
+		Config: map[string]any{
+			"droplet_ids": []any{123},
+			"inbound_rules": []any{
+				map[string]any{
+					"protocol": "tcp",
+					"ports":    "5432",
+					"sources": map[string]any{
+						"addresses": []any{"10.20.0.0/16"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if mock.lastReq == nil || len(mock.lastReq.InboundRules) != 1 {
+		t.Fatal("expected 1 inbound rule sent to godo")
+	}
+	got := mock.lastReq.InboundRules[0].Sources
+	if got == nil || len(got.Addresses) != 1 || got.Addresses[0] != "10.20.0.0/16" {
+		t.Errorf("Sources.Addresses = %#v, want [10.20.0.0/16]", got)
+	}
+}
+
+// TestFirewallDriver_Create_AcceptsStructuredDestinationsShape mirrors the
+// inbound regression for outbound destinations.
+func TestFirewallDriver_Create_AcceptsStructuredDestinationsShape(t *testing.T) {
+	mock := &mockFirewallClient{fw: testFirewall()}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "fw-out-structured",
+		Config: map[string]any{
+			"droplet_ids": []any{123},
+			"outbound_rules": []any{
+				map[string]any{
+					"protocol": "tcp",
+					"ports":    "1-65535",
+					"destinations": map[string]any{
+						"addresses": []any{"0.0.0.0/0"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if mock.lastReq == nil || len(mock.lastReq.OutboundRules) != 1 {
+		t.Fatal("expected 1 outbound rule sent to godo")
+	}
+	got := mock.lastReq.OutboundRules[0].Destinations
+	if got == nil || len(got.Addresses) != 1 || got.Addresses[0] != "0.0.0.0/0" {
+		t.Errorf("Destinations.Addresses = %#v, want [0.0.0.0/0]", got)
+	}
+}
+
+// TestFirewallDriver_Create_FlatSourcesShape_StillWorks asserts the
+// pre-existing flat-list shape continues to work after the dual-shape
+// patch (no regression to the documented canonical form).
+func TestFirewallDriver_Create_FlatSourcesShape_StillWorks(t *testing.T) {
+	mock := &mockFirewallClient{fw: testFirewall()}
+	d := drivers.NewFirewallDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "fw-flat",
+		Config: map[string]any{
+			"droplet_ids": []any{123},
+			"inbound_rules": []any{
+				map[string]any{
+					"protocol": "tcp",
+					"ports":    "5432",
+					"sources":  []any{"10.20.0.0/16"},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got := mock.lastReq.InboundRules[0].Sources
+	if got == nil || len(got.Addresses) != 1 || got.Addresses[0] != "10.20.0.0/16" {
+		t.Errorf("Sources.Addresses = %#v, want [10.20.0.0/16]", got)
+	}
+}


### PR DESCRIPTION
## Summary
- AppPlatformDriver.Diff only compared image/expose/region → silent env_vars drift.
- When STAGING_PG_HOST (sourced from Droplet.private_ip) resolves to a new value, App kept stale connection string and migrate timed out.
- Fix: appOutput surfaces env_vars + jobs + workers + vpc_uuid; Diff compares against desired config.

## Why
Deploy 25653219644: state.config DATABASE_URL pinned to 10.20.0.2 while Droplet had moved to 10.20.0.6. Migrate connect timeout.

## Test plan
- [x] 4 new tests pass (env_vars drift, job env_vars drift, upgrade-path guard, VPC drift).
- [x] go test ./... clean.
- [ ] Re-deploy after pin bump → Plan flags App update, migrate connects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)