### PR TITLE
chore: bump workflow SDK to v0.51.7

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,6 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.51.2 h1:TXnb3L+HUAU+eUp25Nev1Fj6PBuKK7NtMkAumTTVx1Y=
-github.com/GoCodeAlone/workflow v0.51.2/go.mod h1:8825xDA4dAxlKN0OObT9dbwLvhxMkk5obB2+1dZo+jo=
-github.com/GoCodeAlone/workflow v0.51.6 h1:jN/cAsCoIcwvHdMAbdhNfTIDiYtN1W+sd87aWS4DP0I=
-github.com/GoCodeAlone/workflow v0.51.6/go.mod h1:5dh9esKq48kH4zKWjccXmyOirWL+T+YzfLclzhdRIV4=
 github.com/GoCodeAlone/workflow v0.51.7 h1:+81UNlLQPfnB6hwncWM6DPHHmonLoiqBL0YGQ6OW9g4=
 github.com/GoCodeAlone/workflow v0.51.7/go.mod h1:5dh9esKq48kH4zKWjccXmyOirWL+T+YzfLclzhdRIV4=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=


### PR DESCRIPTION
Pure pin bump from v0.51.2 to v0.51.7. Build passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)