### PR TITLE
fix: check live DNS for absent records

### DIFF
--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -207,7 +207,7 @@ func (d *DNSDriver) Delete(ctx context.Context, ref interfaces.ResourceRef) erro
 	return nil
 }
 
-func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
+func (d *DNSDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, current *interfaces.ResourceOutput) (*interfaces.DiffResult, error) {
 	desiredDomain, hasDesiredDomain, err := dnsDomainFromConfigIfPresent(desired.Config)
 	if err != nil {
 		return nil, err
@@ -238,6 +238,19 @@ func (d *DNSDriver) Diff(_ context.Context, desired interfaces.ResourceSpec, cur
 	currentRecords, err := dnsRecordsFromOutput(current)
 	if err != nil {
 		return nil, err
+	}
+	if len(absentRecords) > 0 && len(currentRecords) == 0 {
+		domain := current.ProviderID
+		if hasDesiredDomain {
+			domain = desiredDomain
+		}
+		if domain != "" {
+			liveRecords, err := d.listRecords(ctx, domain)
+			if err != nil {
+				return nil, err
+			}
+			currentRecords = liveRecords
+		}
 	}
 	if dnsAnyAbsentRecordPresent(absentRecords, currentRecords) {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -1098,6 +1098,40 @@ func TestDNSDriver_Diff_AbsentRecordNeedsUpdate(t *testing.T) {
 	}
 }
 
+func TestDNSDriver_Diff_AbsentRecordChecksLiveRecordsWhenStateHasNoRecords(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "EXAMPLE.COM"},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+		Outputs:    map[string]any{"domain": "example.com"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !diff.NeedsUpdate {
+		t.Fatalf("NeedsUpdate = false, want true")
+	}
+	if len(mock.recordListCalls) == 0 {
+		t.Fatalf("Diff did not check live DNS records")
+	}
+}
+
 func TestDNSDriver_Diff_AbsentRecordDataUsesCanonicalHostnameMatch(t *testing.T) {
 	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
 


### PR DESCRIPTION
## Summary
- make `infra.dns` Diff fall back to live DNS records when `absent_records` is configured and state outputs lack records
- preserve the existing state-output path when records are already available
- add regression coverage for stale live DNS that is missing from persisted state outputs

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts`
- `GOWORK=off go build ./cmd/plugin`
- `git diff --check`

## Context
BMW's scoped www workflow used `absent_records`, but plan still reported no changes because the stale live `www` CNAME was not present in persisted DNS outputs. For deletion intent, live DNS is the source of truth when state has no record list.