### PR TITLE
fix(app-platform): pass worker registry credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to workflow-plugin-digitalocean are documented here.
 
 ### Fixed
 
+- **App Platform worker private image pulls** — `workers[].image` now applies
+  `provider_specific.digitalocean.registry_credentials` the same way the
+  primary service image does, allowing private GHCR worker components to run
+  inside a multi-component App Platform app.
 - **App Platform route drift detection** — `infra.container_service.routes` is
   now recorded in outputs and compared during `Diff`, so adding or clearing
   public ingress routes on an existing app triggers an in-place App Platform

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -813,6 +813,7 @@ func buildWorkerSpec(m map[string]any) *godo.AppWorkerSpec {
 	}
 	// Image from "image" field (accepts string or structured map).
 	if img, err := imageSpecFromConfig(m); err == nil {
+		applyRegistryCredentialsFromConfig(img, m)
 		w.Image = img
 	}
 	// size tier override.

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -1324,6 +1324,38 @@ func TestBuildAppSpec_Workers_ImageStringShape(t *testing.T) {
 	}
 }
 
+func TestBuildAppSpec_Workers_ImageRegistryCredentialsProviderSpecific(t *testing.T) {
+	cfg := map[string]any{
+		"image": "registry.digitalocean.com/myrepo/myapp:v1",
+		"workers": []any{
+			map[string]any{
+				"name":        "internal-agent",
+				"image":       "ghcr.io/gocodealone/workflow-compute-agent-heartbeat:abc123",
+				"run_command": "/app/compute-agent-heartbeat",
+				"provider_specific": map[string]any{
+					"digitalocean": map[string]any{
+						"registry_credentials": "x-access-token:ghp_secret",
+					},
+				},
+			},
+		},
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if len(spec.Workers) != 1 {
+		t.Fatalf("expected 1 worker, got %d", len(spec.Workers))
+	}
+	img := spec.Workers[0].Image
+	if img == nil {
+		t.Fatal("worker image is nil")
+	}
+	if img.RegistryType != godo.ImageSourceSpecRegistryType_Ghcr {
+		t.Fatalf("RegistryType = %q, want GHCR", img.RegistryType)
+	}
+	if img.RegistryCredentials != "x-access-token:ghp_secret" {
+		t.Fatalf("RegistryCredentials = %q, want provider-specific credential", img.RegistryCredentials)
+	}
+}
+
 func TestBuildAppSpec_Workers_ImageEmpty(t *testing.T) {
 	cfg := map[string]any{
 		"image": "registry.digitalocean.com/myrepo/myapp:v1",


### PR DESCRIPTION
## Summary
- apply provider-specific registry credentials to App Platform worker images
- add regression coverage for private GHCR worker components

## Verification
- GOWORK=off go test ./...

## Context
workflow-compute staging needs a private internal worker component inside the same App Platform app. Without this, worker image pulls can omit GHCR credentials even when the component config declares them.