### PR TITLE
fix(app-platform): emit ingress rules for routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/plugins/
+.worktrees/

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -1056,7 +1056,17 @@ func routesCanonicalFromOutput(v any) []any {
 }
 
 func routesCanonicalFromSpec(spec *godo.AppSpec) []any {
-	if spec == nil || len(spec.Services) == 0 || spec.Services[0] == nil || len(spec.Services[0].Routes) == 0 {
+	if spec == nil {
+		return nil
+	}
+	primaryServiceName := ""
+	if len(spec.Services) > 0 && spec.Services[0] != nil {
+		primaryServiceName = spec.Services[0].Name
+	}
+	if routes := routesCanonicalFromIngressSpec(spec.Ingress, primaryServiceName); len(routes) > 0 {
+		return routes
+	}
+	if len(spec.Services) == 0 || spec.Services[0] == nil || len(spec.Services[0].Routes) == 0 {
 		return nil
 	}
 	out := make([]any, 0, len(spec.Services[0].Routes))
@@ -1069,6 +1079,32 @@ func routesCanonicalFromSpec(spec *godo.AppSpec) []any {
 			path = "/"
 		}
 		out = append(out, routeCanonicalMap(path, r.PreservePathPrefix))
+	}
+	return out
+}
+
+func routesCanonicalFromIngressSpec(ingress *godo.AppIngressSpec, serviceName string) []any {
+	if ingress == nil || len(ingress.Rules) == 0 {
+		return nil
+	}
+	out := make([]any, 0, len(ingress.Rules))
+	for _, rule := range ingress.Rules {
+		if rule == nil || rule.Match == nil || rule.Match.Path == nil || rule.Component == nil {
+			continue
+		}
+		if serviceName != "" && rule.Component.Name != serviceName {
+			continue
+		}
+		path := ""
+		if rule.Match.Path.Prefix != nil {
+			path = *rule.Match.Path.Prefix
+		} else if rule.Match.Path.Exact != nil {
+			path = *rule.Match.Path.Exact
+		}
+		if path == "" {
+			path = "/"
+		}
+		out = append(out, routeCanonicalMap(path, rule.Component.PreservePathPrefix))
 	}
 	return out
 }

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -96,7 +96,7 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		StaticSites:                  staticSitesFromConfig(cfg),
 		Domains:                      domainsFromConfig(cfg),
 		Alerts:                       appAlertsFromConfig(cfg),
-		Ingress:                      ingressFromConfig(cfg),
+		Ingress:                      ingressFromConfig(cfg, name),
 		Egress:                       egressFromConfig(cfg),
 		Maintenance:                  maintenanceFromConfig(cfg),
 		Vpc:                          vpcFromConfig(cfg),
@@ -609,24 +609,48 @@ func domainsFromConfig(cfg map[string]any) []*godo.AppDomainSpec {
 	return out
 }
 
-// ingressFromConfig converts the canonical "ingress" map to a *godo.AppIngressSpec.
-// The canonical ingress spec is minimal; complex routing should use provider_specific.
+// ingressFromConfig converts canonical "ingress" and "routes" config to a
+// *godo.AppIngressSpec. App Platform service routes are deprecated; top-level
+// ingress rules are the public-routing source of truth.
 // Returns nil when no supported fields are present (consistent with CORS/autoscaling/maintenance).
-func ingressFromConfig(cfg map[string]any) *godo.AppIngressSpec {
-	raw, ok := cfg["ingress"].(map[string]any)
-	if !ok || len(raw) == 0 {
-		return nil
-	}
+func ingressFromConfig(cfg map[string]any, serviceName string) *godo.AppIngressSpec {
+	raw, _ := cfg["ingress"].(map[string]any)
 	spec := &godo.AppIngressSpec{}
 	if lb := strFromConfig(raw, "load_balancer", ""); lb != "" {
 		spec.LoadBalancer = godo.AppIngressSpecLoadBalancer(strings.ToUpper(lb))
 	}
-	// Rules are complex; skip for now unless coming from provider_specific.
+	spec.Rules = ingressRulesFromRoutesConfig(cfg, serviceName)
 	// Return nil when no supported field was set to avoid sending an empty ingress block.
 	if spec.LoadBalancer == "" && len(spec.Rules) == 0 {
 		return nil
 	}
 	return spec
+}
+
+func ingressRulesFromRoutesConfig(cfg map[string]any, serviceName string) []*godo.AppIngressSpecRule {
+	raw, ok := cfg["routes"].([]any)
+	if !ok || len(raw) == 0 || canonicalExpose(cfg) == "internal" {
+		return nil
+	}
+	rules := make([]*godo.AppIngressSpecRule, 0, len(raw))
+	for _, v := range raw {
+		m, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		path := strFromConfig(m, "path", "/")
+		preservePathPrefix, _ := m["preserve_path_prefix"].(bool)
+		rules = append(rules, &godo.AppIngressSpecRule{
+			Match: &godo.AppIngressSpecRuleMatch{
+				Path: &godo.AppIngressSpecRuleStringMatch{Prefix: &path},
+			},
+			Component: &godo.AppIngressSpecRuleRoutingComponent{
+				Name:               serviceName,
+				PreservePathPrefix: preservePathPrefix,
+			},
+		})
+	}
+	return rules
 }
 
 // egressFromConfig converts the canonical "egress" map to a *godo.AppEgressSpec.

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -623,6 +623,18 @@ func TestBuildAppSpec_Routes(t *testing.T) {
 	if routes[1].Path != "/health" {
 		t.Errorf("route[1].Path = %q, want /health", routes[1].Path)
 	}
+	if spec.Ingress == nil || len(spec.Ingress.Rules) != 2 {
+		t.Fatalf("expected 2 ingress rules from routes, got %+v", spec.Ingress)
+	}
+	if spec.Ingress.Rules[0].Match == nil || spec.Ingress.Rules[0].Match.Path == nil || spec.Ingress.Rules[0].Match.Path.Prefix == nil {
+		t.Fatalf("route[0] ingress match missing: %+v", spec.Ingress.Rules[0])
+	}
+	if got := *spec.Ingress.Rules[0].Match.Path.Prefix; got != "/api" {
+		t.Errorf("ingress route[0] prefix = %q, want /api", got)
+	}
+	if spec.Ingress.Rules[0].Component == nil || spec.Ingress.Rules[0].Component.Name != "test-app" || !spec.Ingress.Rules[0].Component.PreservePathPrefix {
+		t.Errorf("ingress route[0] component = %+v, want test-app preserve=true", spec.Ingress.Rules[0].Component)
+	}
 }
 
 // ── HealthCheck ──────────────────────────────────────────────────────────────

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -550,6 +550,54 @@ func TestAppPlatformDriver_AppOutput_RoutesDerivedFromAppSpec(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_AppOutput_RoutesDerivedFromIngressSpec(t *testing.T) {
+	path := "/"
+	otherPath := "/sidecar"
+	mock := &mockAppClient{app: &godo.App{
+		ID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+		Spec: &godo.AppSpec{
+			Name: "my-app",
+			Services: []*godo.AppServiceSpec{{
+				Name: "my-app",
+			}},
+			Ingress: &godo.AppIngressSpec{Rules: []*godo.AppIngressSpecRule{{
+				Match: &godo.AppIngressSpecRuleMatch{
+					Path: &godo.AppIngressSpecRuleStringMatch{Prefix: &path},
+				},
+				Component: &godo.AppIngressSpecRuleRoutingComponent{
+					Name:               "my-app",
+					PreservePathPrefix: true,
+				},
+			}, {
+				Match: &godo.AppIngressSpecRuleMatch{
+					Path: &godo.AppIngressSpecRuleStringMatch{Prefix: &otherPath},
+				},
+				Component: &godo.AppIngressSpecRuleRoutingComponent{
+					Name: "sidecar",
+				},
+			}}},
+		},
+		ActiveDeployment: &godo.Deployment{Phase: godo.DeploymentPhase_Active},
+	}}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	routes, _ := out.Outputs["routes"].([]any)
+	if len(routes) != 1 {
+		t.Fatalf("expected one route in outputs, got %#v", out.Outputs["routes"])
+	}
+	route, _ := routes[0].(map[string]any)
+	if route["path"] != "/" || route["preserve_path_prefix"] != true {
+		t.Fatalf("unexpected route output: %#v", route)
+	}
+}
+
 func TestAppPlatformDriver_Diff_DetectsRouteAdd(t *testing.T) {
 	mock := &mockAppClient{}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
@@ -2149,7 +2197,6 @@ func TestAppPlatformDriver_Diff_DetectsEnvVarsDrift(t *testing.T) {
 		t.Errorf("env_vars change must NOT force replace (in-place Update suffices)")
 	}
 }
-
 
 // TestAppPlatformDriver_Diff_DetectsJobEnvVarsDrift covers the migrate-job
 // case specifically — pre_deploy jobs carry their own env_vars that can


### PR DESCRIPTION
## Summary
- map canonical `routes:` to current App Platform `spec.ingress.rules` while preserving legacy service routes
- derive route drift output from top-level ingress rules scoped to the primary service
- add regression coverage for ingress route output and sidecar route exclusion

## Verification
- `GOWORK=off go test ./...`
- `git diff --check`

## Context
workflow-compute staging prereq provider app was created with no public ingress: `default_ingress=null`, `live_url=null`, `services[].routes=[]`, deployment phase `ERROR`. DigitalOcean App Platform now treats service `routes` as deprecated and uses top-level ingress rules for routing.