### PR TITLE
fix(release): keep plugin manifests out of VCS stamp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/plugins/
 .worktrees/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,29 +3,10 @@ version: 2
 project_name: workflow-plugin-digitalocean
 
 before:
-  # goreleaser v2 exec's each hook string via shlex.Split rather than
-  # passing it to a shell, so shell builtins (export), shell operators
-  # (&&, ;), and command substitution ($(...)) only work when wrapped in
-  # `sh -c "<...>"`. The two sed lines below only worked accidentally:
-  # goreleaser passed everything past the first whitespace as args to
-  # `sed`, which silently absorbs `&&` and `rm` as positional args. The
-  # wfctl-validate line below contains `export` (a builtin) so was the
-  # first to actually fail; wrapping all three in `sh -c` makes the
-  # behaviour match the apparent intent.
   hooks:
-    - "sh -c \"sed -i.bak 's/\\\"version\\\": \\\".*\\\"/\\\"version\\\": \\\"{{ .Version }}\\\"/' plugin.json && rm -f plugin.json.bak\""
-    - "sh -c \"sed -i.bak 's|/releases/download/v[^/]*/|/releases/download/{{ .Tag }}/|g' plugin.json && rm -f plugin.json.bak\""
-    - "sh -c \"export GOPRIVATE=github.com/GoCodeAlone/*; WFCTL_VERSION=$(go list -m github.com/GoCodeAlone/workflow | awk '{print $2}') && GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION} plugin validate --file plugin.json --strict-contracts\""
-
-# NOTE: removed top-level `after:` hook (introduced in #41). goreleaser
-# v2 has no top-level `after:` hook — it failed v0.9.0's release at
-# `yaml: unmarshal errors: line 12: field after not found in type
-# config.Project`. The previous `mv plugin.json.orig plugin.json` was
-# theatre — the GH Actions runner is ephemeral, so the in-place sed
-# mutations to plugin.json are discarded the moment the runner shuts
-# down. There is no need to restore plugin.json on the runner. Removed
-# the matching `cp plugin.json plugin.json.orig` from the before block
-# too — it was preserving state nothing else reads.
+    - "sh -c \"mkdir -p dist/release && cp plugin.json dist/release/plugin.json && cp plugin.contracts.json dist/release/plugin.contracts.json && sed -i.bak 's/\\\"version\\\": \\\".*\\\"/\\\"version\\\": \\\"{{ .Version }}\\\"/' dist/release/plugin.json && rm -f dist/release/plugin.json.bak\""
+    - "sh -c \"sed -i.bak 's|/releases/download/v[^/]*/|/releases/download/{{ .Tag }}/|g' dist/release/plugin.json && rm -f dist/release/plugin.json.bak\""
+    - "sh -c \"export GOPRIVATE=github.com/GoCodeAlone/*; WFCTL_VERSION=$(GOWORK=off go list -m github.com/GoCodeAlone/workflow | awk '{print $2}') && GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION} plugin validate --file dist/release/plugin.json --strict-contracts\""
 
 builds:
   - id: workflow-plugin-digitalocean
@@ -45,12 +26,13 @@ builds:
 
 archives:
   - id: workflow-plugin-digitalocean
-    builds:
+    ids:
       - workflow-plugin-digitalocean
     formats: [tar.gz]
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     files:
-      - plugin.json
+      - src: dist/release/plugin.json
+        dst: plugin.json
       - plugin.contracts.json
 
 checksum:

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -53,9 +54,9 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 		} `yaml:"builds"`
 		Archives []struct {
 			ID           string   `yaml:"id"`
-			Builds       []string `yaml:"builds"`
+			IDs          []string `yaml:"ids"`
 			NameTemplate string   `yaml:"name_template"`
-			Files        []string `yaml:"files"`
+			Files        []archiveFileSpec `yaml:"files"`
 		} `yaml:"archives"`
 	}
 	releaseData, err := os.ReadFile(filepath.Join(repoRoot, ".goreleaser.yaml"))
@@ -76,13 +77,13 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 	if archive.NameTemplate != "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}" {
 		t.Fatalf("unsupported archive name_template %q; update download manifest generation/test", archive.NameTemplate)
 	}
-	if len(archive.Builds) != 1 || archive.Builds[0] != build.ID {
-		t.Fatalf("archive builds = %v, want [%s]", archive.Builds, build.ID)
+	if len(archive.IDs) != 1 || archive.IDs[0] != build.ID {
+		t.Fatalf("archive ids = %v, want [%s]", archive.IDs, build.ID)
 	}
-	if !containsString(archive.Files, "plugin.json") {
+	if !containsArchiveFile(archive.Files, "dist/release/plugin.json", "plugin.json") {
 		t.Fatalf("archive files = %v, want plugin.json", archive.Files)
 	}
-	if !containsString(archive.Files, "plugin.contracts.json") {
+	if !containsArchiveFile(archive.Files, "plugin.contracts.json", "plugin.contracts.json") {
 		t.Fatalf("archive files = %v, want plugin.contracts.json", archive.Files)
 	}
 
@@ -114,7 +115,9 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 	}
 
 	archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
-	if err := writeTestArchive(repoRoot, archivePath, archive.Files); err != nil {
+	if err := writeTestArchive(repoRoot, archivePath, archive.Files, map[string][]byte{
+		"dist/release/plugin.json": manifestData,
+	}); err != nil {
 		t.Fatalf("write test archive: %v", err)
 	}
 	if !tarGzContains(archivePath, "plugin.contracts.json") {
@@ -122,16 +125,84 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 	}
 }
 
-func containsString(values []string, want string) bool {
+func TestGoReleaserReleaseManifestValidationDirectory(t *testing.T) {
+	repoRoot := testRepoRoot(t)
+	releaseData, err := os.ReadFile(filepath.Join(repoRoot, ".goreleaser.yaml"))
+	if err != nil {
+		t.Fatalf("read .goreleaser.yaml: %v", err)
+	}
+	text := string(releaseData)
+	for _, want := range []string{
+		"cp plugin.json dist/release/plugin.json",
+		"cp plugin.contracts.json dist/release/plugin.contracts.json",
+		"--file dist/release/plugin.json --strict-contracts",
+		"WFCTL_VERSION=$(GOWORK=off go list -m github.com/GoCodeAlone/workflow",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf(".goreleaser.yaml release validation hook missing %q", want)
+		}
+	}
+
+	dir := filepath.Join(t.TempDir(), "dist", "release")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir release dir: %v", err)
+	}
+	for _, name := range []string{"plugin.json", "plugin.contracts.json"} {
+		data, err := os.ReadFile(filepath.Join(repoRoot, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o644); err != nil {
+			t.Fatalf("write release %s: %v", name, err)
+		}
+	}
+	for _, name := range []string{"plugin.json", "plugin.contracts.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("release validation directory missing %s: %v", name, err)
+		}
+	}
+}
+
+type archiveFileSpec struct {
+	Src string
+	Dst string
+}
+
+func (s *archiveFileSpec) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		s.Src = value.Value
+		s.Dst = value.Value
+		return nil
+	case yaml.MappingNode:
+		var raw struct {
+			Src string `yaml:"src"`
+			Dst string `yaml:"dst"`
+		}
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		s.Src = raw.Src
+		s.Dst = raw.Dst
+		if s.Dst == "" {
+			s.Dst = raw.Src
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported archive file spec kind %v", value.Kind)
+	}
+}
+
+func containsArchiveFile(values []archiveFileSpec, src, dst string) bool {
 	for _, value := range values {
-		if value == want {
+		if value.Src == src && value.Dst == dst {
 			return true
 		}
 	}
 	return false
 }
 
-func writeTestArchive(repoRoot, archivePath string, files []string) error {
+func writeTestArchive(repoRoot, archivePath string, files []archiveFileSpec, overrides map[string][]byte) error {
 	out, err := os.Create(archivePath)
 	if err != nil {
 		return err
@@ -141,12 +212,16 @@ func writeTestArchive(repoRoot, archivePath string, files []string) error {
 	defer gz.Close()
 	tw := tar.NewWriter(gz)
 	defer tw.Close()
-	for _, name := range files {
-		data, err := os.ReadFile(filepath.Join(repoRoot, name))
-		if err != nil {
-			return err
+	for _, file := range files {
+		data, ok := overrides[file.Src]
+		if !ok {
+			var err error
+			data, err = os.ReadFile(filepath.Join(repoRoot, file.Src))
+			if err != nil {
+				return err
+			}
 		}
-		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o644, Size: int64(len(data))}); err != nil {
+		if err := tw.WriteHeader(&tar.Header{Name: file.Dst, Mode: 0o644, Size: int64(len(data))}); err != nil {
 			return err
 		}
 		if _, err := tw.Write(data); err != nil {


### PR DESCRIPTION
## Summary
- generate release-mutated plugin.json under ignored dist/release instead of mutating tracked plugin.json
- copy plugin.contracts.json beside the generated release manifest before strict validation
- update GoReleaser archive config from deprecated archives.builds to ids
- add release manifest/archive tests for the generated dist/release shape

## Validation
- GOWORK=off go test ./...
- GOWORK=off go run github.com/goreleaser/goreleaser/v2@latest check
- antagonistic review: CLEAR