### PR TITLE
fix: surface app domain health

### DIFF
--- a/internal/drivers/app_domain.go
+++ b/internal/drivers/app_domain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
@@ -30,19 +31,11 @@ func (d *AppDomainDriver) Create(ctx context.Context, spec interfaces.ResourceSp
 }
 
 func (d *AppDomainDriver) Read(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.ResourceOutput, error) {
-	appID, domain, err := parseAppDomainProviderID(ref.ProviderID)
+	read, err := d.readAppDomain(ctx, ref)
 	if err != nil {
 		return nil, fmt.Errorf("app domain read %q: %w", ref.Name, err)
 	}
-	app, err := d.getApp(ctx, appID)
-	if err != nil {
-		return nil, fmt.Errorf("app domain read %q: %w", ref.Name, err)
-	}
-	found := findAppDomain(app, domain)
-	if found == nil {
-		return nil, fmt.Errorf("app domain %q on app %q: %w", domain, appID, ErrResourceNotFound)
-	}
-	return appDomainOutput(ref.Name, app, found), nil
+	return appDomainOutput(ref.Name, read.app, read.spec, read.live), nil
 }
 
 func (d *AppDomainDriver) Update(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -131,10 +124,21 @@ func (d *AppDomainDriver) Diff(_ context.Context, desired interfaces.ResourceSpe
 }
 
 func (d *AppDomainDriver) HealthCheck(ctx context.Context, ref interfaces.ResourceRef) (*interfaces.HealthResult, error) {
-	if _, err := d.Read(ctx, ref); err != nil {
+	read, err := d.readAppDomain(ctx, ref)
+	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
-	return &interfaces.HealthResult{Healthy: true, Message: "domain configured"}, nil
+	if read.live == nil {
+		return &interfaces.HealthResult{
+			Healthy: false,
+			Message: fmt.Sprintf("domain %s configured in app spec but live domain status is not reported", read.spec.Domain),
+		}, nil
+	}
+	message := liveDomainHealthMessage(read.live)
+	if read.live.Phase == godo.AppJobSpecKindPHASE_Active {
+		return &interfaces.HealthResult{Healthy: true, Message: message}, nil
+	}
+	return &interfaces.HealthResult{Healthy: false, Message: message}, nil
 }
 
 func (d *AppDomainDriver) Scale(_ context.Context, _ interfaces.ResourceRef, _ int) (*interfaces.ResourceOutput, error) {
@@ -175,7 +179,33 @@ func (d *AppDomainDriver) upsert(ctx context.Context, ref interfaces.ResourceRef
 	if found == nil {
 		found = desired
 	}
-	return appDomainOutput(spec.Name, updated, found), nil
+	return appDomainOutput(spec.Name, updated, found, findLiveAppDomain(updated, domain)), nil
+}
+
+type appDomainRead struct {
+	app  *godo.App
+	spec *godo.AppDomainSpec
+	live *godo.AppDomain
+}
+
+func (d *AppDomainDriver) readAppDomain(ctx context.Context, ref interfaces.ResourceRef) (*appDomainRead, error) {
+	appID, domain, err := parseAppDomainProviderID(ref.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+	app, err := d.getApp(ctx, appID)
+	if err != nil {
+		return nil, err
+	}
+	found := findAppDomain(app, domain)
+	live := findLiveAppDomain(app, domain)
+	if found == nil && live != nil {
+		found = live.Spec
+	}
+	if found == nil {
+		return nil, fmt.Errorf("app domain %q on app %q: %w", domain, appID, ErrResourceNotFound)
+	}
+	return &appDomainRead{app: app, spec: found, live: live}, nil
 }
 
 func (d *AppDomainDriver) resolveApp(ctx context.Context, ref interfaces.ResourceRef, spec interfaces.ResourceSpec) (*godo.App, error) {
@@ -292,26 +322,144 @@ func findAppDomain(app *godo.App, domain string) *godo.AppDomainSpec {
 	return nil
 }
 
-func appDomainOutput(name string, app *godo.App, domain *godo.AppDomainSpec) *interfaces.ResourceOutput {
+func findLiveAppDomain(app *godo.App, domain string) *godo.AppDomain {
+	if app == nil {
+		return nil
+	}
+	for _, existing := range app.Domains {
+		if existing == nil || existing.Spec == nil {
+			continue
+		}
+		if strings.EqualFold(existing.Spec.Domain, domain) {
+			return existing
+		}
+	}
+	return nil
+}
+
+func appDomainOutput(name string, app *godo.App, domain *godo.AppDomainSpec, live *godo.AppDomain) *interfaces.ResourceOutput {
 	appName := ""
 	if app.Spec != nil {
 		appName = app.Spec.Name
+	}
+	outputs := map[string]any{
+		"app_id":              app.ID,
+		"app":                 appName,
+		"domain":              domain.Domain,
+		"type":                string(domain.Type),
+		"zone":                domain.Zone,
+		"certificate":         domain.Certificate,
+		"minimum_tls_version": domain.MinimumTLSVersion,
+		"wildcard":            domain.Wildcard,
+	}
+	status := "configured"
+	if live != nil {
+		addLiveDomainOutputs(outputs, live)
+		status = appDomainStatus(live.Phase)
 	}
 	return &interfaces.ResourceOutput{
 		Name:       name,
 		Type:       "infra.app_domain",
 		ProviderID: app.ID + "/" + domain.Domain,
-		Outputs: map[string]any{
-			"app_id":              app.ID,
-			"app":                 appName,
-			"domain":              domain.Domain,
-			"type":                string(domain.Type),
-			"zone":                domain.Zone,
-			"certificate":         domain.Certificate,
-			"minimum_tls_version": domain.MinimumTLSVersion,
-			"wildcard":            domain.Wildcard,
-		},
-		Status: "active",
+		Outputs:    outputs,
+		Status:     status,
+	}
+}
+
+func addLiveDomainOutputs(outputs map[string]any, live *godo.AppDomain) {
+	outputs["phase"] = string(live.Phase)
+	if live.ID != "" {
+		outputs["domain_id"] = live.ID
+	}
+	if !live.CertificateExpiresAt.IsZero() {
+		outputs["certificate_expires_at"] = live.CertificateExpiresAt.Format(time.RFC3339)
+	}
+	if live.Validation != nil {
+		outputs["validation_txt_name"] = live.Validation.TXTName
+		outputs["validation_txt_value"] = live.Validation.TXTValue
+	}
+	if len(live.Validations) > 0 {
+		validations := make([]any, 0, len(live.Validations))
+		for _, validation := range live.Validations {
+			if validation == nil {
+				continue
+			}
+			validations = append(validations, map[string]any{
+				"txt_name":  validation.TXTName,
+				"txt_value": validation.TXTValue,
+			})
+		}
+		if len(validations) > 0 {
+			outputs["validations"] = validations
+		}
+	}
+	if progress := appDomainProgressSummary(live.Progress); progress != "" {
+		outputs["progress"] = progress
+	}
+}
+
+func appDomainStatus(phase godo.AppDomainPhase) string {
+	switch phase {
+	case godo.AppJobSpecKindPHASE_Active:
+		return "active"
+	case godo.AppJobSpecKindPHASE_Pending:
+		return "pending"
+	case godo.AppJobSpecKindPHASE_Configuring:
+		return "configuring"
+	case godo.AppJobSpecKindPHASE_Error:
+		return "error"
+	case godo.AppJobSpecKindPHASE_Unknown, "":
+		return "unknown"
+	default:
+		return strings.ToLower(string(phase))
+	}
+}
+
+func liveDomainHealthMessage(live *godo.AppDomain) string {
+	message := fmt.Sprintf("domain phase %s", live.Phase)
+	if progress := appDomainProgressSummary(live.Progress); progress != "" {
+		message += ": " + progress
+	}
+	return message
+}
+
+func appDomainProgressSummary(progress *godo.AppDomainProgress) string {
+	if progress == nil {
+		return ""
+	}
+	var parts []string
+	for _, step := range progress.Steps {
+		collectDomainProgressStep(&parts, step)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func collectDomainProgressStep(parts *[]string, step *godo.AppDomainProgressStep) {
+	if step == nil {
+		return
+	}
+	current := strings.TrimSpace(step.Name)
+	if current == "" {
+		current = "step"
+	}
+	if step.Status != "" {
+		current += ": " + string(step.Status)
+	}
+	if step.Reason != nil {
+		reason := strings.TrimSpace(step.Reason.Code)
+		if step.Reason.Message != "" {
+			if reason != "" {
+				reason += ": "
+			}
+			reason += strings.TrimSpace(step.Reason.Message)
+		}
+		if reason != "" {
+			current += " " + reason
+		}
+	}
+	*parts = append(*parts, current)
+	for _, child := range step.Steps {
+		collectDomainProgressStep(parts, child)
 	}
 }
 

--- a/internal/drivers/app_domain_test.go
+++ b/internal/drivers/app_domain_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
 	"github.com/GoCodeAlone/workflow/interfaces"
 	"github.com/digitalocean/godo"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func appWithDomains(domains ...*godo.AppDomainSpec) *godo.App {
@@ -102,6 +103,140 @@ func TestAppDomainDriver_CreateRejectsDefaultDomainType(t *testing.T) {
 	}
 	if mock.lastUpdateReq != nil {
 		t.Fatal("DEFAULT validation should fail before App Platform Update")
+	}
+}
+
+func TestAppDomainDriver_ReadIncludesLiveDomainStatus(t *testing.T) {
+	app := appWithDomains(&godo.AppDomainSpec{
+		Domain:   "www.buymywishlist.com",
+		Type:     godo.AppDomainSpecType_Alias,
+		Zone:     "buymywishlist.com",
+		Wildcard: true,
+	})
+	app.Domains = []*godo.AppDomain{{
+		ID:    "domain-1",
+		Spec:  &godo.AppDomainSpec{Domain: "www.buymywishlist.com"},
+		Phase: godo.AppJobSpecKindPHASE_Configuring,
+		Validation: &godo.AppDomainValidation{
+			TXTName:  "_acme-challenge.www",
+			TXTValue: "txt-value",
+		},
+		Validations: []*godo.AppDomainValidation{{
+			TXTName:  "_acme-challenge.www",
+			TXTValue: "txt-value",
+		}},
+		Progress: &godo.AppDomainProgress{Steps: []*godo.AppDomainProgressStep{{
+			Name:   "certificate",
+			Status: godo.AppJobSpecKindProgressStepStatus_Running,
+		}}},
+	}}
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	out, err := d.Read(context.Background(), interfaces.ResourceRef{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/www.buymywishlist.com",
+	})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if out.Status != "configuring" {
+		t.Fatalf("Status = %q, want configuring", out.Status)
+	}
+	if got := out.Outputs["phase"]; got != "CONFIGURING" {
+		t.Fatalf("phase output = %#v, want CONFIGURING", got)
+	}
+	if got := out.Outputs["validation_txt_name"]; got != "_acme-challenge.www" {
+		t.Fatalf("validation_txt_name = %#v, want TXT name", got)
+	}
+	if got := out.Outputs["validation_txt_value"]; got != "txt-value" {
+		t.Fatalf("validation_txt_value = %#v, want TXT value", got)
+	}
+	if got := out.Outputs["progress"]; got != "certificate: RUNNING" {
+		t.Fatalf("progress = %#v, want certificate progress", got)
+	}
+	if _, err := structpb.NewStruct(out.Outputs); err != nil {
+		t.Fatalf("outputs are not structpb-compatible: %v", err)
+	}
+	validations, ok := out.Outputs["validations"].([]any)
+	if !ok || len(validations) != 1 {
+		t.Fatalf("validations = %#v, want []any with one element", out.Outputs["validations"])
+	}
+	validation, ok := validations[0].(map[string]any)
+	if !ok {
+		t.Fatalf("validations[0] = %#v, want map[string]any", validations[0])
+	}
+	if validation["txt_name"] != "_acme-challenge.www" || validation["txt_value"] != "txt-value" {
+		t.Fatalf("validation = %#v, want TXT details", validation)
+	}
+}
+
+func TestAppDomainDriver_HealthCheckReportsLiveDomainError(t *testing.T) {
+	app := appWithDomains(&godo.AppDomainSpec{Domain: "www.buymywishlist.com", Type: godo.AppDomainSpecType_Alias})
+	app.Domains = []*godo.AppDomain{{
+		Spec:  &godo.AppDomainSpec{Domain: "www.buymywishlist.com"},
+		Phase: godo.AppJobSpecKindPHASE_Error,
+		Progress: &godo.AppDomainProgress{Steps: []*godo.AppDomainProgressStep{{
+			Name:   "certificate",
+			Status: godo.AppJobSpecKindProgressStepStatus_Error,
+			Reason: &godo.AppDomainProgressStepReason{
+				Code:    "validation_failed",
+				Message: "CNAME target is invalid",
+			},
+		}}},
+	}}
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/www.buymywishlist.com",
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if result.Healthy {
+		t.Fatal("HealthCheck healthy = true, want false")
+	}
+	if !strings.Contains(result.Message, "ERROR") || !strings.Contains(result.Message, "validation_failed") || !strings.Contains(result.Message, "CNAME target is invalid") {
+		t.Fatalf("HealthCheck message = %q, want phase and progress reason", result.Message)
+	}
+}
+
+func TestAppDomainDriver_HealthCheckRequiresLiveDomainActive(t *testing.T) {
+	app := appWithDomains(&godo.AppDomainSpec{Domain: "www.buymywishlist.com", Type: godo.AppDomainSpecType_Alias})
+	app.Domains = []*godo.AppDomain{{
+		Spec:  &godo.AppDomainSpec{Domain: "www.buymywishlist.com"},
+		Phase: godo.AppJobSpecKindPHASE_Pending,
+	}}
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppDomainDriverWithClient(mock)
+
+	pending, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/www.buymywishlist.com",
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck pending: %v", err)
+	}
+	if pending.Healthy || !strings.Contains(pending.Message, "PENDING") {
+		t.Fatalf("pending result = %+v, want unhealthy PENDING", pending)
+	}
+
+	app.Domains[0].Phase = godo.AppJobSpecKindPHASE_Active
+	active, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "bmw-www-domain",
+		Type:       "infra.app_domain",
+		ProviderID: app.ID + "/www.buymywishlist.com",
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck active: %v", err)
+	}
+	if !active.Healthy || !strings.Contains(active.Message, "ACTIVE") {
+		t.Fatalf("active result = %+v, want healthy ACTIVE", active)
 	}
 }
 


### PR DESCRIPTION
## Summary
- read DigitalOcean App Platform live domain metadata from `app.domains`
- expose domain phase, progress, validation TXT records, and certificate expiry in app-domain outputs
- make app-domain health fail until the live phase is `ACTIVE`

## TDD proof
With implementation reverted and tests kept:
```
$ GOWORK=off go test ./internal/drivers -run 'TestAppDomainDriver_(ReadIncludesLiveDomainStatus|HealthCheckReportsLiveDomainError|HealthCheckRequiresLiveDomainActive)' -count=1\nFAIL: Status = "active", want configuring; health stayed true for ERROR/PENDING\n```\n\nWith implementation restored:\n```\n$ GOWORK=off go test ./internal/drivers -run 'TestAppDomainDriver_(ReadIncludesLiveDomainStatus|HealthCheckReportsLiveDomainError|HealthCheckRequiresLiveDomainActive)' -count=1\nok github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers\n```\n\n## Verification\n- `GOWORK=off go test ./...`\n- `GOWORK=off go vet ./...`\n- `GOWORK=off go build ./cmd/plugin`\n- `GOWORK=off go run github.com/GoCodeAlone/workflow/cmd/wfctl@v0.57.1 plugin validate --file plugin.json --strict-contracts`\n- `git diff --check`