### PR TITLE
fix: reject default custom domains

### DIFF
--- a/internal/drivers/app_domain.go
+++ b/internal/drivers/app_domain.go
@@ -102,6 +102,9 @@ func (d *AppDomainDriver) Diff(_ context.Context, desired interfaces.ResourceSpe
 			changes = append(changes, interfaces.FieldChange{Path: "app", Old: currentApp, New: desiredApp, ForceNew: true})
 		}
 	}
+	if err := validateAppDomainTypeConfig(desired.Config); err != nil {
+		return nil, fmt.Errorf("app domain diff %q: %w", desired.Name, err)
+	}
 	if desiredType := desiredDomainType(desired.Config); desiredType != "" {
 		curType, _ := current.Outputs["type"].(string)
 		if strings.ToUpper(curType) != desiredType {
@@ -156,7 +159,10 @@ func (d *AppDomainDriver) upsert(ctx context.Context, ref interfaces.ResourceRef
 	if app.Spec == nil {
 		return nil, fmt.Errorf("app domain upsert %q: app %q has nil spec", spec.Name, app.ID)
 	}
-	desired := appDomainSpecFromConfig(domain, spec.Config)
+	desired, err := appDomainSpecFromConfig(domain, spec.Config)
+	if err != nil {
+		return nil, fmt.Errorf("app domain upsert %q: %w", spec.Name, err)
+	}
 	app.Spec.Domains = mergeAppDomain(app.Spec.Domains, desired)
 	updated, _, err := d.client.Update(ctx, app.ID, &godo.AppUpdateRequest{Spec: app.Spec})
 	if err != nil {
@@ -217,8 +223,11 @@ func (d *AppDomainDriver) findAppObjectByName(ctx context.Context, name string) 
 	return nil, fmt.Errorf("app %q: %w", name, ErrResourceNotFound)
 }
 
-func appDomainSpecFromConfig(domain string, cfg map[string]any) *godo.AppDomainSpec {
+func appDomainSpecFromConfig(domain string, cfg map[string]any) (*godo.AppDomainSpec, error) {
 	out := &godo.AppDomainSpec{Domain: domain}
+	if err := validateAppDomainTypeConfig(cfg); err != nil {
+		return nil, err
+	}
 	if t := desiredDomainType(cfg); t != "" {
 		out.Type = godo.AppDomainSpecType(t)
 	}
@@ -234,12 +243,24 @@ func appDomainSpecFromConfig(domain string, cfg map[string]any) *godo.AppDomainS
 	if wildcard, ok := cfg["wildcard"].(bool); ok {
 		out.Wildcard = wildcard
 	}
-	return out
+	return out, nil
 }
 
 func desiredDomainType(cfg map[string]any) string {
 	t, _ := cfg["type"].(string)
 	return strings.ToUpper(strings.TrimSpace(t))
+}
+
+func validateAppDomainTypeConfig(cfg map[string]any) error {
+	t := desiredDomainType(cfg)
+	switch t {
+	case "", string(godo.AppDomainSpecType_Primary), string(godo.AppDomainSpecType_Alias):
+		return nil
+	case string(godo.AppDomainSpecType_Default):
+		return fmt.Errorf("domain type DEFAULT is reserved for DigitalOcean starter domains and is rejected by App Platform for custom domains; use PRIMARY or ALIAS")
+	default:
+		return fmt.Errorf("domain type %q is not supported; use PRIMARY or ALIAS", t)
+	}
 }
 
 func mergeAppDomain(existing []*godo.AppDomainSpec, desired *godo.AppDomainSpec) []*godo.AppDomainSpec {

--- a/internal/drivers/app_domain_test.go
+++ b/internal/drivers/app_domain_test.go
@@ -2,6 +2,7 @@ package drivers_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
@@ -76,6 +77,31 @@ func TestAppDomainDriver_CreateAddsDomainWithoutRebuildingApp(t *testing.T) {
 	added := got.Domains[1]
 	if added.Domain != "www.buymywishlist.com" || added.Type != godo.AppDomainSpecType_Alias {
 		t.Fatalf("added domain = %+v, want www alias", added)
+	}
+}
+
+func TestAppDomainDriver_CreateRejectsDefaultDomainType(t *testing.T) {
+	app := appWithDomains()
+	mock := &mockAppClient{app: app, listApps: []*godo.App{app}}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	_, err := d.Create(context.Background(), interfaces.ResourceSpec{
+		Name: "bmw-www-domain",
+		Type: "infra.app_domain",
+		Config: map[string]any{
+			"app":    "buymywishlist",
+			"domain": "www.buymywishlist.com",
+			"type":   "DEFAULT",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected DEFAULT custom domain type to be rejected")
+	}
+	if !strings.Contains(err.Error(), "DEFAULT") || !strings.Contains(err.Error(), "PRIMARY or ALIAS") {
+		t.Fatalf("error = %q, want targeted DEFAULT guidance", err)
+	}
+	if mock.lastUpdateReq != nil {
+		t.Fatal("DEFAULT validation should fail before App Platform Update")
 	}
 }
 

--- a/internal/drivers/app_platform_buildspec.go
+++ b/internal/drivers/app_platform_buildspec.go
@@ -91,6 +91,10 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		return nil, fmt.Errorf("app platform sidecars: %w", err)
 	}
 	services := append([]*godo.AppServiceSpec{svc}, sidecars...)
+	domains, err := domainsFromConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("app platform domains: %w", err)
+	}
 
 	spec := &godo.AppSpec{
 		Name:                         name,
@@ -99,7 +103,7 @@ func buildAppSpec(name string, cfg map[string]any, region string) (*godo.AppSpec
 		Jobs:                         jobsFromConfig(cfg),
 		Workers:                      workersFromConfig(cfg),
 		StaticSites:                  staticSitesFromConfig(cfg),
-		Domains:                      domainsFromConfig(cfg),
+		Domains:                      domains,
 		Alerts:                       appAlertsFromConfig(cfg),
 		Ingress:                      ingress,
 		Egress:                       egressFromConfig(cfg),
@@ -582,13 +586,13 @@ func logDestinationsFromConfig(cfg map[string]any) []*godo.AppLogDestinationSpec
 }
 
 // domainsFromConfig converts the canonical "domains" list to []*godo.AppDomainSpec.
-func domainsFromConfig(cfg map[string]any) []*godo.AppDomainSpec {
+func domainsFromConfig(cfg map[string]any) ([]*godo.AppDomainSpec, error) {
 	raw, ok := cfg["domains"].([]any)
 	if !ok || len(raw) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]*godo.AppDomainSpec, 0, len(raw))
-	for _, v := range raw {
+	for i, v := range raw {
 		m, ok := v.(map[string]any)
 		if !ok {
 			continue
@@ -603,15 +607,18 @@ func domainsFromConfig(cfg map[string]any) []*godo.AppDomainSpec {
 			Certificate:       strFromConfig(m, "certificate", ""),
 			MinimumTLSVersion: strFromConfig(m, "minimum_tls_version", ""),
 		}
+		if err := validateAppDomainTypeConfig(m); err != nil {
+			return nil, fmt.Errorf("domains[%d]: %w", i, err)
+		}
 		if wc, ok := m["wildcard"].(bool); ok {
 			d.Wildcard = wc
 		}
-		if t := strFromConfig(m, "type", ""); t != "" {
-			d.Type = godo.AppDomainSpecType(strings.ToUpper(t))
+		if t := desiredDomainType(m); t != "" {
+			d.Type = godo.AppDomainSpecType(t)
 		}
 		out = append(out, d)
 	}
-	return out
+	return out, nil
 }
 
 // ingressFromConfig converts canonical "ingress" and "routes" config to a

--- a/internal/drivers/app_platform_buildspec_test.go
+++ b/internal/drivers/app_platform_buildspec_test.go
@@ -869,6 +869,47 @@ func TestBuildAppSpec_Domains(t *testing.T) {
 	}
 }
 
+func TestBuildAppSpec_DomainsNormalizesType(t *testing.T) {
+	cfg := map[string]any{
+		"image": "registry.digitalocean.com/myrepo/myapp:v1",
+		"domains": []any{
+			map[string]any{
+				"domain": "app.example.com",
+				"type":   " primary ",
+			},
+		},
+	}
+	spec := buildSpecViaCreate(t, cfg)
+	if got := spec.Domains[0].Type; got != godo.AppDomainSpecType_Primary {
+		t.Fatalf("domain type = %q, want PRIMARY", got)
+	}
+}
+
+func TestBuildAppSpec_DomainsRejectDefaultCustomDomainType(t *testing.T) {
+	cfg := map[string]any{
+		"image": "registry.digitalocean.com/myrepo/myapp:v1",
+		"domains": []any{
+			map[string]any{
+				"domain": "www.example.com",
+				"type":   "DEFAULT",
+				"zone":   "example.com",
+			},
+		},
+	}
+	mock := &mockAppClient{app: testApp()}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	_, err := d.Create(t.Context(), interfaces.ResourceSpec{
+		Name:   "test-app",
+		Config: cfg,
+	})
+	if err == nil {
+		t.Fatal("expected DEFAULT custom domain type to be rejected")
+	}
+	if !strings.Contains(err.Error(), "DEFAULT") || !strings.Contains(err.Error(), "PRIMARY or ALIAS") {
+		t.Fatalf("error = %q, want targeted DEFAULT guidance", err)
+	}
+}
+
 // ── Egress ───────────────────────────────────────────────────────────────────
 
 func TestBuildAppSpec_Egress(t *testing.T) {

--- a/plugin.json
+++ b/plugin.json
@@ -112,10 +112,9 @@
               "required": false,
               "enum": [
                 "PRIMARY",
-                "ALIAS",
-                "DEFAULT"
+                "ALIAS"
               ],
-              "description": "App Platform domain type."
+              "description": "App Platform custom domain type. Use PRIMARY for the app's primary custom domain or ALIAS for a non-primary custom domain."
             },
             "zone": {
               "type": "string",


### PR DESCRIPTION
## Summary
- reject App Platform custom domains configured with type DEFAULT before calling the API
- remove DEFAULT from the plugin schema enum for infra.app_domain
- cover both scoped app-domain updates and full App Platform app spec builds

## Validation
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- GOWORK=off go build ./cmd/plugin
- GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts
- git diff --check