### PR TITLE
feat(steps): add step.iac_scale — closes #108

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -152,6 +152,15 @@ func (p *DOProvider) AppsClient() steps.IaCLogsClient {
 	return p.client.Apps
 }
 
+// AppsScaleClient returns the godo Apps service as steps.AppsScaleClient for
+// use by step.iac_scale. Returns nil when Initialize has not been called.
+func (p *DOProvider) AppsScaleClient() steps.AppsScaleClient {
+	if p.client == nil {
+		return nil
+	}
+	return p.client.Apps
+}
+
 // ResourceDriver returns the driver for the given resource type.
 func (p *DOProvider) ResourceDriver(resourceType string) (interfaces.ResourceDriver, error) {
 	d, ok := p.drivers[resourceType]

--- a/internal/step_router.go
+++ b/internal/step_router.go
@@ -83,23 +83,33 @@ func (s *doIaCServer) GetContractRegistry(_ context.Context, _ *emptypb.Empty) (
 
 // GetStepTypes returns the step type names provided by this plugin.
 func (s *doIaCServer) GetStepTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {
-	return &pb.TypeList{Types: []string{"step.iac_logs"}}, nil
+	return &pb.TypeList{Types: []string{
+		"step.iac_logs",
+		"step.iac_scale",
+	}}, nil
 }
 
-// CreateStep instantiates a step.iac_logs instance for the given config and
+// CreateStep instantiates a step instance for the given type and config, then
 // stores it under a newly-allocated handle ID.
 func (s *doIaCServer) CreateStep(_ context.Context, req *pb.CreateStepRequest) (*pb.HandleResponse, error) {
-	if req.GetType() != "step.iac_logs" {
-		return &pb.HandleResponse{Error: fmt.Sprintf("unknown step type %q", req.GetType())}, nil
-	}
-
 	cfg := make(map[string]any)
 	if req.GetConfig() != nil {
 		cfg = req.GetConfig().AsMap()
 	}
 
-	factory := steps.NewIaCLogsFactory(s.provider.AppsClient())
-	inst, err := factory.CreateStep(req.GetType(), req.GetName(), cfg)
+	var inst sdk.StepInstance
+	var err error
+
+	switch req.GetType() {
+	case "step.iac_logs":
+		factory := steps.NewIaCLogsFactory(s.provider.AppsClient())
+		inst, err = factory.CreateStep(req.GetType(), req.GetName(), cfg)
+	case "step.iac_scale":
+		inst = steps.NewIaCScaleStep(req.GetName(), s.provider.AppsScaleClient())
+	default:
+		return &pb.HandleResponse{Error: fmt.Sprintf("unknown step type %q", req.GetType())}, nil
+	}
+
 	if err != nil {
 		return &pb.HandleResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
 	}

--- a/internal/steps/iac_scale.go
+++ b/internal/steps/iac_scale.go
@@ -106,8 +106,11 @@ func (s *iacScaleStep) Execute(
 	// No-op path: count is already at target — skip the Update call entirely.
 	if previousCount == targetCount {
 		return &sdk.StepResult{Output: map[string]any{
-			"previous_count": previousCount,
-			"new_count":      previousCount,
+			// Use float64 for numeric outputs: structpb.NewStruct (used by step_router.go
+			// to encode the output over gRPC) only supports float64 for numbers; int64
+			// values cause "encode step output" marshalling errors.
+			"previous_count": float64(previousCount),
+			"new_count":      float64(previousCount),
 			"app_id":         appID,
 			"deployment_id":  "",
 		}}, nil
@@ -132,8 +135,10 @@ func (s *iacScaleStep) Execute(
 	}
 
 	return &sdk.StepResult{Output: map[string]any{
-		"previous_count": previousCount,
-		"new_count":      targetCount,
+		// Use float64 for numeric outputs: structpb.NewStruct only supports float64
+		// for numbers; int64 values cause marshalling errors over gRPC.
+		"previous_count": float64(previousCount),
+		"new_count":      float64(targetCount),
 		"app_id":         appID,
 		"deployment_id":  deploymentID,
 	}}, nil
@@ -203,13 +208,15 @@ func findServiceCount(spec *godo.AppSpec, componentName string) (int64, bool) {
 }
 
 // setServiceCount replaces the named service entry in spec.Services with a
-// shallow copy whose InstanceCount is set to count. Using a copy avoids
-// mutating the pointer owned by the godo Get response in-place, which
-// prevents aliasing surprises if the caller reuses the original app object.
+// shallow copy of the AppServiceSpec struct whose InstanceCount is set to count.
+// The slice element (spec.Services[i]) is replaced with a new pointer to the
+// copied struct, so the original AppServiceSpec that was pointed to by the godo
+// Get response is not mutated — only the slice entry is updated.
 func setServiceCount(spec *godo.AppSpec, componentName string, count int64) {
 	for i, svc := range spec.Services {
 		if svc.Name == componentName {
-			// Shallow-copy the spec to avoid mutating the Get-response pointer.
+			// Copy the AppServiceSpec struct (not the spec itself) so the
+			// original struct pointed to by the Get response is not modified.
 			copied := *svc
 			copied.InstanceCount = count
 			spec.Services[i] = &copied

--- a/internal/steps/iac_scale.go
+++ b/internal/steps/iac_scale.go
@@ -1,0 +1,255 @@
+// Package steps contains pipeline step implementations for the workflow-plugin-digitalocean
+// external plugin. Each step provides a named pipeline step type (e.g. step.iac_scale)
+// that operators reference in their workflow YAML configs.
+package steps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+
+	"github.com/digitalocean/godo"
+
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+// AppsScaleClient is the subset of the godo Apps service used by IaCScaleStep.
+// Injecting this interface allows tests to provide a fake without starting a
+// real godo client.
+type AppsScaleClient interface {
+	Get(ctx context.Context, appID string) (*godo.App, *godo.Response, error)
+	Update(ctx context.Context, appID string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error)
+}
+
+// iacScaleStep implements step.iac_scale — scales a single App Platform service
+// component to a target instance_count without a full step.iac_apply rerun.
+//
+// Config schema (all values may come from pipeline current or config):
+//
+//	app_id         string (required) — DO App Platform app UUID
+//	component_name string (required) — name of the service component to scale
+//	instance_count int    (required) — target instance count (>= 0)
+//
+// Outputs:
+//
+//	previous_count  int64  — count before this scale operation
+//	new_count       int64  — count after this scale operation
+//	app_id          string — app UUID
+//	deployment_id   string — InProgressDeployment.ID returned by godo after
+//	                         the Apps.Update call; empty on no-op (count unchanged)
+type iacScaleStep struct {
+	name   string
+	client AppsScaleClient
+}
+
+// NewIaCScaleStep creates a step.iac_scale instance backed by the provided
+// AppsScaleClient. The production path injects the real godo Apps client; tests
+// inject a fake.
+func NewIaCScaleStep(name string, client AppsScaleClient) sdk.StepInstance {
+	return &iacScaleStep{name: name, client: client}
+}
+
+// Execute implements sdk.StepInstance.
+//
+// Inputs are merged from current (step outputs of prior steps) and config (the
+// step's static YAML config), with config taking precedence for required fields.
+func (s *iacScaleStep) Execute(
+	ctx context.Context,
+	_ map[string]any,
+	_ map[string]map[string]any,
+	current map[string]any,
+	_ map[string]any,
+	config map[string]any,
+) (*sdk.StepResult, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("step %s: DigitalOcean client not initialized (plugin not yet configured via iac.provider)", s.name)
+	}
+	merged := mergeInputs(current, config)
+
+	appID, _ := merged["app_id"].(string)
+	if appID == "" {
+		return nil, fmt.Errorf("step %s: app_id is required", s.name)
+	}
+	componentName, _ := merged["component_name"].(string)
+	if componentName == "" {
+		return nil, fmt.Errorf("step %s: component_name is required", s.name)
+	}
+
+	// Accept both float64 (JSON/YAML default numeric type) and int variants.
+	targetCount, err := intFromAny(merged["instance_count"])
+	if err != nil {
+		return nil, fmt.Errorf("step %s: instance_count: %w", s.name, err)
+	}
+	if targetCount < 0 {
+		return nil, fmt.Errorf("step %s: instance_count must be >= 0, got %d", s.name, targetCount)
+	}
+
+	// Fetch the full current AppSpec — we must round-trip the complete spec to
+	// avoid clobbering unrelated services, jobs, workers, domains, etc.
+	app, _, err := s.client.Get(ctx, appID)
+	if err != nil {
+		return nil, fmt.Errorf("step %s: get app %q: %w", s.name, appID, wrapGodoErr(err))
+	}
+	if app.Spec == nil {
+		return nil, fmt.Errorf("step %s: app %q has no spec", s.name, appID)
+	}
+
+	// Locate the named service component.
+	previousCount, found := findServiceCount(app.Spec, componentName)
+	if !found {
+		return nil, fmt.Errorf("step %s: component %q not found in app %q (available services: %s)",
+			s.name, componentName, appID, serviceNames(app.Spec))
+	}
+
+	// No-op path: count is already at target — skip the Update call entirely.
+	if previousCount == targetCount {
+		return &sdk.StepResult{Output: map[string]any{
+			"previous_count": previousCount,
+			"new_count":      previousCount,
+			"app_id":         appID,
+			"deployment_id":  "",
+		}}, nil
+	}
+
+	// Mutate a copy of the target component only; leave all other services
+	// unchanged and avoid mutating the pointer returned by the Get response.
+	setServiceCount(app.Spec, componentName, targetCount)
+
+	// Apps.Update with the full spec triggers a new deployment.
+	// A 409 means another deployment is in progress — surface it with a
+	// clear message so operators know to wait or check for concurrent apply.
+	updated, _, err := s.client.Update(ctx, appID, &godo.AppUpdateRequest{Spec: app.Spec})
+	if err != nil {
+		return nil, fmt.Errorf("step %s: scale app %q component %q to %d: %w",
+			s.name, appID, componentName, targetCount, wrapGodoErr(err))
+	}
+
+	deploymentID := ""
+	if updated != nil && updated.InProgressDeployment != nil {
+		deploymentID = updated.InProgressDeployment.ID
+	}
+
+	return &sdk.StepResult{Output: map[string]any{
+		"previous_count": previousCount,
+		"new_count":      targetCount,
+		"app_id":         appID,
+		"deployment_id":  deploymentID,
+	}}, nil
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// mergeInputs returns a merged map where config values take precedence over
+// current (step output) values. Both may be nil.
+func mergeInputs(current, config map[string]any) map[string]any {
+	merged := make(map[string]any, len(current)+len(config))
+	for k, v := range current {
+		merged[k] = v
+	}
+	for k, v := range config {
+		merged[k] = v
+	}
+	return merged
+}
+
+// intFromAny converts float64 (JSON/YAML default), int, int64 to int64.
+// Returns an error when v is nil, a non-numeric type, or a fractional float.
+// instance_count values are always small (0–N), so overflow is not a concern
+// in practice; the range check is present for defense.
+func intFromAny(v any) (int64, error) {
+	switch t := v.(type) {
+	case float64:
+		if math.Trunc(t) != t {
+			return 0, fmt.Errorf("expected integer value, got fractional float %v", t)
+		}
+		if t < 0 || t > math.MaxInt32 {
+			return 0, fmt.Errorf("value %v out of valid range [0, %d]", t, math.MaxInt32)
+		}
+		return int64(t), nil
+	case float32:
+		tf := float64(t)
+		if math.Trunc(tf) != tf {
+			return 0, fmt.Errorf("expected integer value, got fractional float %v", t)
+		}
+		if tf < 0 || tf > math.MaxInt32 {
+			return 0, fmt.Errorf("value %v out of valid range [0, %d]", t, math.MaxInt32)
+		}
+		return int64(t), nil
+	case int:
+		return int64(t), nil
+	case int32:
+		return int64(t), nil
+	case int64:
+		return t, nil
+	case nil:
+		return 0, fmt.Errorf("value is nil (not provided)")
+	default:
+		return 0, fmt.Errorf("expected numeric type, got %T", v)
+	}
+}
+
+// findServiceCount returns the current InstanceCount for the named service
+// component. The second return value is false when no service with that name
+// exists in the spec.
+func findServiceCount(spec *godo.AppSpec, componentName string) (int64, bool) {
+	for _, svc := range spec.Services {
+		if svc.Name == componentName {
+			return svc.InstanceCount, true
+		}
+	}
+	return 0, false
+}
+
+// setServiceCount replaces the named service entry in spec.Services with a
+// shallow copy whose InstanceCount is set to count. Using a copy avoids
+// mutating the pointer owned by the godo Get response in-place, which
+// prevents aliasing surprises if the caller reuses the original app object.
+func setServiceCount(spec *godo.AppSpec, componentName string, count int64) {
+	for i, svc := range spec.Services {
+		if svc.Name == componentName {
+			// Shallow-copy the spec to avoid mutating the Get-response pointer.
+			copied := *svc
+			copied.InstanceCount = count
+			spec.Services[i] = &copied
+			return
+		}
+	}
+}
+
+// serviceNames returns a comma-separated list of service names in the spec for
+// error messages.
+func serviceNames(spec *godo.AppSpec) string {
+	if spec == nil || len(spec.Services) == 0 {
+		return "<none>"
+	}
+	names := make([]string, 0, len(spec.Services))
+	for _, svc := range spec.Services {
+		names = append(names, svc.Name)
+	}
+	result := ""
+	for i, n := range names {
+		if i > 0 {
+			result += ", "
+		}
+		result += n
+	}
+	return result
+}
+
+// wrapGodoErr converts a godo error to a human-readable error with a hint when
+// the status is 409 Conflict (concurrent deployment in progress). Uses
+// errors.As for robust classification so wrapped errors are handled correctly.
+func wrapGodoErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var resp *godo.ErrorResponse
+	if errors.As(err, &resp) {
+		if resp.Response != nil && resp.Response.StatusCode == http.StatusConflict {
+			return fmt.Errorf("concurrent update conflict (another deployment is in progress): %w", err)
+		}
+	}
+	return err
+}

--- a/internal/steps/iac_scale_test.go
+++ b/internal/steps/iac_scale_test.go
@@ -113,10 +113,10 @@ func TestIaCScale_ScaleUp(t *testing.T) {
 	if result.Output["app_id"] != "app-123" {
 		t.Errorf("app_id = %v, want app-123", result.Output["app_id"])
 	}
-	if result.Output["previous_count"] != int64(1) {
+	if result.Output["previous_count"] != float64(1) {
 		t.Errorf("previous_count = %v, want 1", result.Output["previous_count"])
 	}
-	if result.Output["new_count"] != int64(3) {
+	if result.Output["new_count"] != float64(3) {
 		t.Errorf("new_count = %v, want 3", result.Output["new_count"])
 	}
 	if result.Output["deployment_id"] != "dep-new" {
@@ -160,10 +160,10 @@ func TestIaCScale_ScaleDown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.Output["previous_count"] != int64(5) {
+	if result.Output["previous_count"] != float64(5) {
 		t.Errorf("previous_count = %v, want 5", result.Output["previous_count"])
 	}
-	if result.Output["new_count"] != int64(2) {
+	if result.Output["new_count"] != float64(2) {
 		t.Errorf("new_count = %v, want 2", result.Output["new_count"])
 	}
 }
@@ -191,10 +191,10 @@ func TestIaCScale_Idempotent(t *testing.T) {
 	if fake.lastUpdateReq != nil {
 		t.Error("Update should not be called when count is already at target")
 	}
-	if result.Output["previous_count"] != int64(2) {
+	if result.Output["previous_count"] != float64(2) {
 		t.Errorf("previous_count = %v, want 2", result.Output["previous_count"])
 	}
-	if result.Output["new_count"] != int64(2) {
+	if result.Output["new_count"] != float64(2) {
 		t.Errorf("new_count = %v, want 2", result.Output["new_count"])
 	}
 	if result.Output["deployment_id"] != "" {

--- a/internal/steps/iac_scale_test.go
+++ b/internal/steps/iac_scale_test.go
@@ -1,0 +1,435 @@
+package steps_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/digitalocean/godo"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/steps"
+)
+
+// fakeScaleClient is a minimal in-memory AppsScaleClient for unit tests.
+type fakeScaleClient struct {
+	getApp    *godo.App
+	getErr    error
+	updateApp *godo.App
+	updateErr error
+
+	// capture the request so tests can verify the spec sent to Update.
+	lastUpdateReq *godo.AppUpdateRequest
+}
+
+func (f *fakeScaleClient) Get(_ context.Context, _ string) (*godo.App, *godo.Response, error) {
+	return f.getApp, scaleOKResp(), f.getErr
+}
+
+func (f *fakeScaleClient) Update(_ context.Context, _ string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
+	f.lastUpdateReq = req
+	return f.updateApp, scaleOKResp(), f.updateErr
+}
+
+func scaleOKResp() *godo.Response {
+	return &godo.Response{Response: &http.Response{StatusCode: http.StatusOK}}
+}
+
+// makeScaleTestApp builds a minimal *godo.App with one service component.
+func makeScaleTestApp(appID, appName, componentName string, instanceCount int64) *godo.App {
+	return &godo.App{
+		ID: appID,
+		Spec: &godo.AppSpec{
+			Name: appName,
+			Services: []*godo.AppServiceSpec{
+				{
+					Name:          componentName,
+					InstanceCount: instanceCount,
+				},
+			},
+		},
+		ActiveDeployment: &godo.Deployment{
+			ID:    "dep-before",
+			Phase: godo.DeploymentPhase_Active,
+		},
+	}
+}
+
+// makeScaleTestAppMultiSvc builds a *godo.App with multiple service components.
+func makeScaleTestAppMultiSvc(appID, appName string, svcs []struct{ name string; count int64 }) *godo.App {
+	specs := make([]*godo.AppServiceSpec, 0, len(svcs))
+	for _, s := range svcs {
+		specs = append(specs, &godo.AppServiceSpec{
+			Name:          s.name,
+			InstanceCount: s.count,
+		})
+	}
+	return &godo.App{
+		ID: appID,
+		Spec: &godo.AppSpec{
+			Name:     appName,
+			Services: specs,
+		},
+		ActiveDeployment: &godo.Deployment{
+			ID:    "dep-before",
+			Phase: godo.DeploymentPhase_Active,
+		},
+	}
+}
+
+// TestIaCScale_ScaleUp verifies that scaling from 1→3 returns correct outputs.
+func TestIaCScale_ScaleUp(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-123", "my-app", "web", 1)
+	afterApp := &godo.App{
+		ID:   "app-123",
+		Spec: beforeApp.Spec,
+		ActiveDeployment: &godo.Deployment{
+			ID:    "dep-after",
+			Phase: godo.DeploymentPhase_Active,
+		},
+		InProgressDeployment: &godo.Deployment{
+			ID:    "dep-new",
+			Phase: godo.DeploymentPhase_Building,
+		},
+	}
+	fake := &fakeScaleClient{
+		getApp:    beforeApp,
+		updateApp: afterApp,
+	}
+
+	step := steps.NewIaCScaleStep("scale_up", fake)
+	result, err := step.Execute(context.Background(), nil, nil,
+		map[string]any{
+			"app_id": "app-123",
+		},
+		nil,
+		map[string]any{
+			"component_name": "web",
+			"instance_count": float64(3),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output["app_id"] != "app-123" {
+		t.Errorf("app_id = %v, want app-123", result.Output["app_id"])
+	}
+	if result.Output["previous_count"] != int64(1) {
+		t.Errorf("previous_count = %v, want 1", result.Output["previous_count"])
+	}
+	if result.Output["new_count"] != int64(3) {
+		t.Errorf("new_count = %v, want 3", result.Output["new_count"])
+	}
+	if result.Output["deployment_id"] != "dep-new" {
+		t.Errorf("deployment_id = %v, want dep-new", result.Output["deployment_id"])
+	}
+	// Verify only the target component was modified.
+	if fake.lastUpdateReq == nil {
+		t.Fatal("Update was not called")
+	}
+	for _, svc := range fake.lastUpdateReq.Spec.Services {
+		if svc.Name == "web" && svc.InstanceCount != 3 {
+			t.Errorf("service web InstanceCount = %d, want 3", svc.InstanceCount)
+		}
+	}
+}
+
+// TestIaCScale_ScaleDown verifies scaling from 5→2.
+func TestIaCScale_ScaleDown(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-456", "my-app", "api", 5)
+	afterApp := &godo.App{
+		ID:   "app-456",
+		Spec: beforeApp.Spec,
+		InProgressDeployment: &godo.Deployment{
+			ID:    "dep-scale-down",
+			Phase: godo.DeploymentPhase_Deploying,
+		},
+	}
+	fake := &fakeScaleClient{
+		getApp:    beforeApp,
+		updateApp: afterApp,
+	}
+
+	step := steps.NewIaCScaleStep("scale_down", fake)
+	result, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-456",
+			"component_name": "api",
+			"instance_count": float64(2),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Output["previous_count"] != int64(5) {
+		t.Errorf("previous_count = %v, want 5", result.Output["previous_count"])
+	}
+	if result.Output["new_count"] != int64(2) {
+		t.Errorf("new_count = %v, want 2", result.Output["new_count"])
+	}
+}
+
+// TestIaCScale_Idempotent verifies that scaling to the current count is a no-op
+// (Update is not called, previous_count == new_count).
+func TestIaCScale_Idempotent(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-789", "my-app", "worker", 2)
+	fake := &fakeScaleClient{
+		getApp: beforeApp,
+		// updateApp intentionally nil — test verifies Update is not called.
+	}
+
+	step := steps.NewIaCScaleStep("scale_noop", fake)
+	result, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-789",
+			"component_name": "worker",
+			"instance_count": float64(2),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.lastUpdateReq != nil {
+		t.Error("Update should not be called when count is already at target")
+	}
+	if result.Output["previous_count"] != int64(2) {
+		t.Errorf("previous_count = %v, want 2", result.Output["previous_count"])
+	}
+	if result.Output["new_count"] != int64(2) {
+		t.Errorf("new_count = %v, want 2", result.Output["new_count"])
+	}
+	if result.Output["deployment_id"] != "" {
+		t.Errorf("deployment_id should be empty for no-op, got %v", result.Output["deployment_id"])
+	}
+}
+
+// TestIaCScale_OnlyTargetComponentModified verifies that other services
+// in a multi-service app are NOT modified when scaling a specific component.
+func TestIaCScale_OnlyTargetComponentModified(t *testing.T) {
+	// Use a slice instead of map to ensure deterministic ordering.
+	beforeApp := makeScaleTestAppMultiSvc("app-multi", "multi-svc-app", []struct{ name string; count int64 }{
+		{"web", 1},
+		{"worker", 3},
+		{"api", 2},
+	})
+	afterApp := &godo.App{
+		ID:   "app-multi",
+		Spec: beforeApp.Spec,
+		InProgressDeployment: &godo.Deployment{
+			ID:    "dep-multi",
+			Phase: godo.DeploymentPhase_Building,
+		},
+	}
+	fake := &fakeScaleClient{
+		getApp:    beforeApp,
+		updateApp: afterApp,
+	}
+
+	step := steps.NewIaCScaleStep("scale_web_only", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-multi",
+			"component_name": "web",
+			"instance_count": float64(5),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fake.lastUpdateReq == nil {
+		t.Fatal("Update was not called")
+	}
+	for _, svc := range fake.lastUpdateReq.Spec.Services {
+		switch svc.Name {
+		case "web":
+			if svc.InstanceCount != 5 {
+				t.Errorf("web InstanceCount = %d, want 5", svc.InstanceCount)
+			}
+		case "worker":
+			if svc.InstanceCount != 3 {
+				t.Errorf("worker InstanceCount = %d, want 3 (must not change)", svc.InstanceCount)
+			}
+		case "api":
+			if svc.InstanceCount != 2 {
+				t.Errorf("api InstanceCount = %d, want 2 (must not change)", svc.InstanceCount)
+			}
+		}
+	}
+}
+
+// TestIaCScale_SpecCopyDoesNotMutateOriginal verifies that setServiceCount copies
+// the AppServiceSpec struct so the original AppServiceSpec pointed to by the Get
+// response is not mutated (only the slice element is replaced with a new pointer).
+func TestIaCScale_SpecCopyDoesNotMutateOriginal(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-copy", "my-app", "web", 1)
+	// Capture the original AppServiceSpec pointer before Execute — not the slice element.
+	// The slice element (Services[0]) will be updated to point to a new copy;
+	// the original struct pointed to by originalSvc must remain unchanged.
+	originalSvc := beforeApp.Spec.Services[0]
+	originalCount := originalSvc.InstanceCount
+
+	// afterApp uses a distinct spec (not beforeApp.Spec) so Update and Get
+	// don't share the same *AppSpec pointer.
+	afterApp := &godo.App{
+		ID: "app-copy",
+		Spec: &godo.AppSpec{
+			Name: "my-app",
+			Services: []*godo.AppServiceSpec{
+				{Name: "web", InstanceCount: 4},
+			},
+		},
+		InProgressDeployment: &godo.Deployment{ID: "dep-copy"},
+	}
+	fake := &fakeScaleClient{getApp: beforeApp, updateApp: afterApp}
+
+	step := steps.NewIaCScaleStep("scale_copy", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-copy",
+			"component_name": "web",
+			"instance_count": float64(4),
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The original AppServiceSpec struct (not the slice element) must not have
+	// been mutated. setServiceCount copies the struct and replaces the slice
+	// element pointer; the original struct pointed to by originalSvc is untouched.
+	if originalSvc.InstanceCount != originalCount {
+		t.Errorf("original AppServiceSpec struct was mutated: got %d, want %d",
+			originalSvc.InstanceCount, originalCount)
+	}
+}
+
+// TestIaCScale_InvalidComponentName verifies that a component_name not found
+// in the app's services returns a clear error.
+func TestIaCScale_InvalidComponentName(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-notfound", "my-app", "web", 1)
+	fake := &fakeScaleClient{getApp: beforeApp}
+
+	step := steps.NewIaCScaleStep("scale_bad_comp", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-notfound",
+			"component_name": "nonexistent-service",
+			"instance_count": float64(3),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for unknown component_name")
+	}
+}
+
+// TestIaCScale_NegativeInstanceCount verifies that instance_count < 0 is rejected.
+func TestIaCScale_NegativeInstanceCount(t *testing.T) {
+	fake := &fakeScaleClient{}
+
+	step := steps.NewIaCScaleStep("scale_negative", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-any",
+			"component_name": "web",
+			"instance_count": float64(-1),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for negative instance_count")
+	}
+}
+
+// TestIaCScale_FractionalInstanceCount verifies that a fractional float
+// instance_count (e.g. 2.9) is rejected rather than silently truncated.
+func TestIaCScale_FractionalInstanceCount(t *testing.T) {
+	fake := &fakeScaleClient{}
+
+	step := steps.NewIaCScaleStep("scale_fractional", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-any",
+			"component_name": "web",
+			"instance_count": float64(2.9),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for fractional instance_count")
+	}
+}
+
+// TestIaCScale_MissingAppID verifies that missing app_id is rejected.
+func TestIaCScale_MissingAppID(t *testing.T) {
+	fake := &fakeScaleClient{}
+
+	step := steps.NewIaCScaleStep("scale_no_appid", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"component_name": "web",
+			"instance_count": float64(2),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for missing app_id")
+	}
+}
+
+// TestIaCScale_MissingComponentName verifies that missing component_name is rejected.
+func TestIaCScale_MissingComponentName(t *testing.T) {
+	fake := &fakeScaleClient{}
+
+	step := steps.NewIaCScaleStep("scale_no_comp", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-any",
+			"instance_count": float64(2),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for missing component_name")
+	}
+}
+
+// TestIaCScale_NilClient verifies that Execute with a nil client returns a
+// clear initialization error instead of panicking.
+func TestIaCScale_NilClient(t *testing.T) {
+	step := steps.NewIaCScaleStep("scale_nil", nil)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-any",
+			"component_name": "web",
+			"instance_count": float64(2),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for nil client")
+	}
+}
+
+// TestIaCScale_GodoConflict verifies that a 409 Conflict from godo (concurrent update)
+// is propagated with a clear error message.
+func TestIaCScale_GodoConflict(t *testing.T) {
+	beforeApp := makeScaleTestApp("app-409", "my-app", "web", 1)
+	fake := &fakeScaleClient{
+		getApp: beforeApp,
+		updateErr: &godo.ErrorResponse{
+			Response: &http.Response{StatusCode: http.StatusConflict},
+			Message:  "another deployment is already in progress",
+		},
+	}
+
+	step := steps.NewIaCScaleStep("scale_409", fake)
+	_, err := step.Execute(context.Background(), nil, nil, nil, nil,
+		map[string]any{
+			"app_id":         "app-409",
+			"component_name": "web",
+			"instance_count": float64(2),
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error for 409 conflict")
+	}
+	if msg := err.Error(); len(msg) == 0 {
+		t.Fatal("error message should not be empty")
+	}
+}
+
+// Ensure fakeScaleClient satisfies the AppsScaleClient interface.
+var _ steps.AppsScaleClient = (*fakeScaleClient)(nil)

--- a/plugin.contracts.json
+++ b/plugin.contracts.json
@@ -13,6 +13,14 @@
       "mode": "strict",
       "input": "workflow.plugins.digitalocean.IacLogsRequest",
       "output": "workflow.plugins.digitalocean.IacLogsResponse"
+    },
+    {
+      "kind": "step",
+      "type": "step.iac_scale",
+      "mode": "strict",
+      "config": "workflow.plugins.digitalocean.IacScaleConfig",
+      "input": "workflow.plugins.digitalocean.IacScaleInput",
+      "output": "workflow.plugins.digitalocean.IacScaleOutput"
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -38,7 +38,7 @@
   "capabilities": {
     "configProvider": false,
     "moduleTypes": ["iac.provider"],
-    "stepTypes": ["step.iac_logs"],
+    "stepTypes": ["step.iac_logs", "step.iac_scale"],
     "triggerTypes": [],
     "iacProvider": {
       "name": "digitalocean",


### PR DESCRIPTION
## Summary

- Adds \`step.iac_scale\` pipeline step that scales a single App Platform service component to a target \`instance_count\` without a full \`step.iac_apply\` rerun (closes migration GAP from workflow#617 \`step.do_scale\` removal).
- Per-component targeting: only the named \`component_name\` service has its \`InstanceCount\` mutated; all other services/jobs/workers/routes are preserved intact via a full spec round-trip.
- Extends the \`step_router.go\` architecture introduced in #110 (\`step.iac_logs\`): \`doIaCServer\` now handles \`step.iac_scale\` alongside \`step.iac_logs\` via the embedded \`stepRegistry\`; the plugin still uses \`sdk.ServeIaCPlugin\` as entrypoint.
- 12 unit tests; all 168 existing tests continue to pass; \`go test -race\` clean.

## Files changed

| File | Change |
|------|--------|
| \`internal/steps/iac_scale.go\` | New step implementation + helpers; calls \`godo Apps.Get\` + \`Apps.Update\` with per-component copy mutation; 409 Conflict surfaced with clear message; no-op path skips Update when count unchanged |
| \`internal/steps/iac_scale_test.go\` | 12 unit tests: scale-up, scale-down, idempotent, multi-service isolation, spec-copy mutation guard, invalid component name, negative count, fractional count, missing required fields, nil client, 409 conflict |
| \`internal/step_router.go\` | Added \`step.iac_scale\` to \`GetStepTypes\` and \`CreateStep\` dispatch |
| \`internal/provider.go\` | Added \`AppsScaleClient()\` accessor returning the godo Apps client as \`steps.AppsScaleClient\` |
| \`plugin.json\` | \`capabilities.stepTypes\` now includes \`"step.iac_scale"\` |
| \`plugin.contracts.json\` | Added strict contract descriptor for \`step.iac_scale\` |

## Step config schema

\`\`\`yaml
- type: step.iac_scale
  name: scale_web
  config:
    app_id: "{{ outputs.deploy.app_id }}"    # DO App Platform app UUID
    component_name: web                       # service component to scale
    instance_count: 3                         # target count (>= 0)
\`\`\`

## Outputs

| Key | Type | Description |
|-----|------|-------------|
| \`previous_count\` | float64 | count before scaling |
| \`new_count\` | float64 | count after scaling |
| \`app_id\` | string | app UUID |
| \`deployment_id\` | string | InProgressDeployment.ID from godo; empty on no-op |

## Test plan

- [x] \`go test -race ./internal/steps/... -run TestIaCScale -v\` — all 12 pass
- [x] \`go test -race ./... -count=1\` — all 168 tests pass
- [x] \`go build ./...\` — clean
- [x] \`wfctl plugin validate --file plugin.json --strict-contracts\` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)