### PR TITLE
docs(do): verified banner + CONTRIBUTING + examples + CHANGELOG (QoL sweep)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Report a bug in this plugin
+title: '[Bug] '
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To reproduce
+
+Steps to reproduce the behavior:
+1. Config used (redact any secrets)
+2. Command run
+3. Error output
+
+## Expected behavior
+
+What you expected to happen.
+
+## Environment
+
+- workflow engine version: <!-- e.g. 0.3.51 -->
+- plugin version: <!-- e.g. 1.0.0 -->
+- Go version: <!-- go version -->
+- OS: <!-- e.g. linux/amd64, darwin/arm64 -->
+
+## Additional context
+
+Add any other context or logs here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new capability for this plugin
+title: '[Feature] '
+labels: enhancement
+assignees: ''
+---
+
+## Summary
+
+A one-sentence description of the feature.
+
+## Motivation
+
+Why is this feature needed? What problem does it solve?
+
+## Proposed solution
+
+How would you like it to work? Include config schema changes if relevant.
+
+## Alternatives considered
+
+Any alternative approaches you considered and why you ruled them out.
+
+## Additional context
+
+Links, screenshots, or related issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Motivation
+
+<!-- Why is this change needed? Link to issue if applicable. Closes #NNN -->
+
+## Test plan
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Manual smoke test (describe)
+
+## Checklist
+
+- [ ] CHANGELOG.md updated (Keep-a-Changelog format)
+- [ ] No secrets or credentials included
+- [ ] One feature or bugfix per PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Eliminates the runtime-failure surface (sentinel-stub returning `ErrApplyV1Remov
 
 ## [Unreleased]
 
+### Added
+
+- README verified-status banner per workflow#714 (multi-repo QoL sweep).
+- CONTRIBUTING.md, examples/minimal/config.yaml, and GitHub issue/PR templates.
+
 ### Fixed
 
 - **App Platform worker private image pulls** — `workers[].image` now applies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to workflow-plugin-digitalocean
+
+This plugin is part of the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) ecosystem.
+
+## Before contributing
+
+Read the [upstream CONTRIBUTING.md](https://github.com/GoCodeAlone/workflow/blob/main/CONTRIBUTING.md) for general conventions, signing, and review expectations.
+
+## Local development
+
+```sh
+git clone https://github.com/GoCodeAlone/workflow-plugin-digitalocean.git
+cd workflow-plugin-digitalocean
+go build ./...
+go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR.
+- Update CHANGELOG.md with a Keep-a-Changelog entry.
+- Add tests covering new behavior.
+- Run `go vet ./...` before pushing.
+
+## Reporting issues
+
+See the issue templates under `.github/ISSUE_TEMPLATE/`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# workflow-plugin-digitalocean
+
+> ✅ **Verified** — used in production at **buymywishlist, core-dump, workflow-compute**. This plugin has been validated end-to-end in a merged main-branch wfctl.yaml of an active GoCodeAlone project.
+
+DigitalOcean IaC provider for the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) engine. Manages App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway resources via `wfctl infra`.
+
+## Supported resource types
+
+| Type | Description |
+|------|-------------|
+| `infra.container_service` | DigitalOcean App Platform service |
+| `infra.k8s_cluster` | DigitalOcean Kubernetes (DOKS) |
+| `infra.database` | Managed database (PostgreSQL, MySQL, Redis, MongoDB) |
+| `infra.cache` | Managed Redis cache |
+| `infra.load_balancer` | Load balancer |
+| `infra.vpc` | Virtual Private Cloud |
+| `infra.firewall` | Cloud firewall (Droplet/DOKS tag-based) |
+| `infra.dns` | DNS domain + records |
+| `infra.storage` | Spaces object storage |
+| `infra.registry` | DigitalOcean Container Registry (DOCR) |
+| `infra.certificate` | TLS certificate |
+| `infra.droplet` | Droplet (VM) |
+| `infra.volume` | Block Storage volume |
+| `infra.iam_role` | IAM role (declarative) |
+| `infra.api_gateway` | API gateway |
+
+## Quick start
+
+See [`examples/minimal/config.yaml`](examples/minimal/config.yaml) for a minimal working configuration.
+
+```sh
+wfctl infra plan   --env staging
+wfctl infra apply  --env staging
+```
+
+## Requirements
+
+- workflow engine ≥ `0.57.1`
+- `DIGITALOCEAN_TOKEN` environment variable set to a valid DO personal access token
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/examples/minimal/config.yaml
+++ b/examples/minimal/config.yaml
@@ -1,0 +1,32 @@
+# Minimal workflow-plugin-digitalocean example.
+# Provisions a single Droplet on DigitalOcean.
+#
+# Prerequisites:
+#   export DIGITALOCEAN_TOKEN=<your-do-personal-access-token>
+#
+# Usage:
+#   wfctl infra plan  --env staging
+#   wfctl infra apply --env staging
+
+infra:
+  auto_bootstrap: false
+
+modules:
+  - name: do-provider
+    type: iac.provider
+    config:
+      provider: digitalocean
+      token: ${DIGITALOCEAN_TOKEN}
+
+  - name: my-droplet
+    type: infra.droplet
+    config:
+      provider: do-provider
+    environments:
+      staging:
+        config:
+          name: my-app
+          region: nyc1
+          size: s-1vcpu-1gb
+          image: ubuntu-24-04-x64
+          monitoring: true


### PR DESCRIPTION
## Summary

- Prepend verified-status banner to README.md (production at buymywishlist, core-dump, workflow-compute).
- Add CONTRIBUTING.md from shared plugin template.
- Add `examples/minimal/config.yaml` (minimal `infra.droplet` config; `wfctl validate --skip-unknown-types` passes).
- Add `.github/ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, and `PULL_REQUEST_TEMPLATE.md`.
- Record QoL sweep additions in `CHANGELOG.md [Unreleased]`.

## Motivation

Part of the multi-repo QoL sweep (workflow#714). Brings workflow-plugin-digitalocean up to the P0 documentation baseline.

## Test plan

- [x] `go build ./...` passes (GOWORK=off)
- [x] `go vet ./...` passes (GOWORK=off)
- [x] `wfctl validate --skip-unknown-types examples/minimal/config.yaml` → PASS

## Checklist

- [x] CHANGELOG.md updated (Keep-a-Changelog format)
- [x] No secrets or credentials included
- [x] One feature or bugfix per PR

Cross-ref: GoCodeAlone/workflow#714

🤖 Generated with [Claude Code](https://claude.com/claude-code)