### PR TITLE
feat: add App Platform domain resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 > ✅ **Verified** — used in production at **buymywishlist, core-dump, workflow-compute**. This plugin has been validated end-to-end in a merged main-branch wfctl.yaml of an active GoCodeAlone project.
 
-DigitalOcean IaC provider for the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) engine. Manages App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway resources via `wfctl infra`.
+DigitalOcean IaC provider for the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) engine. Manages App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway resources via `wfctl infra`.
 
 ## Supported resource types
 
 | Type | Description |
 |------|-------------|
 | `infra.container_service` | DigitalOcean App Platform service |
+| `infra.app_domain` | App Platform domain binding |
 | `infra.k8s_cluster` | DigitalOcean Kubernetes (DOKS) |
 | `infra.database` | Managed database (PostgreSQL, MySQL, Redis, MongoDB) |
 | `infra.cache` | Managed Redis cache |

--- a/internal/drivers/app_domain.go
+++ b/internal/drivers/app_domain.go
@@ -1,0 +1,312 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+// AppDomainDriver manages one App Platform domain entry without rebuilding the
+// rest of the app spec.
+type AppDomainDriver struct {
+	client AppPlatformClient
+}
+
+// NewAppDomainDriver creates an AppDomainDriver backed by a real godo client.
+func NewAppDomainDriver(c *godo.Client) *AppDomainDriver {
+	return &AppDomainDriver{client: c.Apps}
+}
+
+// NewAppDomainDriverWithClient creates a driver with an injected apps client.
+func NewAppDomainDriverWithClient(c AppPlatformClient) *AppDomainDriver {
+	return &AppDomainDriver{client: c}
+}
+
+func (d *AppDomainDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return d.upsert(ctx, interfaces.ResourceRef{Name: spec.Name, Type: spec.Type}, spec)
+}
+
+func (d *AppDomainDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
+	appID, domain, err := parseAppDomainProviderID(ref.ProviderID)
+	if err != nil {
+		return nil, fmt.Errorf("app domain read %q: %w", ref.Name, err)
+	}
+	app, err := d.getApp(ctx, appID)
+	if err != nil {
+		return nil, fmt.Errorf("app domain read %q: %w", ref.Name, err)
+	}
+	found := findAppDomain(app, domain)
+	if found == nil {
+		return nil, fmt.Errorf("app domain %q on app %q: %w", domain, appID, ErrResourceNotFound)
+	}
+	return appDomainOutput(ref.Name, app, found), nil
+}
+
+func (d *AppDomainDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	return d.upsert(ctx, ref, spec)
+}
+
+func (d *AppDomainDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) error {
+	appID, domain, err := parseAppDomainProviderID(ref.ProviderID)
+	if err != nil {
+		return fmt.Errorf("app domain delete %q: %w", ref.Name, err)
+	}
+	app, err := d.getApp(ctx, appID)
+	if err != nil {
+		return fmt.Errorf("app domain delete %q: %w", ref.Name, err)
+	}
+	if app.Spec == nil {
+		return fmt.Errorf("app domain delete %q: app %q has nil spec", ref.Name, appID)
+	}
+	domains := make([]*godo.AppDomainSpec, 0, len(app.Spec.Domains))
+	for _, existing := range app.Spec.Domains {
+		if existing == nil || !strings.EqualFold(existing.Domain, domain) {
+			domains = append(domains, existing)
+		}
+	}
+	if len(domains) == len(app.Spec.Domains) {
+		return nil
+	}
+	app.Spec.Domains = domains
+	_, _, err = d.client.Update(ctx, app.ID, &godo.AppUpdateRequest{Spec: app.Spec})
+	if err != nil {
+		return fmt.Errorf("app domain delete %q: %w", ref.Name, WrapGodoError(err))
+	}
+	return nil
+}
+
+func (d *AppDomainDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+	domain, err := requiredString(desired.Config, "domain")
+	if err != nil {
+		return nil, fmt.Errorf("app domain diff %q: %w", desired.Name, err)
+	}
+	if current == nil {
+		return &interfaces.DiffResult{NeedsUpdate: true}, nil
+	}
+	var changes []interfaces.FieldChange
+	if curDomain, _ := current.Outputs["domain"].(string); !strings.EqualFold(curDomain, domain) {
+		changes = append(changes, interfaces.FieldChange{Path: "domain", Old: curDomain, New: domain, ForceNew: true})
+	}
+	if desiredType := desiredDomainType(desired.Config); desiredType != "" {
+		curType, _ := current.Outputs["type"].(string)
+		if strings.ToUpper(curType) != desiredType {
+			changes = append(changes, interfaces.FieldChange{Path: "type", Old: curType, New: desiredType})
+		}
+	}
+	for _, key := range []string{"zone", "certificate", "minimum_tls_version"} {
+		desiredValue, _ := desired.Config[key].(string)
+		if desiredValue == "" {
+			continue
+		}
+		currentValue, _ := current.Outputs[key].(string)
+		if currentValue != desiredValue {
+			changes = append(changes, interfaces.FieldChange{Path: key, Old: currentValue, New: desiredValue})
+		}
+	}
+	if desiredWildcard, ok := desired.Config["wildcard"].(bool); ok {
+		currentWildcard, _ := current.Outputs["wildcard"].(bool)
+		if currentWildcard != desiredWildcard {
+			changes = append(changes, interfaces.FieldChange{Path: "wildcard", Old: currentWildcard, New: desiredWildcard})
+		}
+	}
+	return &interfaces.DiffResult{NeedsUpdate: len(changes) > 0, NeedsReplace: hasForceNewChange(changes), Changes: changes}, nil
+}
+
+func (d *AppDomainDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
+	if _, err := d.Read(ctx, ref); err != nil {
+		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+	}
+	return &interfaces.HealthResult{Healthy: true, Message: "domain configured"}, nil
+}
+
+func (d *AppDomainDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
+	return nil, fmt.Errorf("app domain scale: unsupported")
+}
+
+func (d *AppDomainDriver) SensitiveKeys() []string { return nil }
+
+func (d *AppDomainDriver) ProviderIDFormat() interfaces.ProviderIDFormat {
+	return interfaces.IDFormatFreeform
+}
+
+func (d *AppDomainDriver) upsert(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
+	domain, err := requiredString(spec.Config, "domain")
+	if err != nil {
+		return nil, fmt.Errorf("app domain upsert %q: %w", spec.Name, err)
+	}
+	app, err := d.resolveApp(ctx, ref, spec)
+	if err != nil {
+		return nil, fmt.Errorf("app domain upsert %q: %w", spec.Name, err)
+	}
+	if app.Spec == nil {
+		return nil, fmt.Errorf("app domain upsert %q: app %q has nil spec", spec.Name, app.ID)
+	}
+	desired := appDomainSpecFromConfig(domain, spec.Config)
+	app.Spec.Domains = mergeAppDomain(app.Spec.Domains, desired)
+	updated, _, err := d.client.Update(ctx, app.ID, &godo.AppUpdateRequest{Spec: app.Spec})
+	if err != nil {
+		return nil, fmt.Errorf("app domain upsert %q: %w", spec.Name, WrapGodoError(err))
+	}
+	if updated == nil {
+		updated = app
+	}
+	found := findAppDomain(updated, domain)
+	if found == nil {
+		found = desired
+	}
+	return appDomainOutput(spec.Name, updated, found), nil
+}
+
+func (d *AppDomainDriver) resolveApp(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*godo.App, error) {
+	if appID, _, err := parseAppDomainProviderID(ref.ProviderID); err == nil {
+		return d.getApp(ctx, appID)
+	}
+	if appID, _ := spec.Config["app_id"].(string); appID != "" {
+		return d.getApp(ctx, appID)
+	}
+	appName, _ := spec.Config["app"].(string)
+	if appName == "" {
+		appName, _ = spec.Config["app_name"].(string)
+	}
+	if appName == "" {
+		return nil, fmt.Errorf("config requires app or app_id")
+	}
+	return d.findAppObjectByName(ctx, appName)
+}
+
+func (d *AppDomainDriver) getApp(ctx context.Context, appID string) (*godo.App, error) {
+	app, _, err := d.client.Get(ctx, appID)
+	if err != nil {
+		return nil, WrapGodoError(err)
+	}
+	if app == nil || app.ID == "" {
+		return nil, fmt.Errorf("app %q: %w", appID, ErrResourceNotFound)
+	}
+	return app, nil
+}
+
+func (d *AppDomainDriver) findAppObjectByName(ctx context.Context, name string) (*godo.App, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		apps, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("app platform list: %w", WrapGodoError(err))
+		}
+		for _, app := range apps {
+			if app != nil && app.Spec != nil && app.Spec.Name == name {
+				return app, nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return nil, fmt.Errorf("app %q: %w", name, ErrResourceNotFound)
+}
+
+func appDomainSpecFromConfig(domain string, cfg map[string]any) *godo.AppDomainSpec {
+	out := &godo.AppDomainSpec{Domain: domain}
+	if t := desiredDomainType(cfg); t != "" {
+		out.Type = godo.AppDomainSpecType(t)
+	}
+	if zone, _ := cfg["zone"].(string); zone != "" {
+		out.Zone = zone
+	}
+	if certificate, _ := cfg["certificate"].(string); certificate != "" {
+		out.Certificate = certificate
+	}
+	if minimumTLSVersion, _ := cfg["minimum_tls_version"].(string); minimumTLSVersion != "" {
+		out.MinimumTLSVersion = minimumTLSVersion
+	}
+	if wildcard, ok := cfg["wildcard"].(bool); ok {
+		out.Wildcard = wildcard
+	}
+	return out
+}
+
+func desiredDomainType(cfg map[string]any) string {
+	t, _ := cfg["type"].(string)
+	return strings.ToUpper(strings.TrimSpace(t))
+}
+
+func mergeAppDomain(existing []*godo.AppDomainSpec, desired *godo.AppDomainSpec) []*godo.AppDomainSpec {
+	out := make([]*godo.AppDomainSpec, 0, len(existing)+1)
+	replaced := false
+	for _, domain := range existing {
+		if domain != nil && strings.EqualFold(domain.Domain, desired.Domain) {
+			out = append(out, desired)
+			replaced = true
+			continue
+		}
+		out = append(out, domain)
+	}
+	if !replaced {
+		out = append(out, desired)
+	}
+	return out
+}
+
+func findAppDomain(app *godo.App, domain string) *godo.AppDomainSpec {
+	if app == nil || app.Spec == nil {
+		return nil
+	}
+	for _, existing := range app.Spec.Domains {
+		if existing != nil && strings.EqualFold(existing.Domain, domain) {
+			return existing
+		}
+	}
+	return nil
+}
+
+func appDomainOutput(name string, app *godo.App, domain *godo.AppDomainSpec) *interfaces.ResourceOutput {
+	appName := ""
+	if app.Spec != nil {
+		appName = app.Spec.Name
+	}
+	return &interfaces.ResourceOutput{
+		Name:       name,
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/" + domain.Domain,
+		Outputs: map[string]any{
+			"app_id":              app.ID,
+			"app":                 appName,
+			"domain":              domain.Domain,
+			"type":                string(domain.Type),
+			"zone":                domain.Zone,
+			"certificate":         domain.Certificate,
+			"minimum_tls_version": domain.MinimumTLSVersion,
+			"wildcard":            domain.Wildcard,
+		},
+		Status: "active",
+	}
+}
+
+func parseAppDomainProviderID(providerID string) (string, string, error) {
+	appID, domain, ok := strings.Cut(providerID, "/")
+	if !ok || strings.TrimSpace(appID) == "" || strings.TrimSpace(domain) == "" {
+		return "", "", fmt.Errorf("provider_id must be <app-id>/<domain>")
+	}
+	return appID, domain, nil
+}
+
+func requiredString(cfg map[string]any, key string) (string, error) {
+	value, _ := cfg[key].(string)
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", fmt.Errorf("config requires %s", key)
+	}
+	return value, nil
+}
+
+func hasForceNewChange(changes []interfaces.FieldChange) bool {
+	for _, change := range changes {
+		if change.ForceNew {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/drivers/app_domain.go
+++ b/internal/drivers/app_domain.go
@@ -90,6 +90,18 @@ func (d *AppDomainDriver) Diff(_ context.Context, desired interfaces.ResourceSpe
 	if curDomain, _ := current.Outputs["domain"].(string); !strings.EqualFold(curDomain, domain) {
 		changes = append(changes, interfaces.FieldChange{Path: "domain", Old: curDomain, New: domain, ForceNew: true})
 	}
+	if desiredAppID, _ := desired.Config["app_id"].(string); desiredAppID != "" {
+		currentAppID, _ := current.Outputs["app_id"].(string)
+		if currentAppID != desiredAppID {
+			changes = append(changes, interfaces.FieldChange{Path: "app_id", Old: currentAppID, New: desiredAppID, ForceNew: true})
+		}
+	}
+	if desiredApp, _ := desired.Config["app"].(string); desiredApp != "" {
+		currentApp, _ := current.Outputs["app"].(string)
+		if currentApp != desiredApp {
+			changes = append(changes, interfaces.FieldChange{Path: "app", Old: currentApp, New: desiredApp, ForceNew: true})
+		}
+	}
 	if desiredType := desiredDomainType(desired.Config); desiredType != "" {
 		curType, _ := current.Outputs["type"].(string)
 		if strings.ToUpper(curType) != desiredType {
@@ -168,9 +180,6 @@ func (d *AppDomainDriver) resolveApp(ctx context.Context, ref interfaces.Resourc
 		return d.getApp(ctx, appID)
 	}
 	appName, _ := spec.Config["app"].(string)
-	if appName == "" {
-		appName, _ = spec.Config["app_name"].(string)
-	}
 	if appName == "" {
 		return nil, fmt.Errorf("config requires app or app_id")
 	}

--- a/internal/drivers/app_domain_test.go
+++ b/internal/drivers/app_domain_test.go
@@ -1,0 +1,141 @@
+package drivers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
+	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/digitalocean/godo"
+)
+
+func appWithDomains(domains ...*godo.AppDomainSpec) *godo.App {
+	app := testApp()
+	app.Spec = &godo.AppSpec{
+		Name:   "buymywishlist",
+		Region: "nyc",
+		Services: []*godo.AppServiceSpec{{
+			Name: "web",
+			Image: &godo.ImageSourceSpec{
+				RegistryType: "DOCR",
+				Repository:   "bmw-api",
+				Tag:          "sha-abc123",
+			},
+			Envs: []*godo.AppVariableDefinition{{
+				Key:   "DATABASE_URL",
+				Value: "${DATABASE_URL}",
+				Type:  godo.AppVariableType_Secret,
+				Scope: godo.AppVariableScope_RunAndBuildTime,
+			}},
+		}},
+		Domains: domains,
+	}
+	return app
+}
+
+func TestAppDomainDriver_CreateAddsDomainWithoutRebuildingApp(t *testing.T) {
+	app := appWithDomains(&godo.AppDomainSpec{
+		Domain: "buymywishlist.com",
+		Type:   godo.AppDomainSpecType_Primary,
+		Zone:   "buymywishlist.com",
+	})
+	mock := &mockAppClient{app: app, listApps: []*godo.App{app}}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-www-domain",
+		Type: "infra.app_domain",
+		Config: map[string]any{
+			"app":    "buymywishlist",
+			"domain": "www.buymywishlist.com",
+			"type":   "ALIAS",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if out.ProviderID != app.ID+"/www.buymywishlist.com" {
+		t.Fatalf("ProviderID = %q, want %q", out.ProviderID, app.ID+"/www.buymywishlist.com")
+	}
+	if mock.lastUpdateReq == nil {
+		t.Fatal("expected App Platform Update to be called")
+	}
+	got := mock.lastUpdateReq.Spec
+	if got == nil {
+		t.Fatal("Update spec is nil")
+	}
+	if len(got.Services) != 1 || got.Services[0].Image == nil || got.Services[0].Image.Tag != "sha-abc123" {
+		t.Fatalf("service spec was not preserved: %+v", got.Services)
+	}
+	if len(got.Services[0].Envs) != 1 || got.Services[0].Envs[0].Key != "DATABASE_URL" {
+		t.Fatalf("service env was not preserved: %+v", got.Services[0].Envs)
+	}
+	if len(got.Domains) != 2 {
+		t.Fatalf("domains len = %d, want 2: %+v", len(got.Domains), got.Domains)
+	}
+	added := got.Domains[1]
+	if added.Domain != "www.buymywishlist.com" || added.Type != godo.AppDomainSpecType_Alias {
+		t.Fatalf("added domain = %+v, want www alias", added)
+	}
+}
+
+func TestAppDomainDriver_DiffDetectsMissingAndMatchingDomain(t *testing.T) {
+	d := drivers.NewAppDomainDriverWithClient(&mockAppClient{})
+	desired := interfaces.ResourceSpec{
+		Name: "bmw-www-domain",
+		Type: "infra.app_domain",
+		Config: map[string]any{
+			"domain": "www.buymywishlist.com",
+			"type":   "ALIAS",
+		},
+	}
+	missing, err := d.Diff(context.Background(), desired, nil)
+	if err != nil {
+		t.Fatalf("Diff missing: %v", err)
+	}
+	if !missing.NeedsUpdate {
+		t.Fatalf("missing domain Diff.NeedsUpdate = false, want true")
+	}
+
+	matching, err := d.Diff(context.Background(), desired, &interfaces.ResourceOutput{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: "app-id/www.buymywishlist.com",
+		Outputs: map[string]any{
+			"domain": "www.buymywishlist.com",
+			"type":   "ALIAS",
+		},
+		Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("Diff matching: %v", err)
+	}
+	if matching.NeedsUpdate {
+		t.Fatalf("matching domain Diff.NeedsUpdate = true, want false: %+v", matching.Changes)
+	}
+}
+
+func TestAppDomainDriver_DeleteRemovesOnlyDesiredDomain(t *testing.T) {
+	app := appWithDomains(
+		&godo.AppDomainSpec{Domain: "buymywishlist.com", Type: godo.AppDomainSpecType_Primary},
+		&godo.AppDomainSpec{Domain: "www.buymywishlist.com", Type: godo.AppDomainSpecType_Alias},
+	)
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	err := d.Delete(context.Background(), interfaces.ResourceRef{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/www.buymywishlist.com",
+	})
+	if err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if mock.lastUpdateReq == nil || mock.lastUpdateReq.Spec == nil {
+		t.Fatal("expected App Platform Update to be called")
+	}
+	got := mock.lastUpdateReq.Spec.Domains
+	if len(got) != 1 || got[0].Domain != "buymywishlist.com" {
+		t.Fatalf("remaining domains = %+v, want apex only", got)
+	}
+}

--- a/internal/drivers/app_domain_test.go
+++ b/internal/drivers/app_domain_test.go
@@ -115,6 +115,55 @@ func TestAppDomainDriver_DiffDetectsMissingAndMatchingDomain(t *testing.T) {
 	}
 }
 
+func TestAppDomainDriver_DiffTreatsAppTargetChangeAsReplacement(t *testing.T) {
+	d := drivers.NewAppDomainDriverWithClient(&mockAppClient{})
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-www-domain",
+		Type: "infra.app_domain",
+		Config: map[string]any{
+			"app":    "other-app",
+			"domain": "www.buymywishlist.com",
+			"type":   "ALIAS",
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: "app-id/www.buymywishlist.com",
+		Outputs: map[string]any{
+			"app":    "buymywishlist",
+			"app_id": "app-id",
+			"domain": "www.buymywishlist.com",
+			"type":   "ALIAS",
+		},
+		Status: "active",
+	})
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsReplace {
+		t.Fatalf("app target change NeedsReplace = false, want true: %+v", result.Changes)
+	}
+}
+
+func TestAppDomainDriver_CreateRejectsUndocumentedAppNameAlias(t *testing.T) {
+	app := appWithDomains()
+	mock := &mockAppClient{app: app, listApps: []*godo.App{app}}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-www-domain",
+		Type: "infra.app_domain",
+		Config: map[string]any{
+			"app_name": "buymywishlist",
+			"domain":   "www.buymywishlist.com",
+			"type":     "ALIAS",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected undocumented app_name alias to be rejected")
+	}
+}
+
 func TestAppDomainDriver_DeleteRemovesOnlyDesiredDomain(t *testing.T) {
 	app := appWithDomains(
 		&godo.AppDomainSpec{Domain: "buymywishlist.com", Type: godo.AppDomainSpecType_Primary},

--- a/internal/drivers/providerid_format_test.go
+++ b/internal/drivers/providerid_format_test.go
@@ -42,6 +42,7 @@ func TestAllDrivers_DeclareProviderIDFormat(t *testing.T) {
 		{"droplet", drivers.NewDropletDriverWithClient(&mockDropletClient{}, "nyc3"), interfaces.IDFormatFreeform},
 		{"spaces", drivers.NewSpacesDriverWithClient(&mockSpacesClient{}, "nyc3"), interfaces.IDFormatFreeform},
 		{"registry", drivers.NewRegistryDriverWithClient(&mockRegistryClient{}), interfaces.IDFormatFreeform},
+		{"app_domain", drivers.NewAppDomainDriverWithClient(&mockAppClient{}), interfaces.IDFormatFreeform},
 		// IAMRoleDriver has no godo client (DO has no IAM API); construct directly.
 		{"iam_role", drivers.NewIAMRoleDriver(), interfaces.IDFormatFreeform},
 	}

--- a/internal/iacserver_test.go
+++ b/internal/iacserver_test.go
@@ -44,7 +44,7 @@ const (
 // The assertions cover:
 //
 //  1. Required service Name + Version (provider Go methods).
-//  2. Required service Capabilities (the 16-resource declaration list
+//  2. Required service Capabilities (the 17-resource declaration list
 //     emitted by *DOProvider.Capabilities — typed-marshal happy path).
 //  3. Optional Enumerator service EnumerateAll on an
 //     unsupported-by-design resource type ("infra.unsupported_for_test").
@@ -106,8 +106,8 @@ func TestDOIaCProviderRequiredServer_AllRPCs(t *testing.T) {
 		t.Fatalf("Capabilities RPC: %v", err)
 	}
 	got := capsResp.GetCapabilities()
-	if len(got) != 16 {
-		t.Errorf("Capabilities len = %d, want 16 (one per DO resource type)", len(got))
+	if len(got) != 17 {
+		t.Errorf("Capabilities len = %d, want 17 (one per DO resource type)", len(got))
 	}
 	hasContainerService := false
 	for _, c := range got {

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -99,6 +99,7 @@ func (p *DOProvider) Initialize(ctx context.Context, config map[string]any) erro
 
 	p.drivers = map[string]interfaces.ResourceDriver{
 		"infra.container_service": drivers.NewAppPlatformDriver(p.client, p.region),
+		"infra.app_domain":        drivers.NewAppDomainDriver(p.client),
 		"infra.k8s_cluster":       drivers.NewKubernetesDriver(p.client, p.region),
 		"infra.database":          drivers.NewDatabaseDriver(p.client, p.region),
 		"infra.cache":             drivers.NewCacheDriver(p.client, p.region),
@@ -124,6 +125,7 @@ func (p *DOProvider) Capabilities() []interfaces.IaCCapabilityDeclaration {
 	noScale := []string{"create", "read", "update", "delete"}
 	return []interfaces.IaCCapabilityDeclaration{
 		{ResourceType: "infra.container_service", Tier: 3, Operations: ops},
+		{ResourceType: "infra.app_domain", Tier: 2, Operations: noScale},
 		{ResourceType: "infra.k8s_cluster", Tier: 1, Operations: ops},
 		{ResourceType: "infra.database", Tier: 1, Operations: ops},
 		{ResourceType: "infra.cache", Tier: 1, Operations: ops},

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -53,6 +53,7 @@ func TestDOProvider_Capabilities(t *testing.T) {
 	}
 	required := []string{
 		"infra.container_service",
+		"infra.app_domain",
 		"infra.k8s_cluster",
 		"infra.database",
 		"infra.cache",

--- a/internal/sizing.go
+++ b/internal/sizing.go
@@ -62,6 +62,7 @@ var doSizingMap = map[string]map[interfaces.Size]string{
 	},
 	// Resource types below have no variable sizing — all tiers return "n/a".
 	"infra.vpc":         noopSizing(),
+	"infra.app_domain":  noopSizing(),
 	"infra.firewall":    noopSizing(),
 	"infra.dns":         noopSizing(),
 	"infra.storage":     noopSizing(),

--- a/internal/sizing_test.go
+++ b/internal/sizing_test.go
@@ -28,6 +28,7 @@ func TestResolveSizing(t *testing.T) {
 		{"infra.api_gateway", interfaces.SizeS, "apps-s-1vcpu-1gb"},
 		// Types without variable sizing return "n/a".
 		{"infra.vpc", interfaces.SizeM, "n/a"},
+		{"infra.app_domain", interfaces.SizeM, "n/a"},
 		{"infra.firewall", interfaces.SizeL, "n/a"},
 		{"infra.dns", interfaces.SizeS, "n/a"},
 		{"infra.storage", interfaces.SizeXL, "n/a"},

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-plugin-digitalocean",
   "version": "2.0.0",
-  "description": "DigitalOcean IaC provider: App Platform, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
+  "description": "DigitalOcean IaC provider: App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",
@@ -61,6 +61,7 @@
       "name": "digitalocean",
       "resourceTypes": [
         "infra.container_service",
+        "infra.app_domain",
         "infra.k8s_cluster",
         "infra.database",
         "infra.cache",
@@ -86,6 +87,60 @@
             ],
             "default": "public",
             "description": "Whether the service has a public edge route (public, default) or is reachable only from sibling components via DO App Platform internal DNS (<name>.internal:<port>) (internal)."
+          }
+        },
+        "infra.app_domain": {
+          "description": "DigitalOcean App Platform domain binding. Updates only AppSpec.Domains on an existing App Platform app so DNS/domain aliases can be reconciled without rebuilding service images or runtime environment variables.",
+          "fields": {
+            "app": {
+              "type": "string",
+              "required": false,
+              "description": "Existing App Platform app name. Required unless app_id is set."
+            },
+            "app_id": {
+              "type": "string",
+              "required": false,
+              "description": "Existing App Platform app UUID. Required unless app is set."
+            },
+            "domain": {
+              "type": "string",
+              "required": true,
+              "description": "Fully qualified domain name to attach to the app."
+            },
+            "type": {
+              "type": "string",
+              "required": false,
+              "enum": [
+                "PRIMARY",
+                "ALIAS",
+                "DEFAULT"
+              ],
+              "description": "App Platform domain type."
+            },
+            "zone": {
+              "type": "string",
+              "required": false,
+              "description": "DigitalOcean DNS zone for provider-managed DNS validation."
+            },
+            "wildcard": {
+              "type": "bool",
+              "required": false,
+              "description": "Whether the domain is a wildcard binding."
+            },
+            "certificate": {
+              "type": "string",
+              "required": false,
+              "description": "Certificate ID to attach when using a custom certificate."
+            },
+            "minimum_tls_version": {
+              "type": "string",
+              "required": false,
+              "enum": [
+                "1.2",
+                "1.3"
+              ],
+              "description": "Minimum TLS version for this domain."
+            }
           }
         },
         "infra.firewall": {


### PR DESCRIPTION
## Summary
- adds `infra.app_domain` for scoped App Platform domain bindings
- updates only `AppSpec.Domains` on an existing app, preserving services/images/env vars
- advertises the resource through provider capabilities, sizing, manifest schema, README, and provider ID-format tests

## Verification
- RED: `GOWORK=off go test ./internal/drivers -run 'TestAppDomainDriver' -count=1` failed on missing `NewAppDomainDriverWithClient`
- `GOWORK=off go test ./internal/drivers -run 'TestAppDomainDriver|TestAllDrivers_DeclareProviderIDFormat' -count=1`
- `GOWORK=off go test ./internal -run 'TestDOProvider_Capabilities|TestDOIaCProviderRequiredServer_AllRPCs|TestResolveSizing' -count=1`
- `GOWORK=off go test ./...`
- `GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts`
- `git diff --check`
- `GOWORK=off go build ./cmd/plugin`