### PR TITLE
fix(app): detect App Platform route drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **App Platform route drift detection** — `infra.container_service.routes` is
+  now recorded in outputs and compared during `Diff`, so adding or clearing
+  public ingress routes on an existing app triggers an in-place App Platform
+  update instead of silently no-oping.
+
 ### Added
 
 - **`DropletDriver.Replace` implements `interfaces.ResourceReplacer`** (workflow v0.23.0+). Replaces use detach-before-create orchestration: read old → DetachByDropletID per attached Block Storage Volume → wait for each detach action completion (60s/2s bounds) → delete old Droplet → create new Droplet with the resolved volume IDs (bypassing the name-resolution race in `resolveDropletVolumes`). Fixes the "422 storage already associated with another droplet" failure class when replacing Droplets with attached Volumes.

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -257,6 +257,27 @@ func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.Resourc
 		changes = append(changes, interfaces.FieldChange{Path: "expose", Old: curExpose, New: desiredExpose})
 	}
 
+	// routes drift — App Platform routes live on the service component and
+	// control public ingress. buildAppSpec already sends cfg["routes"] on
+	// Create/Update; Diff must also compare them or existing apps never gain a
+	// route added after first create. Skip when desired omits routes so older
+	// configs do not unexpectedly manage provider defaults after upgrade.
+	if desiredRoutes, ok := desiredRoutesCanonicalFromConfig(desired.Config); ok {
+		if canonicalExpose(desired.Config) == "internal" {
+			desiredRoutes = nil
+		}
+		curRoutes := routesCanonicalFromOutput(current.Outputs["routes"])
+		if _, hasKey := current.Outputs["routes"]; !hasKey {
+			changes = append(changes, interfaces.FieldChange{
+				Path: "routes", Old: "<unknown>", New: desiredRoutes,
+			})
+		} else if !routesCanonicalEqual(desiredRoutes, curRoutes) {
+			changes = append(changes, interfaces.FieldChange{
+				Path: "routes", Old: curRoutes, New: desiredRoutes,
+			})
+		}
+	}
+
 	// region: App Platform's UpdateApp does not accept region changes —
 	// region is a Create-only field on godo.AppSpec, so any drift forces
 	// replace. Mirror VolumeDriver.Diff's region pattern. Guard
@@ -981,6 +1002,10 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 			"env_vars": serviceEnvVarsFromSpec(app.Spec),
 			"jobs":     jobsCanonicalFromSpec(app.Spec),
 			"workers":  workersCanonicalFromSpec(app.Spec),
+			// `routes` records the first service component's public ingress
+			// paths. Stored on Outputs so Diff can add/remove routes on
+			// existing apps instead of only honoring them at Create time.
+			"routes": routesCanonicalFromSpec(app.Spec),
 			// `vpc_uuid` records the App's VPC attachment so Diff can
 			// detect attachment drift. App Platform Update accepts VPC
 			// changes in-place; ForceNew not required.
@@ -992,6 +1017,100 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 		out.Status = "pending"
 	}
 	return out
+}
+
+// desiredRoutesCanonicalFromConfig converts cfg["routes"] into the same
+// canonical shape produced from DO AppSpec. The boolean distinguishes absent
+// routes (do not manage on upgrade) from an explicit empty list (clear routes).
+func desiredRoutesCanonicalFromConfig(cfg map[string]any) ([]any, bool) {
+	raw, ok := cfg["routes"].([]any)
+	if !ok {
+		return nil, false
+	}
+	return routesCanonicalFromConfigList(raw), true
+}
+
+func routesCanonicalFromConfigList(raw []any) []any {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(raw))
+	for _, v := range raw {
+		m, _ := v.(map[string]any)
+		if m == nil {
+			continue
+		}
+		path, _ := m["path"].(string)
+		if path == "" {
+			path = "/"
+		}
+		preservePathPrefix, _ := m["preserve_path_prefix"].(bool)
+		out = append(out, routeCanonicalMap(path, preservePathPrefix))
+	}
+	return out
+}
+
+func routesCanonicalFromOutput(v any) []any {
+	raw, _ := v.([]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(raw))
+	for _, item := range raw {
+		m, _ := item.(map[string]any)
+		if m == nil {
+			continue
+		}
+		path, _ := m["path"].(string)
+		if path == "" {
+			path = "/"
+		}
+		preservePathPrefix, _ := m["preserve_path_prefix"].(bool)
+		out = append(out, routeCanonicalMap(path, preservePathPrefix))
+	}
+	return out
+}
+
+func routesCanonicalFromSpec(spec *godo.AppSpec) []any {
+	if spec == nil || len(spec.Services) == 0 || spec.Services[0] == nil || len(spec.Services[0].Routes) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(spec.Services[0].Routes))
+	for _, r := range spec.Services[0].Routes {
+		if r == nil {
+			continue
+		}
+		path := r.Path
+		if path == "" {
+			path = "/"
+		}
+		out = append(out, routeCanonicalMap(path, r.PreservePathPrefix))
+	}
+	return out
+}
+
+func routeCanonicalMap(path string, preservePathPrefix bool) map[string]any {
+	return map[string]any{
+		"path":                 path,
+		"preserve_path_prefix": preservePathPrefix,
+	}
+}
+
+func routesCanonicalEqual(desired, current []any) bool {
+	if len(desired) != len(current) {
+		return false
+	}
+	for i := range desired {
+		dm, _ := desired[i].(map[string]any)
+		cm, _ := current[i].(map[string]any)
+		if dm == nil || cm == nil {
+			return dm == nil && cm == nil
+		}
+		if dm["path"] != cm["path"] || dm["preserve_path_prefix"] != cm["preserve_path_prefix"] {
+			return false
+		}
+	}
+	return true
 }
 
 // serviceEnvVarsFromSpec returns the first service component's Envs as a

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -34,9 +34,9 @@ type mockAppClient struct {
 	createDeploymentCalled bool
 	lastCreateReq          *godo.AppCreateRequest
 	lastUpdateReq          *godo.AppUpdateRequest
-	getLogsResult          *godo.AppLogs      // returned by GetLogs
-	getLogsErr             error              // error returned by GetLogs
-	getLogsRequests        []getLogsCall      // recorded GetLogs calls
+	getLogsResult          *godo.AppLogs // returned by GetLogs
+	getLogsErr             error         // error returned by GetLogs
+	getLogsRequests        []getLogsCall // recorded GetLogs calls
 }
 
 // getLogsCall records a single GetLogs invocation for assertion in tests.
@@ -512,6 +512,211 @@ func TestAppPlatformDriver_Diff_DetectsExposeChange_InternalToPublic(t *testing.
 	}
 	if !result.NeedsUpdate {
 		t.Fatal("expected NeedsUpdate=true when expose toggles internal→public")
+	}
+}
+
+func TestAppPlatformDriver_AppOutput_RoutesDerivedFromAppSpec(t *testing.T) {
+	mock := &mockAppClient{app: &godo.App{
+		ID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+		Spec: &godo.AppSpec{
+			Name: "my-app",
+			Services: []*godo.AppServiceSpec{{
+				Name: "my-app",
+				Routes: []*godo.AppRouteSpec{{
+					Path:               "/",
+					PreservePathPrefix: true,
+				}},
+			}},
+		},
+		ActiveDeployment: &godo.Deployment{Phase: godo.DeploymentPhase_Active},
+	}}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	routes, _ := out.Outputs["routes"].([]any)
+	if len(routes) != 1 {
+		t.Fatalf("expected one route in outputs, got %#v", out.Outputs["routes"])
+	}
+	route, _ := routes[0].(map[string]any)
+	if route["path"] != "/" || route["preserve_path_prefix"] != true {
+		t.Fatalf("unexpected route output: %#v", route)
+	}
+}
+
+func TestAppPlatformDriver_Diff_DetectsRouteAdd(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			"routes": []any{},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/myrepo/myapp:v1",
+			"routes": []any{
+				map[string]any{"path": "/"},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true when desired route is missing from current app")
+	}
+	if !hasChangePath(result.Changes, "routes") {
+		t.Fatalf("expected routes FieldChange, got %+v", result.Changes)
+	}
+}
+
+func TestAppPlatformDriver_Diff_DetectsRouteRemoval(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			"routes": []any{
+				map[string]any{"path": "/", "preserve_path_prefix": false},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"routes": []any{},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected NeedsUpdate=true when desired routes explicitly clear current routes")
+	}
+	if !hasChangePath(result.Changes, "routes") {
+		t.Fatalf("expected routes FieldChange, got %+v", result.Changes)
+	}
+}
+
+func TestAppPlatformDriver_Diff_NoSpuriousRouteChange(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			"routes": []any{
+				map[string]any{"path": "/", "preserve_path_prefix": false},
+			},
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/myrepo/myapp:v1",
+			"routes": []any{
+				map[string]any{"path": "/"},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Fatalf("expected no route update for equivalent routes, got %+v", result.Changes)
+	}
+}
+
+func TestAppPlatformDriver_Diff_DetectsRouteAdd_OnEmptyState(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			// routes key intentionally absent — state predates this version.
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/myrepo/myapp:v1",
+			"routes": []any{
+				map[string]any{"path": "/"},
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatalf("expected route update when desired declares routes and current.Outputs lacks routes key")
+	}
+	if !hasChangePath(result.Changes, "routes") {
+		t.Fatalf("expected routes FieldChange, got %+v", result.Changes)
+	}
+}
+
+func TestAppPlatformDriver_Diff_NoSpuriousRouteChange_WhenDesiredOmitted(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			// routes key intentionally absent — state predates this version.
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/myrepo/myapp:v1",
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Fatalf("expected no route update when desired omits routes, got %+v", result.Changes)
+	}
+}
+
+func TestAppPlatformDriver_Diff_DetectsRouteClear_OnEmptyState(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"expose": "public",
+			// routes key intentionally absent — state predates this version.
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"routes": []any{},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatal("expected route update when desired explicitly clears routes and current.Outputs lacks routes key")
+	}
+	if !hasChangePath(result.Changes, "routes") {
+		t.Fatalf("expected routes FieldChange, got %+v", result.Changes)
 	}
 }
 
@@ -1493,8 +1698,8 @@ func TestTroubleshoot_AttachesDeployLogsForFailedDeployment(t *testing.T) {
 	}
 	mock := &mockAppClient{
 		app: &godo.App{
-			ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
-			Spec: &godo.AppSpec{Name: "my-app"},
+			ID:                   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+			Spec:                 &godo.AppSpec{Name: "my-app"},
 			InProgressDeployment: dep,
 		},
 		getLogsResult: &godo.AppLogs{
@@ -2047,4 +2252,13 @@ func TestAppPlatformDriver_Diff_DetectsVPCDrift(t *testing.T) {
 	if result.NeedsReplace {
 		t.Errorf("VPC attachment change must NOT force replace (in-place Update suffices)")
 	}
+}
+
+func hasChangePath(changes []interfaces.FieldChange, path string) bool {
+	for _, c := range changes {
+		if c.Path == path {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- record App Platform service routes in resource outputs
- compare declared routes during Diff so route add/remove/clear updates existing apps
- preserve omitted-routes behavior so legacy configs do not start managing provider defaults accidentally

## Verification
- GOWORK=off go test ./internal/drivers
- GOWORK=off go test ./...
- wfctl plugin validate --file plugin.json --strict-contracts
- git diff --check

## Review
- antagonistic review failed twice on missing-state route add/clear cases; both findings fixed
- final antagonistic review passed