### PR TITLE
feat(steps): add step.iac_logs pipeline step

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.51.2
+	github.com/GoCodeAlone/workflow v0.51.7
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.2

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,10 @@ github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQT
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
 github.com/GoCodeAlone/workflow v0.51.2 h1:TXnb3L+HUAU+eUp25Nev1Fj6PBuKK7NtMkAumTTVx1Y=
 github.com/GoCodeAlone/workflow v0.51.2/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
+github.com/GoCodeAlone/workflow v0.51.6 h1:jN/cAsCoIcwvHdMAbdhNfTIDiYtN1W+sd87aWS4DP0I=
+github.com/GoCodeAlone/workflow v0.51.6/go.mod h1:5dh9esKq48kH4zKWjccXmyOirWL+T+YzfLclzhdRIV4=
+github.com/GoCodeAlone/workflow v0.51.7 h1:+81UNlLQPfnB6hwncWM6DPHHmonLoiqBL0YGQ6OW9g4=
+github.com/GoCodeAlone/workflow v0.51.7/go.mod h1:5dh9esKq48kH4zKWjccXmyOirWL+T+YzfLclzhdRIV4=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=

--- a/internal/iacserver.go
+++ b/internal/iacserver.go
@@ -41,6 +41,11 @@ import (
 // the SDK type-assert succeed when only some of the optional methods are
 // overridden — though doIaCServer overrides every one for parity with the
 // underlying *DOProvider's interface coverage.
+//
+// doIaCServer also implements pb.PluginServiceServer (step-related methods)
+// so the workflow SDK (v0.51.6+) can auto-register it as the PluginService,
+// enabling step.iac_logs and any future step types to be served alongside
+// the typed IaC contract on the same gRPC connection. See step_router.go.
 type doIaCServer struct {
 	pb.UnimplementedIaCProviderRequiredServer
 	pb.UnimplementedIaCProviderEnumeratorServer
@@ -55,8 +60,19 @@ type doIaCServer struct {
 	// dispatch methods are declared in resourcedriver_server.go
 	// (Task 11 of the strict-contracts force-cutover plan).
 	pb.UnimplementedResourceDriverServer
+	// pb.UnimplementedPluginServiceServer satisfies the
+	// mustEmbedUnimplementedPluginServiceServer() forward-compat
+	// requirement on pb.PluginServiceServer. All PluginService methods
+	// that doIaCServer actually handles are overridden in step_router.go;
+	// remaining methods fall back to the Unimplemented stubs here.
+	pb.UnimplementedPluginServiceServer
 
 	provider *DOProvider
+
+	// stepRegistry holds the embedded step management state (instances map,
+	// grpcSrv ref, and mu) used by the pb.PluginServiceServer implementation
+	// in step_router.go.
+	stepRegistry
 }
 
 // newDOIaCServer constructs a typed-IaC server backed by the given

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/steps"
 	"github.com/GoCodeAlone/workflow/iac/wfctlhelpers"
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/GoCodeAlone/workflow/platform"
@@ -140,6 +141,15 @@ func (p *DOProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
 		{ResourceType: "infra.iam_role", Tier: 1, Operations: noScale},
 		{ResourceType: "infra.api_gateway", Tier: 3, Operations: noScale},
 	}
+}
+
+// AppsClient returns the godo Apps service for use by pipeline steps.
+// Returns nil when the provider has not yet been initialized (Initialize not called).
+func (p *DOProvider) AppsClient() steps.IaCLogsClient {
+	if p.client == nil {
+		return nil
+	}
+	return p.client.Apps
 }
 
 // ResourceDriver returns the driver for the given resource type.

--- a/internal/step_router.go
+++ b/internal/step_router.go
@@ -1,0 +1,261 @@
+package internal
+
+// step_router.go wires pipeline step support into doIaCServer so the DO
+// plugin can serve step.iac_logs alongside its typed IaC gRPC contract.
+//
+// Architecture:
+//
+//  doIaCServer now implements pb.PluginServiceServer (step-related methods +
+//  GetContractRegistry). The workflow SDK (v0.51.6+) auto-detects this in
+//  registerIaCServicesOnly and registers doIaCServer as the PluginService,
+//  bypassing the minimal iacPluginServiceBridge stub. This lets the host
+//  (wfctl ExternalPluginAdapter) call GetStepTypes / CreateStep /
+//  ExecuteStep / DestroyStep on the same gRPC connection used for IaC RPCs.
+//
+// GetContractRegistry delegates to sdk.BuildContractRegistry so typed-IaC
+// discovery (Enumerator, DriftDetector, etc.) keeps working alongside steps.
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/steps"
+)
+
+// compile-time guard: doIaCServer must satisfy pb.PluginServiceServer.
+var _ pb.PluginServiceServer = (*doIaCServer)(nil)
+
+// stepRegistry holds live step instances keyed by their handle ID.
+// doIaCServer embeds stepRegistry by value; it is initialised lazily on first
+// CreateStep call. mu guards both instances and grpcSrv.
+type stepRegistry struct {
+	mu        sync.RWMutex
+	instances map[string]sdk.StepInstance
+	grpcSrv   *grpc.Server // set by SetGRPCServer; used for GetContractRegistry
+}
+
+// SetGRPCServer stores the *grpc.Server reference so that GetContractRegistry
+// can call sdk.BuildContractRegistry. Called from cmd/plugin/main.go or test
+// wiring BEFORE any gRPC call is dispatched. In production the go-plugin
+// framework creates the server before calling iacGRPCPlugin.GRPCServer, so
+// there is no race: registration (and therefore SetGRPCServer) completes
+// before any host RPC arrives.
+func (s *doIaCServer) SetGRPCServer(srv *grpc.Server) {
+	s.mu.Lock()
+	s.grpcSrv = srv
+	s.mu.Unlock()
+}
+
+// ── pb.PluginServiceServer methods ──────────────────────────────────────────
+
+// GetManifest is intentionally unimplemented — the bridge guard does NOT get
+// hit (doIaCServer IS the PluginService), so the engine falls back to the
+// disk-loaded plugin.json via the Unimplemented gRPC status. This is the
+// same documented behaviour as iacPluginServiceBridge when ManifestProvider
+// is nil.
+func (s *doIaCServer) GetManifest(_ context.Context, _ *emptypb.Empty) (*pb.Manifest, error) {
+	return nil, status.Error(codes.Unimplemented, "manifest not embedded; engine falls back to disk plugin.json")
+}
+
+// GetContractRegistry returns the typed-IaC service registrations from the
+// underlying gRPC server. This is the critical forward-compat hook: without
+// it the host's ExternalPluginAdapter cannot discover IaC services.
+func (s *doIaCServer) GetContractRegistry(_ context.Context, _ *emptypb.Empty) (*pb.ContractRegistry, error) {
+	s.mu.RLock()
+	srv := s.grpcSrv
+	s.mu.RUnlock()
+	if srv == nil {
+		return &pb.ContractRegistry{}, nil
+	}
+	return sdk.BuildContractRegistry(srv), nil
+}
+
+// GetStepTypes returns the step type names provided by this plugin.
+func (s *doIaCServer) GetStepTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {
+	return &pb.TypeList{Types: []string{"step.iac_logs"}}, nil
+}
+
+// CreateStep instantiates a step.iac_logs instance for the given config and
+// stores it under a newly-allocated handle ID.
+func (s *doIaCServer) CreateStep(_ context.Context, req *pb.CreateStepRequest) (*pb.HandleResponse, error) {
+	if req.GetType() != "step.iac_logs" {
+		return &pb.HandleResponse{Error: fmt.Sprintf("unknown step type %q", req.GetType())}, nil
+	}
+
+	cfg := make(map[string]any)
+	if req.GetConfig() != nil {
+		cfg = req.GetConfig().AsMap()
+	}
+
+	factory := steps.NewIaCLogsFactory(s.provider.AppsClient())
+	inst, err := factory.CreateStep(req.GetType(), req.GetName(), cfg)
+	if err != nil {
+		return &pb.HandleResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
+	}
+
+	handleID := newHandleID()
+	s.mu.Lock()
+	if s.instances == nil {
+		s.instances = make(map[string]sdk.StepInstance)
+	}
+	s.instances[handleID] = inst
+	s.mu.Unlock()
+
+	return &pb.HandleResponse{HandleId: handleID}, nil
+}
+
+// ExecuteStep dispatches the step identified by req.HandleId.
+func (s *doIaCServer) ExecuteStep(ctx context.Context, req *pb.ExecuteStepRequest) (*pb.ExecuteStepResponse, error) {
+	s.mu.RLock()
+	inst, ok := s.instances[req.GetHandleId()]
+	s.mu.RUnlock()
+	if !ok {
+		return &pb.ExecuteStepResponse{Error: fmt.Sprintf("unknown step handle: %s", req.GetHandleId())}, nil
+	}
+
+	// Convert proto maps to Go maps.
+	triggerData := protoStructToMap(req.GetTriggerData())
+	stepOutputs := protoStepOutputsToMap(req.GetStepOutputs())
+	current := protoStructToMap(req.GetCurrent())
+	metadata := protoStructToMap(req.GetMetadata())
+	cfg := protoStructToMap(req.GetConfig())
+
+	result, err := inst.Execute(ctx, triggerData, stepOutputs, current, metadata, cfg)
+	if err != nil {
+		return &pb.ExecuteStepResponse{Error: err.Error()}, nil //nolint:nilerr // app error in response field
+	}
+	if result == nil {
+		return &pb.ExecuteStepResponse{}, nil
+	}
+
+	outStruct, encErr := structpb.NewStruct(result.Output)
+	if encErr != nil {
+		return &pb.ExecuteStepResponse{Error: fmt.Sprintf("encode step output: %v", encErr)}, nil //nolint:nilerr // app error in response field
+	}
+	return &pb.ExecuteStepResponse{
+		Output:       outStruct,
+		StopPipeline: result.StopPipeline,
+	}, nil
+}
+
+// DestroyStep removes the step instance identified by req.HandleId.
+func (s *doIaCServer) DestroyStep(_ context.Context, req *pb.HandleRequest) (*pb.ErrorResponse, error) {
+	s.mu.Lock()
+	_, ok := s.instances[req.GetHandleId()]
+	if ok {
+		delete(s.instances, req.GetHandleId())
+	}
+	s.mu.Unlock()
+	if !ok {
+		return &pb.ErrorResponse{Error: fmt.Sprintf("unknown step handle: %s", req.GetHandleId())}, nil
+	}
+	return &pb.ErrorResponse{}, nil
+}
+
+// ── Remaining pb.PluginServiceServer stubs ──────────────────────────────────
+// These are required for the interface but are not used by this plugin.
+
+func (s *doIaCServer) GetModuleTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {
+	return &pb.TypeList{}, nil
+}
+
+func (s *doIaCServer) GetTriggerTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {
+	return &pb.TypeList{}, nil
+}
+
+func (s *doIaCServer) GetModuleSchemas(_ context.Context, _ *emptypb.Empty) (*pb.ModuleSchemaList, error) {
+	return &pb.ModuleSchemaList{}, nil
+}
+
+func (s *doIaCServer) CreateModule(_ context.Context, _ *pb.CreateModuleRequest) (*pb.HandleResponse, error) {
+	return &pb.HandleResponse{Error: "this plugin does not provide module types"}, nil
+}
+
+func (s *doIaCServer) InitModule(_ context.Context, _ *pb.HandleRequest) (*pb.ErrorResponse, error) {
+	return &pb.ErrorResponse{Error: "no module instances"}, nil
+}
+
+func (s *doIaCServer) StartModule(_ context.Context, _ *pb.HandleRequest) (*pb.ErrorResponse, error) {
+	return &pb.ErrorResponse{Error: "no module instances"}, nil
+}
+
+func (s *doIaCServer) StopModule(_ context.Context, _ *pb.HandleRequest) (*pb.ErrorResponse, error) {
+	return &pb.ErrorResponse{Error: "no module instances"}, nil
+}
+
+func (s *doIaCServer) DestroyModule(_ context.Context, _ *pb.HandleRequest) (*pb.ErrorResponse, error) {
+	return &pb.ErrorResponse{Error: "no module instances"}, nil
+}
+
+func (s *doIaCServer) InvokeService(_ context.Context, _ *pb.InvokeServiceRequest) (*pb.InvokeServiceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "string-dispatch InvokeService is not supported")
+}
+
+func (s *doIaCServer) DeliverMessage(_ context.Context, _ *pb.DeliverMessageRequest) (*pb.DeliverMessageResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "message delivery is not supported")
+}
+
+func (s *doIaCServer) GetConfigFragment(_ context.Context, _ *emptypb.Empty) (*pb.ConfigFragmentResponse, error) {
+	return &pb.ConfigFragmentResponse{}, nil
+}
+
+func (s *doIaCServer) GetAsset(_ context.Context, _ *pb.GetAssetRequest) (*pb.GetAssetResponse, error) {
+	return &pb.GetAssetResponse{Error: "assets not provided"}, nil
+}
+
+func (s *doIaCServer) ConfigureCallback(_ context.Context, _ *pb.ConfigureCallbackRequest) (*pb.ErrorResponse, error) {
+	return &pb.ErrorResponse{Error: "callback not supported"}, nil
+}
+
+func (s *doIaCServer) CreateTrigger(_ context.Context, _ *pb.CreateTriggerRequest) (*pb.HandleResponse, error) {
+	return &pb.HandleResponse{Error: "this plugin does not provide trigger types"}, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// protoStructToMap converts a *structpb.Struct to map[string]any.
+// Returns nil when s is nil.
+func protoStructToMap(s *structpb.Struct) map[string]any {
+	if s == nil {
+		return nil
+	}
+	return s.AsMap()
+}
+
+// protoStepOutputsToMap converts the step_outputs field from a gRPC execute
+// request to the Go map form expected by sdk.StepInstance.Execute.
+func protoStepOutputsToMap(m map[string]*structpb.Struct) map[string]map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]map[string]any, len(m))
+	for k, v := range m {
+		out[k] = protoStructToMap(v)
+	}
+	return out
+}
+
+// newHandleID returns a unique string handle for a step instance.
+// Uses a simple incrementing counter rather than a UUID to avoid pulling in
+// github.com/google/uuid as a direct dependency.
+var (
+	handleMu      sync.Mutex
+	handleCounter uint64
+)
+
+func newHandleID() string {
+	handleMu.Lock()
+	handleCounter++
+	id := handleCounter
+	handleMu.Unlock()
+	return fmt.Sprintf("do-step-%d", id)
+}

--- a/internal/step_router.go
+++ b/internal/step_router.go
@@ -165,7 +165,10 @@ func (s *doIaCServer) DestroyStep(_ context.Context, req *pb.HandleRequest) (*pb
 // These are required for the interface but are not used by this plugin.
 
 func (s *doIaCServer) GetModuleTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {
-	return &pb.TypeList{}, nil
+	// Return Unimplemented so the engine falls back to the disk plugin.json for
+	// module-type discovery (iac.provider). An empty TypeList would hide the
+	// advertised module type from gRPC-based capability discovery.
+	return nil, status.Error(codes.Unimplemented, "module types served from disk plugin.json")
 }
 
 func (s *doIaCServer) GetTriggerTypes(_ context.Context, _ *emptypb.Empty) (*pb.TypeList, error) {

--- a/internal/step_router.go
+++ b/internal/step_router.go
@@ -69,12 +69,14 @@ func (s *doIaCServer) GetManifest(_ context.Context, _ *emptypb.Empty) (*pb.Mani
 // GetContractRegistry returns the typed-IaC service registrations from the
 // underlying gRPC server. This is the critical forward-compat hook: without
 // it the host's ExternalPluginAdapter cannot discover IaC services.
+// Returns FailedPrecondition when SetGRPCServer has not been called yet, so
+// mis-wiring is surfaced immediately rather than silently hiding IaC contracts.
 func (s *doIaCServer) GetContractRegistry(_ context.Context, _ *emptypb.Empty) (*pb.ContractRegistry, error) {
 	s.mu.RLock()
 	srv := s.grpcSrv
 	s.mu.RUnlock()
 	if srv == nil {
-		return &pb.ContractRegistry{}, nil
+		return nil, status.Error(codes.FailedPrecondition, "GetContractRegistry: SetGRPCServer was not called — plugin wiring incomplete")
 	}
 	return sdk.BuildContractRegistry(srv), nil
 }

--- a/internal/steps/iac_logs.go
+++ b/internal/steps/iac_logs.go
@@ -1,0 +1,265 @@
+// Package steps provides pipeline step factories for the DigitalOcean plugin.
+//
+// Each step factory implements sdk.StepProvider.CreateStep and returns an
+// sdk.StepInstance. Steps are wired into doIaCServer.stepRouter so the gRPC
+// PluginService surface (GetStepTypes / CreateStep / ExecuteStep / DestroyStep)
+// can dispatch them.
+//
+// Migration note: step.iac_logs replaces the removed step.do_logs from
+// workflow core (deleted in commit 589ef78e, issue #617). Behavioral
+// differences from the old step.do_logs:
+//
+//   - Config key is "module" (infra.container_service name) not "app".
+//   - Adds log_type, component_name, and tail_lines knobs.
+//   - AppLogs.LiveURL is returned in output but the step does NOT stream
+//     live log output — it fetches HistoricURLs only (same limitation as
+//     the troubleshoot path in app_platform.go).
+//   - No deployment ID routing: step.iac_logs fetches runtime or build
+//     logs at the app level (latest deployment). If a specific deployment
+//     ID is needed, use a future step.iac_logs_deployment (not yet
+//     implemented).
+package steps
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/GoCodeAlone/workflow/plugin/external/sdk"
+	"github.com/digitalocean/godo"
+)
+
+// IaCLogsClient is the minimal godo App API surface consumed by step.iac_logs.
+// It is satisfied by *godo.AppsServiceOp (the real godo client) and by test
+// fakes. Only List and GetLogs are needed — no Create/Update/Delete.
+type IaCLogsClient interface {
+	List(ctx context.Context, opts *godo.ListOptions) ([]*godo.App, *godo.Response, error)
+	GetLogs(ctx context.Context, appID, deploymentID, component string, logType godo.AppLogType, follow bool, tailLines int) (*godo.AppLogs, *godo.Response, error)
+}
+
+// defaultLogTailLines is the number of log lines returned when the step
+// config omits tail_lines.
+const defaultLogTailLines = 100
+
+// iacLogsStepConfig holds the parsed per-step configuration for step.iac_logs.
+type iacLogsStepConfig struct {
+	module        string
+	logType       godo.AppLogType
+	componentName string
+	tailLines     int
+	follow        bool
+}
+
+// iacLogsStep is the sdk.StepInstance for step.iac_logs.
+type iacLogsStep struct {
+	client IaCLogsClient
+	cfg    iacLogsStepConfig
+}
+
+// IaCLogsFactory is the sdk.StepProvider factory for "step.iac_logs".
+// client is the godo Apps client from the initialized DO provider. When client
+// is nil (provider not yet initialized) the step's Execute returns an error.
+type IaCLogsFactory struct {
+	client IaCLogsClient
+}
+
+// NewIaCLogsFactory returns the step factory for step.iac_logs.
+// client must be the same IaCLogsClient used by the provider at execution time.
+// Pass nil only in tests that want to verify the not-initialized error path.
+func NewIaCLogsFactory(client IaCLogsClient) *IaCLogsFactory {
+	return &IaCLogsFactory{client: client}
+}
+
+// CreateStep implements sdk.StepProvider.
+func (f *IaCLogsFactory) CreateStep(typeName, _ string, config map[string]any) (sdk.StepInstance, error) {
+	if typeName != "step.iac_logs" {
+		return nil, fmt.Errorf("iac_logs factory: unsupported step type %q", typeName)
+	}
+
+	moduleName, _ := config["module"].(string)
+	if moduleName == "" {
+		return nil, fmt.Errorf("step.iac_logs: 'module' is required (name of an infra.container_service resource)")
+	}
+
+	logTypeStr, _ := config["log_type"].(string)
+	if logTypeStr == "" {
+		logTypeStr = "RUN"
+	}
+	lt, err := parseLogType(logTypeStr)
+	if err != nil {
+		return nil, fmt.Errorf("step.iac_logs: %w", err)
+	}
+
+	componentName, _ := config["component_name"].(string)
+
+	tailLines := defaultLogTailLines
+	if tl, ok := intFromConfig(config, "tail_lines"); ok && tl > 0 {
+		tailLines = tl
+	}
+
+	follow, _ := config["follow"].(bool)
+
+	return &iacLogsStep{
+		client: f.client,
+		cfg: iacLogsStepConfig{
+			module:        moduleName,
+			logType:       lt,
+			componentName: componentName,
+			tailLines:     tailLines,
+			follow:        follow,
+		},
+	}, nil
+}
+
+// Execute implements sdk.StepInstance.
+//
+// Workflow:
+//  1. List DO apps and find the one whose Spec.Name matches cfg.module.
+//  2. Call godo Apps.GetLogs for the found app ID.
+//  3. Fetch the first HistoricURL (newest first) to retrieve log text.
+//  4. Return logs, log_url (LiveURL), and component_count.
+//
+// The step does NOT follow live logs (cfg.follow is not honoured beyond
+// passing it to GetLogs): streaming is not feasible inside a pipeline step.
+func (s *iacLogsStep) Execute(ctx context.Context, _ map[string]any, _ map[string]map[string]any, _ map[string]any, _ map[string]any, _ map[string]any) (*sdk.StepResult, error) {
+	if s.client == nil {
+		return nil, fmt.Errorf("step.iac_logs: DO provider not initialized (client is nil)")
+	}
+
+	// 1. Resolve app ID from app name.
+	appID, err := resolveAppID(ctx, s.client, s.cfg.module)
+	if err != nil {
+		return nil, fmt.Errorf("step.iac_logs: %w", err)
+	}
+
+	// 2. Fetch log metadata from DO API.
+	// deploymentID = "" → latest deployment (DO API default).
+	appLogs, _, err := s.client.GetLogs(ctx, appID, "", s.cfg.componentName, s.cfg.logType, s.cfg.follow, s.cfg.tailLines)
+	if err != nil {
+		return nil, fmt.Errorf("step.iac_logs: GetLogs app=%s: %w", s.cfg.module, err)
+	}
+
+	// Component count: 1 when a specific component is requested, 0 means "all".
+	componentCount := 1
+	if s.cfg.componentName == "" {
+		componentCount = 0 // all components aggregated
+	}
+
+	liveURL := ""
+	if appLogs != nil {
+		liveURL = appLogs.LiveURL
+	}
+
+	// 3. Fetch actual log text from the first historic URL.
+	var logText string
+	if appLogs != nil && len(appLogs.HistoricURLs) > 0 {
+		text, fetchErr := fetchLogContent(ctx, appLogs.HistoricURLs[0], s.cfg.tailLines)
+		if fetchErr != nil {
+			// Non-fatal: return partial output with empty logs rather than
+			// failing the whole step. The caller can inspect log_url to
+			// retrieve logs manually.
+			logText = ""
+		} else {
+			logText = text
+		}
+	}
+
+	return &sdk.StepResult{
+		Output: map[string]any{
+			"logs":            logText,
+			"log_url":         liveURL,
+			"component_count": componentCount,
+		},
+	}, nil
+}
+
+// resolveAppID lists DO apps and returns the ID of the app whose Spec.Name
+// matches appName. Returns an error if not found or if the List call fails.
+func resolveAppID(ctx context.Context, client IaCLogsClient, appName string) (string, error) {
+	apps, _, err := client.List(ctx, &godo.ListOptions{Page: 1, PerPage: 200})
+	if err != nil {
+		return "", err
+	}
+	for _, app := range apps {
+		if app.Spec != nil && app.Spec.Name == appName {
+			return app.ID, nil
+		}
+	}
+	return "", fmt.Errorf("app %q not found in DigitalOcean App Platform", appName)
+}
+
+// logFetchTimeout is the per-request timeout for fetching log content from
+// DO's presigned HistoricURLs. 30s provides generous headroom for slow S3
+// presigned URL responses without hanging pipelines indefinitely.
+var logFetchClient = &http.Client{Timeout: 30 * time.Second}
+
+// fetchLogContent fetches the first log URL and returns the last tailLines
+// lines of the response body. A 10 MB cap prevents pathological responses.
+// URL is a presigned URL and MUST NOT be logged verbatim (to avoid leaking
+// signed AWS-style credentials). Errors reference the failure class only.
+func fetchLogContent(ctx context.Context, url string, tailLines int) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build log request: invalid URL shape")
+	}
+	resp, err := logFetchClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("log fetch: network error")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("log fetch: HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+	if err != nil {
+		return "", fmt.Errorf("log fetch: read body: %w", err)
+	}
+	return tailString(string(body), tailLines), nil
+}
+
+// tailString returns the last n non-empty lines of s. When s has fewer than
+// n lines the entire string is returned unchanged.
+func tailString(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) <= n {
+		return s
+	}
+	return strings.Join(lines[len(lines)-n:], "\n")
+}
+
+// parseLogType validates and converts a log_type string to godo.AppLogType.
+func parseLogType(s string) (godo.AppLogType, error) {
+	switch strings.ToUpper(s) {
+	case "BUILD":
+		return godo.AppLogTypeBuild, nil
+	case "DEPLOY":
+		return godo.AppLogTypeDeploy, nil
+	case "RUN":
+		return godo.AppLogTypeRun, nil
+	case "RUN_RESTARTED":
+		return godo.AppLogTypeRunRestarted, nil
+	default:
+		return "", fmt.Errorf("unsupported log_type %q; valid values: BUILD, DEPLOY, RUN, RUN_RESTARTED", s)
+	}
+}
+
+// intFromConfig extracts an int from a map[string]any config value. Handles
+// int, int64, float64 (JSON numbers) and string representations.
+func intFromConfig(config map[string]any, key string) (int, bool) {
+	v, ok := config[key]
+	if !ok {
+		return 0, false
+	}
+	switch tv := v.(type) {
+	case int:
+		return tv, true
+	case int64:
+		return int(tv), true
+	case float64:
+		return int(tv), true
+	}
+	return 0, false
+}

--- a/internal/steps/iac_logs.go
+++ b/internal/steps/iac_logs.go
@@ -201,9 +201,9 @@ func resolveAppID(ctx context.Context, client IaCLogsClient, appName string) (st
 	return "", fmt.Errorf("app %q not found in DigitalOcean App Platform", appName)
 }
 
-// logFetchTimeout is the per-request timeout for fetching log content from
-// DO's presigned HistoricURLs. 30s provides generous headroom for slow S3
-// presigned URL responses without hanging pipelines indefinitely.
+// logFetchClient is an http.Client with a 30 s per-request timeout used when
+// fetching log content from DO's presigned HistoricURLs. 30 s provides generous
+// headroom for slow S3 presigned URL responses without hanging pipelines.
 var logFetchClient = &http.Client{Timeout: 30 * time.Second}
 
 // fetchLogContent fetches the first log URL and returns the last tailLines

--- a/internal/steps/iac_logs.go
+++ b/internal/steps/iac_logs.go
@@ -143,7 +143,9 @@ func (s *iacLogsStep) Execute(ctx context.Context, _ map[string]any, _ map[strin
 	}
 
 	// Component count: 1 when a specific component is requested, 0 means "all".
-	componentCount := 1
+	// Emitted as float64 so the value round-trips correctly through structpb.NewStruct
+	// (which encodes all numbers as float64 in JSON-derived proto Struct values).
+	var componentCount float64 = 1
 	if s.cfg.componentName == "" {
 		componentCount = 0 // all components aggregated
 	}
@@ -176,16 +178,24 @@ func (s *iacLogsStep) Execute(ctx context.Context, _ map[string]any, _ map[strin
 	}, nil
 }
 
-// resolveAppID lists DO apps and returns the ID of the app whose Spec.Name
-// matches appName. Returns an error if not found or if the List call fails.
+// resolveAppID lists DO apps (paginated) and returns the ID of the app whose
+// Spec.Name matches appName. Returns an error if not found or if any List
+// call fails. Each page fetches up to 200 apps; iteration stops when the
+// returned page is shorter than PerPage (last page) or the app is found.
 func resolveAppID(ctx context.Context, client IaCLogsClient, appName string) (string, error) {
-	apps, _, err := client.List(ctx, &godo.ListOptions{Page: 1, PerPage: 200})
-	if err != nil {
-		return "", err
-	}
-	for _, app := range apps {
-		if app.Spec != nil && app.Spec.Name == appName {
-			return app.ID, nil
+	const perPage = 200
+	for page := 1; ; page++ {
+		apps, _, err := client.List(ctx, &godo.ListOptions{Page: page, PerPage: perPage})
+		if err != nil {
+			return "", err
+		}
+		for _, app := range apps {
+			if app.Spec != nil && app.Spec.Name == appName {
+				return app.ID, nil
+			}
+		}
+		if len(apps) < perPage {
+			break // last page
 		}
 	}
 	return "", fmt.Errorf("app %q not found in DigitalOcean App Platform", appName)
@@ -203,7 +213,7 @@ var logFetchClient = &http.Client{Timeout: 30 * time.Second}
 func fetchLogContent(ctx context.Context, url string, tailLines int) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("build log request: invalid URL shape")
+		return "", fmt.Errorf("log request: invalid URL shape")
 	}
 	resp, err := logFetchClient.Do(req)
 	if err != nil {
@@ -220,8 +230,8 @@ func fetchLogContent(ctx context.Context, url string, tailLines int) (string, er
 	return tailString(string(body), tailLines), nil
 }
 
-// tailString returns the last n non-empty lines of s. When s has fewer than
-// n lines the entire string is returned unchanged.
+// tailString returns the last n lines of s. When s has fewer than n lines the
+// entire string is returned unchanged. Empty lines are preserved (not filtered).
 func tailString(s string, n int) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	if len(lines) <= n {
@@ -247,7 +257,7 @@ func parseLogType(s string) (godo.AppLogType, error) {
 }
 
 // intFromConfig extracts an int from a map[string]any config value. Handles
-// int, int64, float64 (JSON numbers) and string representations.
+// int, int64, and float64 (JSON numbers are decoded as float64 by encoding/json).
 func intFromConfig(config map[string]any, key string) (int, bool) {
 	v, ok := config[key]
 	if !ok {

--- a/internal/steps/iac_logs_test.go
+++ b/internal/steps/iac_logs_test.go
@@ -1,0 +1,312 @@
+package steps_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow/plugin/external/sdk"
+	"github.com/digitalocean/godo"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/steps"
+)
+
+// ── fake app client ──────────────────────────────────────────────────────────
+
+type fakeAppsClient struct {
+	apps    []*godo.App
+	logs    *godo.AppLogs
+	logsErr error
+	listErr error
+}
+
+func (f *fakeAppsClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return f.apps, nil, f.listErr
+}
+
+func (f *fakeAppsClient) GetLogs(_ context.Context, _, _, _ string, _ godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	return f.logs, nil, f.logsErr
+}
+
+// ── factory tests ─────────────────────────────────────────────────────────────
+
+func TestNewIaCLogsFactory_RegistersType(t *testing.T) {
+	factory := steps.NewIaCLogsFactory(nil)
+	if factory == nil {
+		t.Fatal("factory must not be nil")
+	}
+}
+
+func TestIaCLogsFactory_CreateStep_MissingModule(t *testing.T) {
+	factory := steps.NewIaCLogsFactory(nil)
+	_, err := factory.CreateStep("step.iac_logs", "my-step", map[string]any{})
+	if err == nil {
+		t.Fatal("expected error when 'module' config is missing")
+	}
+	if !strings.Contains(err.Error(), "module") {
+		t.Errorf("error should mention 'module', got: %v", err)
+	}
+}
+
+func TestIaCLogsFactory_CreateStep_EmptyModule(t *testing.T) {
+	factory := steps.NewIaCLogsFactory(nil)
+	_, err := factory.CreateStep("step.iac_logs", "my-step", map[string]any{"module": ""})
+	if err == nil {
+		t.Fatal("expected error when 'module' config is empty string")
+	}
+}
+
+func TestIaCLogsFactory_CreateStep_ValidConfig(t *testing.T) {
+	factory := steps.NewIaCLogsFactory(nil)
+	inst, err := factory.CreateStep("step.iac_logs", "my-step", map[string]any{
+		"module":   "my-app",
+		"log_type": "BUILD",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if inst == nil {
+		t.Fatal("expected non-nil StepInstance")
+	}
+}
+
+func TestIaCLogsFactory_CreateStep_Defaults(t *testing.T) {
+	factory := steps.NewIaCLogsFactory(nil)
+	inst, err := factory.CreateStep("step.iac_logs", "my-step", map[string]any{
+		"module": "my-app",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Defaults should be accepted without error.
+	if inst == nil {
+		t.Fatal("expected non-nil StepInstance")
+	}
+}
+
+// ── Execute tests ─────────────────────────────────────────────────────────────
+
+// newTestStep constructs a step instance via the factory and returns it
+// alongside a test HTTP server that serves the given log body.
+func newTestStep(t *testing.T, client steps.IaCLogsClient, cfg map[string]any) sdk.StepInstance {
+	t.Helper()
+	factory := steps.NewIaCLogsFactory(client)
+	if _, ok := cfg["module"]; !ok {
+		cfg["module"] = "my-app"
+	}
+	inst, err := factory.CreateStep("step.iac_logs", "my-step", cfg)
+	if err != nil {
+		t.Fatalf("CreateStep: %v", err)
+	}
+	return inst
+}
+
+func TestIaCLogsStep_Execute_NotInitialized(t *testing.T) {
+	// nil client means the provider was not initialized yet.
+	factory := steps.NewIaCLogsFactory(nil)
+	inst, err := factory.CreateStep("step.iac_logs", "my-step", map[string]any{"module": "my-app"})
+	if err != nil {
+		t.Fatalf("CreateStep: %v", err)
+	}
+	_, execErr := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if execErr == nil {
+		t.Fatal("expected error when client is nil (provider not initialized)")
+	}
+}
+
+func TestIaCLogsStep_Execute_AppNotFound(t *testing.T) {
+	client := &fakeAppsClient{apps: []*godo.App{}} // no apps
+	inst := newTestStep(t, client, map[string]any{"module": "missing-app"})
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when app not found")
+	}
+	if !strings.Contains(err.Error(), "missing-app") {
+		t.Errorf("error should mention app name, got: %v", err)
+	}
+}
+
+func TestIaCLogsStep_Execute_ListError(t *testing.T) {
+	listErr := errors.New("API error: unauthorized")
+	client := &fakeAppsClient{listErr: listErr}
+	inst := newTestStep(t, client, map[string]any{"module": "my-app"})
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error propagation from List")
+	}
+	if !errors.Is(err, listErr) {
+		t.Errorf("expected wrapped listErr, got: %v", err)
+	}
+}
+
+func TestIaCLogsStep_Execute_GetLogsError(t *testing.T) {
+	logsErr := errors.New("godo: 503 service unavailable")
+	client := &fakeAppsClient{
+		apps:    []*godo.App{{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}}},
+		logsErr: logsErr,
+	}
+	inst := newTestStep(t, client, map[string]any{"module": "my-app"})
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error propagation from GetLogs")
+	}
+	if !errors.Is(err, logsErr) {
+		t.Errorf("expected wrapped logsErr, got: %v", err)
+	}
+}
+
+func TestIaCLogsStep_Execute_NoHistoricURLs(t *testing.T) {
+	// GetLogs returns an AppLogs with only a LiveURL (no HistoricURLs).
+	client := &fakeAppsClient{
+		apps: []*godo.App{{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}}},
+		logs: &godo.AppLogs{LiveURL: "wss://example.com/logs"},
+	}
+	inst := newTestStep(t, client, map[string]any{"module": "my-app"})
+	result, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	output := result.Output
+	if output["log_url"] != "wss://example.com/logs" {
+		t.Errorf("log_url should be the LiveURL, got: %v", output["log_url"])
+	}
+	if output["logs"] != "" {
+		t.Errorf("logs should be empty when no HistoricURLs, got: %v", output["logs"])
+	}
+}
+
+func TestIaCLogsStep_Execute_WithHistoricURL(t *testing.T) {
+	// Start a test HTTP server that serves fake log content.
+	logBody := "line1\nline2\nline3\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(logBody))
+	}))
+	defer srv.Close()
+
+	client := &fakeAppsClient{
+		apps: []*godo.App{{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}}},
+		logs: &godo.AppLogs{
+			LiveURL:      "wss://example.com/logs",
+			HistoricURLs: []string{srv.URL},
+		},
+	}
+	inst := newTestStep(t, client, map[string]any{
+		"module":     "my-app",
+		"tail_lines": 100,
+	})
+	result, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	output := result.Output
+	if !strings.Contains(output["logs"].(string), "line1") {
+		t.Errorf("logs should contain fetched content, got: %v", output["logs"])
+	}
+	if output["log_url"] != "wss://example.com/logs" {
+		t.Errorf("log_url should be LiveURL, got: %v", output["log_url"])
+	}
+	// No component_name was specified → 0 means "all components (aggregate)".
+	if output["component_count"].(int) != 0 {
+		t.Errorf("component_count should be 0 (all components) when no component_name, got: %v", output["component_count"])
+	}
+}
+
+func TestIaCLogsStep_Execute_WithComponentName(t *testing.T) {
+	// component_name is forwarded to GetLogs.
+	var capturedComponent string
+	capturedClient := &captureLogsClient{
+		app:       &godo.App{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		captureComponent: func(component string) {
+			capturedComponent = component
+		},
+	}
+	inst := newTestStep(t, capturedClient, map[string]any{
+		"module":         "my-app",
+		"component_name": "web",
+	})
+	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if capturedComponent != "web" {
+		t.Errorf("expected component_name 'web' forwarded to GetLogs, got %q", capturedComponent)
+	}
+}
+
+func TestIaCLogsStep_Execute_LogTypeDefault(t *testing.T) {
+	// Default log_type is RUN.
+	var capturedLogType godo.AppLogType
+	capturedClient := &captureLogsClient{
+		app: &godo.App{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		captureLogType: func(lt godo.AppLogType) {
+			capturedLogType = lt
+		},
+	}
+	inst := newTestStep(t, capturedClient, map[string]any{"module": "my-app"})
+	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if capturedLogType != godo.AppLogTypeRun {
+		t.Errorf("default log_type should be RUN, got %q", capturedLogType)
+	}
+}
+
+func TestIaCLogsStep_Execute_LogTypeBuild(t *testing.T) {
+	var capturedLogType godo.AppLogType
+	capturedClient := &captureLogsClient{
+		app: &godo.App{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}},
+		captureLogType: func(lt godo.AppLogType) {
+			capturedLogType = lt
+		},
+	}
+	inst := newTestStep(t, capturedClient, map[string]any{
+		"module":   "my-app",
+		"log_type": "BUILD",
+	})
+	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if capturedLogType != godo.AppLogTypeBuild {
+		t.Errorf("expected log_type BUILD, got %q", capturedLogType)
+	}
+}
+
+// OutputStructure validates that all documented output keys are present.
+func TestIaCLogsStep_Execute_OutputStructure(t *testing.T) {
+	client := &fakeAppsClient{
+		apps: []*godo.App{{ID: "abc-123", Spec: &godo.AppSpec{Name: "my-app"}}},
+		logs: &godo.AppLogs{LiveURL: "wss://example.com/logs"},
+	}
+	inst := newTestStep(t, client, map[string]any{"module": "my-app"})
+	result, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, key := range []string{"logs", "log_url", "component_count"} {
+		if _, ok := result.Output[key]; !ok {
+			t.Errorf("output missing key %q", key)
+		}
+	}
+}
+
+// ── captureLogsClient ─────────────────────────────────────────────────────────
+
+// captureLogsClient is a test client that records arguments passed to GetLogs.
+type captureLogsClient struct {
+	app              *godo.App
+	captureComponent func(string)
+	captureLogType   func(godo.AppLogType)
+}
+
+func (c *captureLogsClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.App, *godo.Response, error) {
+	return []*godo.App{c.app}, nil, nil
+}
+
+func (c *captureLogsClient) GetLogs(_ context.Context, _, _, component string, logType godo.AppLogType, _ bool, _ int) (*godo.AppLogs, *godo.Response, error) {
+	if c.captureComponent != nil {
+		c.captureComponent(component)
+	}
+	if c.captureLogType != nil {
+		c.captureLogType(logType)
+	}
+	return &godo.AppLogs{}, nil, nil
+}

--- a/internal/steps/iac_logs_test.go
+++ b/internal/steps/iac_logs_test.go
@@ -89,8 +89,7 @@ func TestIaCLogsFactory_CreateStep_Defaults(t *testing.T) {
 
 // ── Execute tests ─────────────────────────────────────────────────────────────
 
-// newTestStep constructs a step instance via the factory and returns it
-// alongside a test HTTP server that serves the given log body.
+// newTestStep constructs a step instance via the factory and returns it.
 func newTestStep(t *testing.T, client steps.IaCLogsClient, cfg map[string]any) sdk.StepInstance {
 	t.Helper()
 	factory := steps.NewIaCLogsFactory(client)
@@ -212,7 +211,8 @@ func TestIaCLogsStep_Execute_WithHistoricURL(t *testing.T) {
 		t.Errorf("log_url should be LiveURL, got: %v", output["log_url"])
 	}
 	// No component_name was specified → 0 means "all components (aggregate)".
-	if output["component_count"].(int) != 0 {
+	// component_count is emitted as float64 to survive structpb round-trips.
+	if output["component_count"].(float64) != 0 {
 		t.Errorf("component_count should be 0 (all components) when no component_name, got: %v", output["component_count"])
 	}
 }
@@ -230,7 +230,10 @@ func TestIaCLogsStep_Execute_WithComponentName(t *testing.T) {
 		"module":         "my-app",
 		"component_name": "web",
 	})
-	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected Execute error: %v", err)
+	}
 	if capturedComponent != "web" {
 		t.Errorf("expected component_name 'web' forwarded to GetLogs, got %q", capturedComponent)
 	}
@@ -246,7 +249,10 @@ func TestIaCLogsStep_Execute_LogTypeDefault(t *testing.T) {
 		},
 	}
 	inst := newTestStep(t, capturedClient, map[string]any{"module": "my-app"})
-	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected Execute error: %v", err)
+	}
 	if capturedLogType != godo.AppLogTypeRun {
 		t.Errorf("default log_type should be RUN, got %q", capturedLogType)
 	}
@@ -264,7 +270,10 @@ func TestIaCLogsStep_Execute_LogTypeBuild(t *testing.T) {
 		"module":   "my-app",
 		"log_type": "BUILD",
 	})
-	_, _ = inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	_, err := inst.Execute(context.Background(), nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected Execute error: %v", err)
+	}
 	if capturedLogType != godo.AppLogTypeBuild {
 		t.Errorf("expected log_type BUILD, got %q", capturedLogType)
 	}

--- a/plugin.contracts.json
+++ b/plugin.contracts.json
@@ -6,6 +6,13 @@
       "type": "iac.provider",
       "mode": "strict",
       "config": "workflow.plugins.digitalocean.IacProviderConfig"
+    },
+    {
+      "kind": "step",
+      "type": "step.iac_logs",
+      "mode": "strict",
+      "input": "workflow.plugins.digitalocean.IacLogsRequest",
+      "output": "workflow.plugins.digitalocean.IacLogsResponse"
     }
   ]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.51.2",
+  "minEngineVersion": "0.51.7",
   "keywords": ["digitalocean", "iac", "infra", "kubernetes", "database", "app-platform", "spaces", "redis"],
   "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
   "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
@@ -38,7 +38,7 @@
   "capabilities": {
     "configProvider": false,
     "moduleTypes": ["iac.provider"],
-    "stepTypes": [],
+    "stepTypes": ["step.iac_logs"],
     "triggerTypes": [],
     "iacProvider": {
       "name": "digitalocean",


### PR DESCRIPTION
## Summary

- Adds `step.iac_logs` pipeline step that fetches App Platform deploy/run logs via godo `Apps.GetLogs`, closing the gap left by the removal of core `step.do_logs` (workflow#617)
- Requires workflow SDK v0.51.7 (two new SDK hooks: `pb.PluginServiceServer` auto-detect + `grpcServerSetter` auto-call in `registerIaCServicesOnly`)
- `doIaCServer` now implements `pb.PluginServiceServer` directly — step dispatch lives on the same gRPC connection as the typed IaC contract

## Config schema

```yaml
steps:
  - name: fetch_logs
    type: step.iac_logs
    config:
      module: my-app          # required — infra.container_service name
      log_type: RUN           # BUILD | DEPLOY | RUN | RUN_RESTARTED (default: RUN)
      component_name: web     # optional — empty = all components aggregated
      tail_lines: 100         # optional — default 100
```

Outputs: `logs` (string), `log_url` (string, the LiveURL), `component_count` (int, 0=all, 1=named component)

## Behavioral differences from the old `step.do_logs`

- Config key is `module` (infra.container_service name) not `app`
- Adds `log_type`, `component_name`, and `tail_lines` config knobs
- `component_count`: 0 = all components aggregated, 1 = named component
- No deployment ID routing — fetches latest deployment logs
- HistoricURLs fetched inline; LiveURL returned as `log_url`
- PresignedURLs are never logged verbatim (signed credentials)

## Files changed

| File | Change |
|------|--------|
| `internal/steps/iac_logs.go` | New — `IaCLogsClient` interface, `IaCLogsFactory`, `iacLogsStep.Execute` |
| `internal/steps/iac_logs_test.go` | New — 14 tests (factory, error paths, execute, arg forwarding) |
| `internal/step_router.go` | New — `doIaCServer` implements `pb.PluginServiceServer` |
| `internal/iacserver.go` | Add `pb.UnimplementedPluginServiceServer` embed + `stepRegistry` field |
| `internal/provider.go` | Add `AppsClient()` accessor |
| `plugin.json` | Add `step.iac_logs` to `stepTypes`, bump `minEngineVersion` to `0.51.7` |
| `go.mod` / `go.sum` | Bump workflow → v0.51.7 |

## Test plan

- [x] `go build` clean (GOWORK=off)
- [x] `go test -race ./...` all pass (14 new tests in `internal/steps`)
- [ ] Integration: configure `step.iac_logs` in a DO App Platform pipeline, verify `logs` and `log_url` in step output

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)