### PR TITLE
fix: check live DNS for absent records

### DIFF
--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -239,7 +239,8 @@ func (d *DNSDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, c
 	if err != nil {
 		return nil, err
 	}
-	if len(absentRecords) > 0 && len(currentRecords) == 0 {
+	absentCheckRecords := currentRecords
+	if len(absentRecords) > 0 {
 		domain := current.ProviderID
 		if hasDesiredDomain {
 			domain = desiredDomain
@@ -249,10 +250,10 @@ func (d *DNSDriver) Diff(ctx context.Context, desired interfaces.ResourceSpec, c
 			if err != nil {
 				return nil, err
 			}
-			currentRecords = liveRecords
+			absentCheckRecords = liveRecords
 		}
 	}
-	if dnsAnyAbsentRecordPresent(absentRecords, currentRecords) {
+	if dnsAnyAbsentRecordPresent(absentRecords, absentCheckRecords) {
 		return &interfaces.DiffResult{NeedsUpdate: true}, nil
 	}
 	if len(desiredRecords) == 0 {

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -1070,7 +1070,12 @@ func TestDNSDriver_Update_DeletesAbsentRecordBeforeUpsert(t *testing.T) {
 }
 
 func TestDNSDriver_Diff_AbsentRecordNeedsUpdate(t *testing.T) {
-	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+		},
+	})
 
 	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
 		Name: "example-dns",
@@ -1132,8 +1137,85 @@ func TestDNSDriver_Diff_AbsentRecordChecksLiveRecordsWhenStateHasNoRecords(t *te
 	}
 }
 
+func TestDNSDriver_Diff_AbsentRecordChecksLiveRecordsWhenStateHasManagedRecords(t *testing.T) {
+	mock := &mockDomainsClient{
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "A", Name: "@", Data: "203.0.113.10", TTL: 1800},
+			{ID: 11, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+		},
+	}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "EXAMPLE.COM"},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"id": 10, "type": "A", "name": "@", "data": "203.0.113.10", "ttl": 1800},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !diff.NeedsUpdate {
+		t.Fatalf("NeedsUpdate = false, want true")
+	}
+	if len(mock.recordListCalls) == 0 {
+		t.Fatalf("Diff did not check live DNS records")
+	}
+}
+
+func TestDNSDriver_Diff_AbsentRecordIgnoresStaleStateWhenLiveRecordsAreClean(t *testing.T) {
+	mock := &mockDomainsClient{expectedDomain: "example.com"}
+	d := drivers.NewDNSDriverWithClient(mock)
+
+	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Name: "example-dns",
+		Config: map[string]any{
+			"domain": "example.com",
+			"absent_records": []any{
+				map[string]any{"type": "CNAME", "name": "www", "data": "EXAMPLE.COM"},
+			},
+		},
+	}, &interfaces.ResourceOutput{
+		Name:       "example-dns",
+		Type:       "infra.dns",
+		ProviderID: "example.com",
+		Outputs: map[string]any{
+			"records": []map[string]any{
+				{"id": 10, "type": "CNAME", "name": "www", "data": "example.com.", "ttl": 1800},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff.NeedsUpdate {
+		t.Fatalf("NeedsUpdate = true, want false when live DNS is clean")
+	}
+	if len(mock.recordListCalls) == 0 {
+		t.Fatalf("Diff did not check live DNS records")
+	}
+}
+
 func TestDNSDriver_Diff_AbsentRecordDataUsesCanonicalHostnameMatch(t *testing.T) {
-	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{})
+	d := drivers.NewDNSDriverWithClient(&mockDomainsClient{
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "example.com.", TTL: 1800},
+		},
+	})
 
 	diff, err := d.Diff(context.Background(), interfaces.ResourceSpec{
 		Name: "example-dns",


### PR DESCRIPTION
## Summary
- check live DNS records whenever absent_records is configured
- keep recorded outputs for normal desired record diffing
- add regression coverage for managed state records plus unmanaged stale live records

## Validation
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- GOWORK=off go build ./cmd/plugin
- GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts
- git diff --check