### PR TITLE
chore: sync plugin.json version to latest tag v

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-plugin-digitalocean",
-  "version": "0.12.0",
+  "version": "1.0.12",
   "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",


### PR DESCRIPTION
Sync the `version` field in `plugin.json` to match the latest git release tag, eliminating drift between the published tag and the manifest the registry/consumers read.

**Change:** `version` field updated to match latest tag.

This is a pure metadata sync — no code changes.