### PR TITLE
fix(database): hydrate adopted connection outputs

### DIFF
--- a/.github/workflows/sync-plugin-version.yml
+++ b/.github/workflows/sync-plugin-version.yml
@@ -24,16 +24,18 @@ jobs:
       - name: Update plugin.json
         run: |
           if [ ! -f plugin.json ]; then echo "no plugin.json; skipping"; exit 0; fi
-          CURRENT=$(python3 -c "import json; print(json.load(open('plugin.json')).get('version',''))")
           TARGET="${{ steps.ver.outputs.version }}"
-          if [ "$CURRENT" = "$TARGET" ]; then
-            echo "plugin.json already at $TARGET; no action"
-            exit 0
-          fi
           python3 -c "
           import json
+          tag = '${{ steps.ver.outputs.tag }}'
           p = json.load(open('plugin.json'))
           p['version'] = '$TARGET'
+          name = p.get('name', 'workflow-plugin-digitalocean')
+          for dl in p.get('downloads', []):
+              goos = dl.get('os')
+              goarch = dl.get('arch')
+              if goos and goarch:
+                  dl['url'] = f'https://github.com/GoCodeAlone/{name}/releases/download/{tag}/{name}-{goos}-{goarch}.tar.gz'
           json.dump(p, open('plugin.json', 'w'), indent=2)
           open('plugin.json', 'a').write('\n')
           "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to workflow-plugin-digitalocean are documented here.
   now recorded in outputs and compared during `Diff`, so adding or clearing
   public ingress routes on an existing app triggers an in-place App Platform
   update instead of silently no-oping.
+- **Database adoption hydrates connection outputs** — name-based reads now
+  follow the list match with a `Get` call so adopted managed databases expose
+  `outputs.uri` for Workflow `infra_output` secret generation.
+- **plugin.json download URLs stay release-aligned** — the tag sync workflow now
+  updates both manifest `version` and download URLs, preventing stale asset
+  links after release tags.
 
 ### Added
 

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -164,6 +164,24 @@ func (d *DatabaseDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (
 // findDatabaseByName iterates the paginated database list and returns the first
 // database whose Name matches. Returns ErrResourceNotFound if no match is found.
 func (d *DatabaseDriver) findDatabaseByName(ctx context.Context, name string) (*interfaces.ResourceOutput, error) {
+	db, err := d.lookupDatabaseByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if db.ID == "" {
+		return dbOutput(db), nil
+	}
+	hydrated, _, err := d.client.Get(ctx, db.ID)
+	if err != nil {
+		return nil, fmt.Errorf("database read %q after name lookup: %w", name, WrapGodoError(err))
+	}
+	if hydrated == nil {
+		return dbOutput(db), nil
+	}
+	return dbOutput(hydrated), nil
+}
+
+func (d *DatabaseDriver) lookupDatabaseByName(ctx context.Context, name string) (*godo.Database, error) {
 	opts := &godo.ListOptions{Page: 1, PerPage: 200}
 	for {
 		dbs, resp, err := d.client.List(ctx, opts)
@@ -172,7 +190,7 @@ func (d *DatabaseDriver) findDatabaseByName(ctx context.Context, name string) (*
 		}
 		for i := range dbs {
 			if dbs[i].Name == name {
-				return dbOutput(&dbs[i]), nil
+				return &dbs[i], nil
 			}
 		}
 		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
@@ -193,11 +211,11 @@ func (d *DatabaseDriver) resolveProviderID(ctx context.Context, ref interfaces.R
 	}
 	log.Printf("warn: database %q: ProviderID %q is not UUID-like; resolving by name (state-heal)",
 		ref.Name, ref.ProviderID)
-	out, err := d.findDatabaseByName(ctx, ref.Name)
+	db, err := d.lookupDatabaseByName(ctx, ref.Name)
 	if err != nil {
 		return "", fmt.Errorf("database state-heal for %q: %w", ref.Name, err)
 	}
-	return out.ProviderID, nil
+	return db.ID, nil
 }
 
 func (d *DatabaseDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -14,10 +14,13 @@ import (
 
 type mockDatabaseClient struct {
 	db              *godo.Database
+	listDB          *godo.Database
 	err             error
 	firewallErr     error
 	lastCreateReq   *godo.DatabaseCreateRequest
 	lastFirewallReq *godo.DatabaseUpdateFirewallRulesRequest
+	getCalls        int
+	listCalls       int
 }
 
 func (m *mockDatabaseClient) Create(_ context.Context, req *godo.DatabaseCreateRequest) (*godo.Database, *godo.Response, error) {
@@ -25,16 +28,22 @@ func (m *mockDatabaseClient) Create(_ context.Context, req *godo.DatabaseCreateR
 	return m.db, nil, m.err
 }
 func (m *mockDatabaseClient) Get(_ context.Context, _ string) (*godo.Database, *godo.Response, error) {
+	m.getCalls++
 	return m.db, nil, m.err
 }
 func (m *mockDatabaseClient) List(_ context.Context, _ *godo.ListOptions) ([]godo.Database, *godo.Response, error) {
+	m.listCalls++
 	if m.err != nil {
 		return nil, nil, m.err
 	}
-	if m.db == nil {
+	db := m.db
+	if m.listDB != nil {
+		db = m.listDB
+	}
+	if db == nil {
 		return nil, nil, nil
 	}
-	return []godo.Database{*m.db}, nil, nil
+	return []godo.Database{*db}, nil, nil
 }
 func (m *mockDatabaseClient) Resize(_ context.Context, _ string, _ *godo.DatabaseResizeRequest) (*godo.Response, error) {
 	return nil, m.err
@@ -446,6 +455,30 @@ func TestDatabaseDriver_Read_NameBased(t *testing.T) {
 	}
 	if out.Name != "my-db" {
 		t.Errorf("Name = %q, want %q", out.Name, "my-db")
+	}
+}
+
+func TestDatabaseDriver_Read_NameBasedHydratesConnectionOutputs(t *testing.T) {
+	listDB := *testDatabase()
+	listDB.Connection = nil
+	mock := &mockDatabaseClient{
+		listDB: &listDB,
+		db:     testDatabase(),
+	}
+	d := drivers.NewDatabaseDriverWithClient(mock, "nyc3")
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{Name: "my-db"})
+	if err != nil {
+		t.Fatalf("Read by name: %v", err)
+	}
+	if mock.listCalls != 1 {
+		t.Fatalf("List calls = %d, want 1", mock.listCalls)
+	}
+	if mock.getCalls != 1 {
+		t.Fatalf("Get calls = %d, want 1 to hydrate connection outputs", mock.getCalls)
+	}
+	if uri, _ := out.Outputs["uri"].(string); uri == "" {
+		t.Fatalf("uri output missing after adoption/name-based read: %#v", out.Outputs)
 	}
 }
 

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -53,9 +53,9 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 			Goarch []string `yaml:"goarch"`
 		} `yaml:"builds"`
 		Archives []struct {
-			ID           string   `yaml:"id"`
-			IDs          []string `yaml:"ids"`
-			NameTemplate string   `yaml:"name_template"`
+			ID           string            `yaml:"id"`
+			IDs          []string          `yaml:"ids"`
+			NameTemplate string            `yaml:"name_template"`
 			Files        []archiveFileSpec `yaml:"files"`
 		} `yaml:"archives"`
 	}
@@ -122,6 +122,23 @@ func TestPluginDownloadsMatchGoReleaserArchives(t *testing.T) {
 	}
 	if !tarGzContains(archivePath, "plugin.contracts.json") {
 		t.Fatal("test release archive missing plugin.contracts.json")
+	}
+}
+
+func TestSyncPluginVersionWorkflowUpdatesDownloads(t *testing.T) {
+	repoRoot := testRepoRoot(t)
+	body, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "sync-plugin-version.yml"))
+	if err != nil {
+		t.Fatalf("read sync workflow: %v", err)
+	}
+	text := string(body)
+	for _, want := range []string{
+		"dl['url'] = f'https://github.com/GoCodeAlone/{name}/releases/download/{tag}/{name}-{goos}-{goarch}.tar.gz'",
+		"p['version'] = '$TARGET'",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("sync workflow must update manifest downloads with release tag, missing %q", want)
+		}
 	}
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -14,22 +14,22 @@
     {
       "os": "linux",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.12/workflow-plugin-digitalocean-linux-amd64.tar.gz"
     },
     {
       "os": "linux",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.12/workflow-plugin-digitalocean-linux-arm64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.12/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
     },
     {
       "os": "darwin",
       "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v0.12.0/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v1.0.12/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
     }
   ],
   "iacProvider": {


### PR DESCRIPTION
## Summary
- hydrate name-based database reads with a follow-up Get so adopted databases expose connection outputs like uri
- keep database state-heal ID lookup list-only so update/delete paths do not require connection hydration
- update plugin.json release download URLs and tag sync workflow so manifest URLs track release tags

## Verification
- RED proof: with the production hydration fix reverted, `GOWORK=off go test ./internal/drivers -run TestDatabaseDriver_Read_NameBasedHydratesConnectionOutputs -count=1` fails with `Get calls = 0, want 1 to hydrate connection outputs`
- GREEN proof: `GOWORK=off go test ./internal/drivers -run TestDatabaseDriver_Read_NameBasedHydratesConnectionOutputs -count=1`
- `GOWORK=off go test ./...`
- `wfctl plugin validate --file plugin.json --strict-contracts`
- `git diff --check`