### PR TITLE
fix(app): avoid mixed App Platform route modes

### DIFF
--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -87,6 +87,11 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 	}
 	services := append([]*godo.AppServiceSpec{svc}, sidecars...)
 
+	ingress := ingressFromConfig(cfg, name)
+	if ingress != nil && len(ingress.Rules) > 0 {
+		svc.Routes = nil
+	}
+
 	spec := &godo.AppSpec{
 		Name:                         name,
 		Region:                       region,
@@ -96,7 +101,7 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		StaticSites:                  staticSitesFromConfig(cfg),
 		Domains:                      domainsFromConfig(cfg),
 		Alerts:                       appAlertsFromConfig(cfg),
-		Ingress:                      ingressFromConfig(cfg, name),
+		Ingress:                      ingress,
 		Egress:                       egressFromConfig(cfg),
 		Maintenance:                  maintenanceFromConfig(cfg),
 		Vpc:                          vpcFromConfig(cfg),

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -26,6 +26,11 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 
 	httpPort, httpPortSet := intFromConfig(cfg, "http_port", 8080)
 	instanceCount, _ := intFromConfig(cfg, "instance_count", 1)
+	ingress := ingressFromConfig(cfg, name)
+	serviceRoutes := routesFromConfig(cfg)
+	if ingress != nil && len(ingress.Rules) > 0 {
+		serviceRoutes = nil
+	}
 
 	svc := &godo.AppServiceSpec{
 		Name:                name,
@@ -40,7 +45,7 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		InstanceSizeSlug:    instanceSizeSlugFromConfig(cfg),
 		Protocol:            httpPortProtocolFromConfig(cfg),
 		InternalPorts:       internalPortsFromConfig(cfg),
-		Routes:              routesFromConfig(cfg),
+		Routes:              serviceRoutes,
 		HealthCheck:         serviceHealthCheckFromConfig(cfg),
 		LivenessHealthCheck: livenessHealthCheckFromConfig(cfg),
 		CORS:                corsFromConfig(cfg),
@@ -86,11 +91,6 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		return nil, fmt.Errorf("app platform sidecars: %w", err)
 	}
 	services := append([]*godo.AppServiceSpec{svc}, sidecars...)
-
-	ingress := ingressFromConfig(cfg, name)
-	if ingress != nil && len(ingress.Rules) > 0 {
-		svc.Routes = nil
-	}
 
 	spec := &godo.AppSpec{
 		Name:                         name,

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -613,9 +613,8 @@ func TestBuildAppSpec_Routes(t *testing.T) {
 		},
 	}
 	spec := buildSpecViaCreate(t, cfg)
-	routes := spec.Services[0].Routes
-	if len(routes) != 0 {
-		t.Fatalf("service Routes = %+v, want nil when top-level ingress rules are emitted", routes)
+	if spec.Services[0].Routes != nil {
+		t.Fatalf("service Routes = %+v, want nil when top-level ingress rules are emitted", spec.Services[0].Routes)
 	}
 	if spec.Ingress == nil || len(spec.Ingress.Rules) != 2 {
 		t.Fatalf("expected 2 ingress rules from routes, got %+v", spec.Ingress)

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -614,14 +614,8 @@ func TestBuildAppSpec_Routes(t *testing.T) {
 	}
 	spec := buildSpecViaCreate(t, cfg)
 	routes := spec.Services[0].Routes
-	if len(routes) != 2 {
-		t.Fatalf("expected 2 routes, got %d", len(routes))
-	}
-	if routes[0].Path != "/api" || !routes[0].PreservePathPrefix {
-		t.Errorf("route[0] = %+v, want path=/api preserve=true", routes[0])
-	}
-	if routes[1].Path != "/health" {
-		t.Errorf("route[1].Path = %q, want /health", routes[1].Path)
+	if len(routes) != 0 {
+		t.Fatalf("service Routes = %+v, want nil when top-level ingress rules are emitted", routes)
 	}
 	if spec.Ingress == nil || len(spec.Ingress.Rules) != 2 {
 		t.Fatalf("expected 2 ingress rules from routes, got %+v", spec.Ingress)


### PR DESCRIPTION
## Summary
- clear per-service App Platform routes when canonical routes are emitted as top-level ingress rules
- keep canonical route output on the supported ingress path
- update route builder coverage to reject mixed route modes

## Why
DigitalOcean rejects app specs that combine component routing with App Ingress routing. workflow-compute staging hit this with v1.0.10 while creating `wfcompute-gh-provider-stg`.

## Verification
- `GOWORK=off go test ./internal/drivers -run TestBuildAppSpec_Routes -count=1` failed before the fix
- `GOWORK=off go test ./internal/drivers -run 'TestBuildAppSpec_Routes|TestBuildAppSpec_Ingress' -count=1`\n- `GOWORK=off go test ./...`\n- antagonistic/security review: CLEAR\n