### PR TITLE
feat: support absent DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ DigitalOcean IaC provider for the [GoCodeAlone/workflow](https://github.com/GoCo
 | `infra.load_balancer` | Load balancer |
 | `infra.vpc` | Virtual Private Cloud |
 | `infra.firewall` | Cloud firewall (Droplet/DOKS tag-based) |
-| `infra.dns` | DNS domain + records |
+| `infra.dns` | DNS domain, records, and targeted stale-record removal |
 | `infra.storage` | Spaces object storage |
 | `infra.registry` | DigitalOcean Container Registry (DOCR) |
 | `infra.certificate` | TLS certificate |
@@ -33,6 +33,24 @@ See [`examples/minimal/config.yaml`](examples/minimal/config.yaml) for a minimal
 wfctl infra plan   --env staging
 wfctl infra apply  --env staging
 ```
+
+## DNS stale-record removal
+
+`infra.dns` is not authoritative for every record in a zone. Use `absent_records` to delete specific stale records while leaving unmanaged records intact.
+
+```yaml
+resources:
+  - name: site-dns
+    type: infra.dns
+    config:
+      domain: example.com
+      absent_records:
+        - type: CNAME
+          name: www
+          data: example.com.
+```
+
+`data` is optional. When omitted, every record matching `type` and `name` is deleted. When set for hostname-like records such as `CNAME`, `MX`, `NS`, and `SRV`, matching ignores case and a trailing dot.
 
 ## Requirements
 

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -50,12 +50,17 @@ func NewDNSDriverWithClient(c DomainsClient) *DNSDriver {
 //
 //	domain   string            — the zone name (e.g. "example.com")
 //	records  []any|[]map[string]any — each: {type, name, data, ttl}
+//	absent_records []any|[]map[string]any — each: {type, name, data?}
 func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
 	domain, err := dnsDomainFromConfig(spec.Config, spec.Name)
 	if err != nil {
 		return nil, err
 	}
 	declaredRecords, err := declaredDNSRecords(spec.Config)
+	if err != nil {
+		return nil, err
+	}
+	absentRecords, err := declaredAbsentDNSRecords(spec.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +93,12 @@ func (d *DNSDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*
 		return nil, err
 	}
 
+	if err := validateDNSAbsentRecordsDoNotConflict(declaredRecords, absentRecords); err != nil {
+		return nil, err
+	}
+	if err := d.deleteRecords(ctx, domain, absentRecords); err != nil {
+		return nil, err
+	}
 	if err := d.upsertRecords(ctx, domain, declaredRecords); err != nil {
 		return nil, err
 	}
@@ -166,8 +177,18 @@ func (d *DNSDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec
 	if err != nil {
 		return nil, err
 	}
+	absentRecords, err := declaredAbsentDNSRecords(spec.Config)
+	if err != nil {
+		return nil, err
+	}
 	if ref.ProviderID != "" && !strings.EqualFold(domain, ref.ProviderID) {
 		return nil, fmt.Errorf("dns update %q: cannot change domain from %q to %q", ref.Name, ref.ProviderID, domain)
+	}
+	if err := validateDNSAbsentRecordsDoNotConflict(declaredRecords, absentRecords); err != nil {
+		return nil, err
+	}
+	if err := d.deleteRecords(ctx, domain, absentRecords); err != nil {
+		return nil, err
 	}
 	if err := d.upsertRecords(ctx, domain, declaredRecords); err != nil {
 		return nil, err
@@ -195,6 +216,13 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 	if err != nil {
 		return nil, err
 	}
+	absentRecords, err := declaredAbsentDNSRecords(desired.Config)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDNSAbsentRecordsDoNotConflict(desiredRecords, absentRecords); err != nil {
+		return nil, err
+	}
 	if current == nil {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
@@ -207,12 +235,15 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 			},
 		}, nil
 	}
-	if len(desiredRecords) == 0 {
-		return &interfaces.DiffResult{NeedsUpdate: false}, nil
-	}
 	currentRecords, err := dnsRecordsFromOutput(current)
 	if err != nil {
 		return nil, err
+	}
+	if dnsAnyAbsentRecordPresent(absentRecords, currentRecords) {
+		return &interfaces.DiffResult{NeedsUpdate: true}, nil
+	}
+	if len(desiredRecords) == 0 {
+		return &interfaces.DiffResult{NeedsUpdate: false}, nil
 	}
 	currentByKey := make(map[string][]godo.DomainRecord)
 	for _, record := range currentRecords {
@@ -232,6 +263,12 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 		}
 	}
 	return &interfaces.DiffResult{NeedsUpdate: false}, nil
+}
+
+type dnsAbsentRecord struct {
+	Type string
+	Name string
+	Data string
 }
 
 func (d *DNSDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
@@ -294,6 +331,31 @@ func (d *DNSDriver) upsertRecords(ctx context.Context, domain string, records []
 				}
 				existingByKey = dnsRecordsByUpsertKey(latest)
 			}
+		}
+	}
+	return nil
+}
+
+func (d *DNSDriver) deleteRecords(ctx context.Context, domain string, records []dnsAbsentRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+	existing, err := d.listRecords(ctx, domain)
+	if err != nil {
+		return err
+	}
+	for _, record := range existing {
+		for _, absent := range records {
+			if !dnsAbsentRecordMatches(absent, record) {
+				continue
+			}
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("dns delete record %q %s/%s: %w", domain, record.Type, record.Name, err)
+			}
+			if _, err := d.client.DeleteRecord(ctx, domain, record.ID); err != nil {
+				return fmt.Errorf("dns delete record %q %s/%s: %w", domain, record.Type, record.Name, WrapGodoError(err))
+			}
+			break
 		}
 	}
 	return nil
@@ -483,7 +545,53 @@ func declaredDNSRecords(config map[string]any) ([]godo.DomainRecordEditRequest, 
 	return out, nil
 }
 
+func declaredAbsentDNSRecords(config map[string]any) ([]dnsAbsentRecord, error) {
+	rawValue, ok := config["absent_records"]
+	if !ok {
+		return nil, nil
+	}
+	raw, err := dnsRecordConfigMapsWithLabel(rawValue, "absent_records")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]dnsAbsentRecord, 0, len(raw))
+	seen := make(map[string]struct{})
+	for i, m := range raw {
+		recordType, err := dnsOptionalStringFieldWithLabel(i, m, "type", "A", "absent_records")
+		if err != nil {
+			return nil, err
+		}
+		recordType = strings.ToUpper(recordType)
+		if !isSupportedDNSRecordType(recordType) {
+			return nil, fmt.Errorf("dns absent_records[%d].type %q is not supported", i, recordType)
+		}
+		name, err := dnsOptionalStringFieldWithLabel(i, m, "name", "@", "absent_records")
+		if err != nil {
+			return nil, err
+		}
+		data, err := dnsOptionalStringFieldWithLabel(i, m, "data", "", "absent_records")
+		if err != nil {
+			return nil, err
+		}
+		absent := dnsAbsentRecord{Type: recordType, Name: name, Data: data}
+		if err := validateDNSAbsentRecord(i, absent); err != nil {
+			return nil, err
+		}
+		key := dnsAbsentRecordIdentity(absent)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, absent)
+	}
+	return out, nil
+}
+
 func dnsRecordConfigMaps(rawValue any) ([]map[string]any, error) {
+	return dnsRecordConfigMapsWithLabel(rawValue, "records")
+}
+
+func dnsRecordConfigMapsWithLabel(rawValue any, label string) ([]map[string]any, error) {
 	switch raw := rawValue.(type) {
 	case []map[string]any:
 		return raw, nil
@@ -492,13 +600,71 @@ func dnsRecordConfigMaps(rawValue any) ([]map[string]any, error) {
 		for i, rec := range raw {
 			m, ok := rec.(map[string]any)
 			if !ok {
-				return nil, fmt.Errorf("dns records[%d] must be an object", i)
+				return nil, fmt.Errorf("dns %s[%d] must be an object", label, i)
 			}
 			maps = append(maps, m)
 		}
 		return maps, nil
 	default:
-		return nil, fmt.Errorf("dns records must be a list")
+		return nil, fmt.Errorf("dns %s must be a list", label)
+	}
+}
+
+func validateDNSAbsentRecord(index int, record dnsAbsentRecord) error {
+	if !isValidDNSRecordName(record.Name) {
+		return fmt.Errorf("dns absent_records[%d].name must be a valid DNS record name", index)
+	}
+	if record.Type == "CNAME" && record.Name == "@" {
+		return fmt.Errorf("dns absent_records[%d].name CNAME records cannot be declared at the zone apex", index)
+	}
+	if record.Data != "" && dnsRecordTypeExpectsHostnameValue(record.Type) {
+		if !isValidDNSHostnameValue(record.Data) {
+			return fmt.Errorf("dns absent_records[%d].data must be a hostname for %s records", index, record.Type)
+		}
+	}
+	return nil
+}
+
+func validateDNSAbsentRecordsDoNotConflict(records []godo.DomainRecordEditRequest, absentRecords []dnsAbsentRecord) error {
+	for _, req := range records {
+		for _, absent := range absentRecords {
+			if absent.Type == req.Type && dnsCanonicalRecordName(absent.Name) == dnsCanonicalRecordName(req.Name) {
+				if absent.Data == "" || dnsRecordDataMatches(absent.Type, absent.Data, req.Data) {
+					return fmt.Errorf("dns records %s/%s cannot be both declared and absent", req.Type, req.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func dnsAnyAbsentRecordPresent(absentRecords []dnsAbsentRecord, currentRecords []godo.DomainRecord) bool {
+	for _, current := range currentRecords {
+		for _, absent := range absentRecords {
+			if dnsAbsentRecordMatches(absent, current) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func dnsAbsentRecordMatches(absent dnsAbsentRecord, record godo.DomainRecord) bool {
+	return strings.EqualFold(absent.Type, record.Type) &&
+		dnsCanonicalRecordName(absent.Name) == dnsCanonicalRecordName(record.Name) &&
+		(absent.Data == "" || dnsRecordDataMatches(absent.Type, absent.Data, record.Data))
+}
+
+func dnsAbsentRecordIdentity(record dnsAbsentRecord) string {
+	return strings.ToUpper(record.Type) + "\x00" + dnsCanonicalRecordName(record.Name) + "\x00" + dnsCanonicalRecordData(record.Type, record.Data)
+}
+
+func dnsRecordTypeExpectsHostnameValue(recordType string) bool {
+	switch recordType {
+	case "CNAME", "MX", "NS", "SRV":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -591,16 +757,20 @@ func dnsRecordEditRequestFromConfig(index int, m map[string]any) (godo.DomainRec
 }
 
 func dnsOptionalStringField(index int, m map[string]any, key, defaultValue string) (string, error) {
+	return dnsOptionalStringFieldWithLabel(index, m, key, defaultValue, "records")
+}
+
+func dnsOptionalStringFieldWithLabel(index int, m map[string]any, key, defaultValue, label string) (string, error) {
 	value, ok := m[key]
 	if !ok {
 		return defaultValue, nil
 	}
 	text, ok := value.(string)
 	if !ok {
-		return "", fmt.Errorf("dns records[%d].%s must be a string", index, key)
+		return "", fmt.Errorf("dns %s[%d].%s must be a string", label, index, key)
 	}
 	if text == "" && defaultValue != "" {
-		return "", fmt.Errorf("dns records[%d].%s must not be empty", index, key)
+		return "", fmt.Errorf("dns %s[%d].%s must not be empty", label, index, key)
 	}
 	return text, nil
 }

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -31,6 +31,7 @@ type mockDomainsClient struct {
 	attemptedEdits              []editedRecord
 	createdRecords              []createdRecord
 	editedRecords               []editedRecord
+	deletedRecords              []deletedRecord
 	createRecordErr             error
 	createRecordErrs            []error
 	afterCreateRecordErr        func()
@@ -55,6 +56,11 @@ type editedRecord struct {
 	domain string
 	id     int
 	req    godo.DomainRecordEditRequest
+}
+
+type deletedRecord struct {
+	domain string
+	id     int
 }
 
 func (m *mockDomainsClient) Create(ctx context.Context, req *godo.DomainCreateRequest) (*godo.Domain, *godo.Response, error) {
@@ -157,7 +163,28 @@ func (m *mockDomainsClient) EditRecord(ctx context.Context, domain string, id in
 	m.replaceRecord(record)
 	return &record, nil, m.err
 }
-func (m *mockDomainsClient) DeleteRecord(_ context.Context, _ string, _ int) (*godo.Response, error) {
+func (m *mockDomainsClient) DeleteRecord(ctx context.Context, domain string, id int) (*godo.Response, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := m.checkDomain(domain); err != nil {
+		return nil, err
+	}
+	m.deletedRecords = append(m.deletedRecords, deletedRecord{domain: domain, id: id})
+	for i := range m.records {
+		if m.records[i].ID == id {
+			m.records = append(m.records[:i], m.records[i+1:]...)
+			break
+		}
+	}
+	for pageIndex := range m.recordPages {
+		for recordIndex := range m.recordPages[pageIndex] {
+			if m.recordPages[pageIndex][recordIndex].ID == id {
+				m.recordPages[pageIndex] = append(m.recordPages[pageIndex][:recordIndex], m.recordPages[pageIndex][recordIndex+1:]...)
+				break
+			}
+		}
+	}
 	return nil, m.err
 }
 func (m *mockDomainsClient) Records(ctx context.Context, domain string, opts *godo.ListOptions) ([]godo.DomainRecord, *godo.Response, error) {
@@ -934,6 +961,223 @@ func TestDNSDriver_Update_NormalEditHonorsCanceledContextBeforeEdit(t *testing.T
 	}
 	if len(mock.editedRecords) != 0 {
 		t.Fatalf("edited records = %d, want 0", len(mock.editedRecords))
+	}
+}
+
+func TestDNSDriver_Update_DeletesAbsentRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+			{ID: 11, Type: "TXT", Name: "@", Data: "keep", TTL: 300},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mock.deletedRecords) != 1 || mock.deletedRecords[0].id != 10 {
+		t.Fatalf("deleted records = %+v, want id 10", mock.deletedRecords)
+	}
+	records := out.Outputs["records"].([]map[string]any)
+	for _, record := range records {
+		if record["type"] == "CNAME" && record["name"] == "www" {
+			t.Fatalf("www CNAME still present in outputs: %+v", records)
+		}
+	}
+}
+
+func TestDNSDriver_Create_DeletesAbsentRecord(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+			{ID: 11, Type: "TXT", Name: "@", Data: "keep", TTL: 300},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	out, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "EXAMPLE.COM"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mock.deletedRecords) != 1 || mock.deletedRecords[0].id != 10 {
+		t.Fatalf("deleted records = %+v, want id 10", mock.deletedRecords)
+	}
+	records := out.Outputs["records"].([]map[string]any)
+	for _, record := range records {
+		if record["type"] == "CNAME" && record["name"] == "www" {
+			t.Fatalf("www CNAME still present in outputs: %+v", records)
+		}
+	}
+}
+
+func TestDNSDriver_Update_DeletesAbsentRecordBeforeUpsert(t *testing.T) {
+	mock := &mockDomainsClient{
+		domain:         testDomain(),
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "example-dns", ProviderID: "example.com",
+	}, interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "example.com."},
+			},
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.ondigitalocean.app.", "ttl": 300},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mock.deletedRecords) != 1 || len(mock.createdRecords) != 1 {
+		t.Fatalf("deleted=%+v created=%+v, want one delete then one create", mock.deletedRecords, mock.createdRecords)
+	}
+	if got := mock.createdRecords[0].req.Data; got != "target.ondigitalocean.app." {
+		t.Fatalf("created data = %q", got)
+	}
+}
+
+func TestDNSDriver_Diff_AbsentRecordNeedsUpdate(t *testing.T) {
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+
+	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www"},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"id": 10, "type": "CNAME", "name": "www", "data": "example.com.", "ttl": 1800},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !diff.NeedsUpdate {
+		t.Fatalf("NeedsUpdate = false, want true")
+	}
+}
+
+func TestDNSDriver_Diff_AbsentRecordDataUsesCanonicalHostnameMatch(t *testing.T) {
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+
+	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "EXAMPLE.COM"},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"id": 10, "type": "CNAME", "name": "www", "data": "example.com.", "ttl": 1800},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !diff.NeedsUpdate {
+		t.Fatalf("NeedsUpdate = false, want true")
+	}
+}
+
+func TestDNSDriver_Diff_DeclaredAndAbsentRecordConflicts(t *testing.T) {
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+
+	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www"},
+			},
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com", "ttl": 300},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+	})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot be both declared and absent") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDNSDriver_Diff_DeclaredAndAbsentRecordConflictsWithCanonicalHostnameData(t *testing.T) {
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+
+	_, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "TARGET.EXAMPLE.COM"},
+			},
+			"records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "target.example.com.", "ttl": 300},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+	})
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot be both declared and absent") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/plugin.json
+++ b/plugin.json
@@ -143,6 +143,26 @@
             }
           }
         },
+        "infra.dns": {
+          "description": "DigitalOcean DNS zone and record reconciliation. Declared records are upserted; absent_records deletes targeted stale records without making the whole zone authoritative.",
+          "fields": {
+            "domain": {
+              "type": "string",
+              "required": true,
+              "description": "DNS zone name."
+            },
+            "records": {
+              "type": "array<object>",
+              "required": false,
+              "description": "Records to create or update. Each record supports type, name, data, ttl, and type-specific fields."
+            },
+            "absent_records": {
+              "type": "array<object>",
+              "required": false,
+              "description": "Records to delete when present. Each entry supports type, name, and optional data for exact-value matching."
+            }
+          }
+        },
         "infra.firewall": {
           "description": "DigitalOcean cloud firewall. Attaches to Droplets by ID or by tag (which auto-attaches future Droplets / DOKS pools that receive the tag). Either `droplet_ids` or `tags` is REQUIRED; `wfctl infra apply` rejects firewalls with no targets before any DO API call. NOTE: DO firewalls do not attach to App Platform apps \u2014 for App-Platform-only deployments, use `expose: internal` services plus `trusted_sources` on managed databases.",
           "fields": {


### PR DESCRIPTION
## Summary
- add `absent_records` to `infra.dns` for targeted stale DNS record removal
- delete absent records before upserting declared records
- document the capability in plugin metadata and README

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts`
- `GOWORK=off go build ./cmd/plugin`
- `git diff --check`