### PR TITLE
fix(release): generate manifests outside dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/plugins/
 .worktrees/
 dist/
+.release/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,9 +4,9 @@ project_name: workflow-plugin-digitalocean
 
 before:
   hooks:
-    - "sh -c \"mkdir -p dist/release && cp plugin.json dist/release/plugin.json && cp plugin.contracts.json dist/release/plugin.contracts.json && sed -i.bak 's/\\\"version\\\": \\\".*\\\"/\\\"version\\\": \\\"{{ .Version }}\\\"/' dist/release/plugin.json && rm -f dist/release/plugin.json.bak\""
-    - "sh -c \"sed -i.bak 's|/releases/download/v[^/]*/|/releases/download/{{ .Tag }}/|g' dist/release/plugin.json && rm -f dist/release/plugin.json.bak\""
-    - "sh -c \"export GOPRIVATE=github.com/GoCodeAlone/*; WFCTL_VERSION=$(GOWORK=off go list -m github.com/GoCodeAlone/workflow | awk '{print $2}') && GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION} plugin validate --file dist/release/plugin.json --strict-contracts\""
+    - "sh -c \"rm -rf .release && mkdir -p .release && cp plugin.json .release/plugin.json && cp plugin.contracts.json .release/plugin.contracts.json && sed -i.bak 's/\\\"version\\\": \\\".*\\\"/\\\"version\\\": \\\"{{ .Version }}\\\"/' .release/plugin.json && rm -f .release/plugin.json.bak\""
+    - "sh -c \"sed -i.bak 's|/releases/download/v[^/]*/|/releases/download/{{ .Tag }}/|g' .release/plugin.json && rm -f .release/plugin.json.bak\""
+    - "sh -c \"export GOPRIVATE=github.com/GoCodeAlone/*; WFCTL_VERSION=$(GOWORK=off go list -m github.com/GoCodeAlone/workflow | awk '{print $2}') && GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@${WFCTL_VERSION} plugin validate --file .release/plugin.json --strict-contracts\""
 
 builds:
   - id: workflow-plugin-digitalocean
@@ -31,7 +31,7 @@ archives:
     formats: [tar.gz]
     name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
     files:
-      - src: dist/release/plugin.json
+      - src: .release/plugin.json
         dst: plugin.json
       - plugin.contracts.json
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -80,7 +80,7 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 	if len(archive.IDs) != 1 || archive.IDs[0] != build.ID {
 		t.Fatalf("archive ids = %v, want [%s]", archive.IDs, build.ID)
 	}
-	if !containsArchiveFile(archive.Files, "dist/release/plugin.json", "plugin.json") {
+	if !containsArchiveFile(archive.Files, ".release/plugin.json", "plugin.json") {
 		t.Fatalf("archive files = %v, want plugin.json", archive.Files)
 	}
 	if !containsArchiveFile(archive.Files, "plugin.contracts.json", "plugin.contracts.json") {
@@ -116,7 +116,7 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 
 	archivePath := filepath.Join(t.TempDir(), "plugin.tar.gz")
 	if err := writeTestArchive(repoRoot, archivePath, archive.Files, map[string][]byte{
-		"dist/release/plugin.json": manifestData,
+		".release/plugin.json": manifestData,
 	}); err != nil {
 		t.Fatalf("write test archive: %v", err)
 	}
@@ -133,9 +133,10 @@ func TestGoReleaserReleaseManifestValidationDirectory(t *testing.T) {
 	}
 	text := string(releaseData)
 	for _, want := range []string{
-		"cp plugin.json dist/release/plugin.json",
-		"cp plugin.contracts.json dist/release/plugin.contracts.json",
-		"--file dist/release/plugin.json --strict-contracts",
+		"rm -rf .release",
+		"cp plugin.json .release/plugin.json",
+		"cp plugin.contracts.json .release/plugin.contracts.json",
+		"--file .release/plugin.json --strict-contracts",
 		"WFCTL_VERSION=$(GOWORK=off go list -m github.com/GoCodeAlone/workflow",
 	} {
 		if !strings.Contains(text, want) {
@@ -143,7 +144,7 @@ func TestGoReleaserReleaseManifestValidationDirectory(t *testing.T) {
 		}
 	}
 
-	dir := filepath.Join(t.TempDir(), "dist", "release")
+	dir := filepath.Join(t.TempDir(), ".release")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir release dir: %v", err)
 	}
@@ -160,6 +161,10 @@ func TestGoReleaserReleaseManifestValidationDirectory(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
 			t.Fatalf("release validation directory missing %s: %v", name, err)
 		}
+	}
+
+	if strings.Contains(text, "dist/release") {
+		t.Fatal(".goreleaser.yaml must not generate manifests under dist; GoReleaser requires dist to remain empty before build")
 	}
 }
 


### PR DESCRIPTION
## Summary
- move generated release manifest/contracts from `dist/release` to ignored `.release`
- keep GoReleaser `dist` empty before the release build starts
- add a regression test forbidding `dist/release` generation

## Validation
- GOWORK=off go test ./...
- GOWORK=off go run github.com/goreleaser/goreleaser/v2@latest check
- GOWORK=off go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish
- plain-clone build at 5dfa523 reports `vcs.modified=false`
- antagonistic review: CLEAR