### PR TITLE
fix: wait for updated app deployment

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoCodeAlone/workflow/interfaces"
@@ -52,12 +53,16 @@ type appPlatformMigrationRepairClient interface {
 
 // AppPlatformDriver manages DigitalOcean App Platform (infra.container_service).
 type AppPlatformDriver struct {
-	client                     AppPlatformClient
-	regClient                  RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
-	region                     string
+	client             AppPlatformClient
+	regClient          RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
+	region             string
+	deploymentMu       sync.Mutex
+	waitingDeployments map[string]*appDeploymentWaitState
+}
+
+type appDeploymentWaitState struct {
 	targetDeploymentID         string
 	previousActiveDeploymentID string
-	waitingForDeployment       bool
 }
 
 // NewAppPlatformDriver creates an AppPlatformDriver backed by a real godo client.
@@ -174,13 +179,20 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 		return nil, fmt.Errorf("app platform build spec: %w", err)
 	}
 
+	current, _, err := d.client.Get(ctx, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("app platform update %q: read current app: %w", ref.Name, WrapGodoError(err))
+	}
+	previousActiveDeploymentID := deploymentID(current.ActiveDeployment)
+
 	app, _, err := d.client.Update(ctx, providerID, &godo.AppUpdateRequest{Spec: appSpec})
 	if err != nil {
 		return nil, fmt.Errorf("app platform update %q: %w", ref.Name, WrapGodoError(err))
 	}
-	d.previousActiveDeploymentID = deploymentID(app.ActiveDeployment)
-	d.waitingForDeployment = true
-	d.targetDeploymentID = deploymentID(selectUpdateDeployment(app, d.previousActiveDeploymentID))
+	d.setUpdateDeploymentState(providerID, appDeploymentWaitState{
+		previousActiveDeploymentID: previousActiveDeploymentID,
+		targetDeploymentID:         deploymentID(selectUpdateDeployment(app, previousActiveDeploymentID)),
+	})
 	return appOutput(app), nil
 }
 
@@ -440,17 +452,18 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
-	if d.waitingForDeployment {
-		dep, err := d.currentTargetDeployment(ctx, providerID, app)
+	if d.hasUpdateDeploymentState(providerID) {
+		dep, previousActiveDeploymentID, err := d.currentTargetDeployment(ctx, providerID, app)
 		if err != nil {
 			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 		}
 		if dep == nil {
-			return &interfaces.HealthResult{Healthy: false, Message: fmt.Sprintf("waiting for deployment after update: previous active %s", d.previousActiveDeploymentID)}, nil
+			return &interfaces.HealthResult{Healthy: false, Message: fmt.Sprintf("waiting for deployment after update: previous active %s", previousActiveDeploymentID)}, nil
 		}
 		if err := deploymentHealthError(ref.Name, dep); err != nil {
 			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 		}
+		d.clearUpdateDeploymentState(providerID)
 		return &interfaces.HealthResult{Healthy: true}, nil
 	}
 	listFn := func(ctx context.Context, appID string) ([]*godo.Deployment, error) {
@@ -460,30 +473,58 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 	return appHealthResult(ctx, listFn, app), nil
 }
 
-func (d *AppPlatformDriver) currentTargetDeployment(ctx context.Context, providerID string, app *godo.App) (*godo.Deployment, error) {
-	if dep := selectUpdateDeployment(app, d.previousActiveDeploymentID); dep != nil {
-		if d.targetDeploymentID == "" || dep.ID == d.targetDeploymentID {
-			d.targetDeploymentID = dep.ID
-			return dep, nil
+func (d *AppPlatformDriver) setUpdateDeploymentState(providerID string, state appDeploymentWaitState) {
+	d.deploymentMu.Lock()
+	defer d.deploymentMu.Unlock()
+	if d.waitingDeployments == nil {
+		d.waitingDeployments = make(map[string]*appDeploymentWaitState)
+	}
+	stateCopy := state
+	d.waitingDeployments[providerID] = &stateCopy
+}
+
+func (d *AppPlatformDriver) hasUpdateDeploymentState(providerID string) bool {
+	d.deploymentMu.Lock()
+	defer d.deploymentMu.Unlock()
+	return d.waitingDeployments != nil && d.waitingDeployments[providerID] != nil
+}
+
+func (d *AppPlatformDriver) clearUpdateDeploymentState(providerID string) {
+	d.deploymentMu.Lock()
+	defer d.deploymentMu.Unlock()
+	delete(d.waitingDeployments, providerID)
+}
+
+func (d *AppPlatformDriver) currentTargetDeployment(ctx context.Context, providerID string, app *godo.App) (*godo.Deployment, string, error) {
+	d.deploymentMu.Lock()
+	defer d.deploymentMu.Unlock()
+	state := d.waitingDeployments[providerID]
+	if state == nil {
+		return nil, "", nil
+	}
+	if dep := selectUpdateDeployment(app, state.previousActiveDeploymentID); dep != nil {
+		if state.targetDeploymentID == "" || dep.ID == state.targetDeploymentID {
+			state.targetDeploymentID = dep.ID
+			return dep, state.previousActiveDeploymentID, nil
 		}
 	}
 	deployments, _, err := d.client.ListDeployments(ctx, providerID, &godo.ListOptions{Page: 1, PerPage: 20})
 	if err != nil {
-		return nil, fmt.Errorf("list deployments: %w", err)
+		return nil, state.previousActiveDeploymentID, fmt.Errorf("app platform health check %q: list deployments: %w", providerID, WrapGodoError(err))
 	}
 	for _, dep := range deployments {
 		if dep == nil {
 			continue
 		}
-		if d.targetDeploymentID != "" && dep.ID == d.targetDeploymentID {
-			return dep, nil
+		if state.targetDeploymentID != "" && dep.ID == state.targetDeploymentID {
+			return dep, state.previousActiveDeploymentID, nil
 		}
-		if d.targetDeploymentID == "" && isHistoricalUpdateDeployment(dep, d.previousActiveDeploymentID) {
-			d.targetDeploymentID = dep.ID
-			return dep, nil
+		if state.targetDeploymentID == "" && isHistoricalUpdateDeployment(dep, state.previousActiveDeploymentID) {
+			state.targetDeploymentID = dep.ID
+			return dep, state.previousActiveDeploymentID, nil
 		}
 	}
-	return nil, nil
+	return nil, state.previousActiveDeploymentID, nil
 }
 
 // listDeploymentsFn is a function that returns the most recent deployment(s)

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -52,9 +52,12 @@ type appPlatformMigrationRepairClient interface {
 
 // AppPlatformDriver manages DigitalOcean App Platform (infra.container_service).
 type AppPlatformDriver struct {
-	client    AppPlatformClient
-	regClient RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
-	region    string
+	client                     AppPlatformClient
+	regClient                  RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
+	region                     string
+	targetDeploymentID         string
+	previousActiveDeploymentID string
+	waitingForDeployment       bool
 }
 
 // NewAppPlatformDriver creates an AppPlatformDriver backed by a real godo client.
@@ -175,6 +178,9 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 	if err != nil {
 		return nil, fmt.Errorf("app platform update %q: %w", ref.Name, WrapGodoError(err))
 	}
+	d.previousActiveDeploymentID = deploymentID(app.ActiveDeployment)
+	d.waitingForDeployment = true
+	d.targetDeploymentID = deploymentID(selectUpdateDeployment(app, d.previousActiveDeploymentID))
 	return appOutput(app), nil
 }
 
@@ -434,11 +440,50 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 	if err != nil {
 		return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 	}
+	if d.waitingForDeployment {
+		dep, err := d.currentTargetDeployment(ctx, providerID, app)
+		if err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
+		if dep == nil {
+			return &interfaces.HealthResult{Healthy: false, Message: fmt.Sprintf("waiting for deployment after update: previous active %s", d.previousActiveDeploymentID)}, nil
+		}
+		if err := deploymentHealthError(ref.Name, dep); err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
+		return &interfaces.HealthResult{Healthy: true}, nil
+	}
 	listFn := func(ctx context.Context, appID string) ([]*godo.Deployment, error) {
 		deps, _, err := d.client.ListDeployments(ctx, appID, &godo.ListOptions{Page: 1, PerPage: 1})
 		return deps, err
 	}
 	return appHealthResult(ctx, listFn, app), nil
+}
+
+func (d *AppPlatformDriver) currentTargetDeployment(ctx context.Context, providerID string, app *godo.App) (*godo.Deployment, error) {
+	if dep := selectUpdateDeployment(app, d.previousActiveDeploymentID); dep != nil {
+		if d.targetDeploymentID == "" || dep.ID == d.targetDeploymentID {
+			d.targetDeploymentID = dep.ID
+			return dep, nil
+		}
+	}
+	deployments, _, err := d.client.ListDeployments(ctx, providerID, &godo.ListOptions{Page: 1, PerPage: 20})
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	for _, dep := range deployments {
+		if dep == nil {
+			continue
+		}
+		if d.targetDeploymentID != "" && dep.ID == d.targetDeploymentID {
+			return dep, nil
+		}
+		if d.targetDeploymentID == "" && isHistoricalUpdateDeployment(dep, d.previousActiveDeploymentID) {
+			d.targetDeploymentID = dep.ID
+			return dep, nil
+		}
+	}
+	return nil, nil
 }
 
 // listDeploymentsFn is a function that returns the most recent deployment(s)

--- a/internal/drivers/app_platform_stateheal_test.go
+++ b/internal/drivers/app_platform_stateheal_test.go
@@ -117,6 +117,11 @@ func TestCreate_ProviderIDIsUUIDFromAPI(t *testing.T) {
 func TestUpdate_UsesUUIDWhenProviderIDIsValid(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	c := &stateHealClient{
+		getApp: &godo.App{
+			ID:               uuid,
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "dep-old", Phase: godo.DeploymentPhase_Active},
+		},
 		updatedApp: &godo.App{
 			ID:   uuid,
 			Spec: &godo.AppSpec{Name: "bmw-staging"},
@@ -144,6 +149,11 @@ func TestUpdate_UsesUUIDWhenProviderIDIsValid(t *testing.T) {
 func TestUpdate_HealsStaleName(t *testing.T) {
 	const uuid = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
 	c := &stateHealClient{
+		getApp: &godo.App{
+			ID:               uuid,
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "dep-old", Phase: godo.DeploymentPhase_Active},
+		},
 		// List returns the real app so findAppByName resolves name → UUID.
 		listApps: []*godo.App{
 			{ID: uuid, Spec: &godo.AppSpec{Name: "bmw-staging"}},
@@ -175,6 +185,43 @@ func TestUpdate_HealsStaleName(t *testing.T) {
 	// Returned output must carry the healed UUID.
 	if out.ProviderID != uuid {
 		t.Errorf("ResourceOutput.ProviderID = %q, want UUID %q", out.ProviderID, uuid)
+	}
+}
+
+func TestUpdateDeploymentWaitStateIsScopedPerProviderID(t *testing.T) {
+	const appOne = "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5"
+	const appTwo = "921d821e-12a6-4cb8-a0c1-e131f08af08e"
+	c := &stateHealClient{
+		getApp: &godo.App{
+			ID:               appOne,
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "dep-old", Phase: godo.DeploymentPhase_Active},
+		},
+		updatedApp: &godo.App{
+			ID:               appOne,
+			Spec:             &godo.AppSpec{Name: "bmw-staging"},
+			ActiveDeployment: &godo.Deployment{ID: "dep-old", Phase: godo.DeploymentPhase_Active},
+		},
+	}
+	d := NewAppPlatformDriverWithClient(c, "nyc3")
+	if _, err := d.Update(context.Background(), interfaces.ResourceRef{Name: "bmw-staging", ProviderID: appOne}, interfaces.ResourceSpec{
+		Name:   "bmw-staging",
+		Config: map[string]any{"image": "docker.io/myorg/myapp:latest"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	c.getApp = &godo.App{
+		ID:               appTwo,
+		Spec:             &godo.AppSpec{Name: "other-app"},
+		ActiveDeployment: &godo.Deployment{ID: "dep-other", Phase: godo.DeploymentPhase_Active},
+	}
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{Name: "other-app", ProviderID: appTwo})
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheck for unrelated app inherited update wait state: %q", result.Message)
 	}
 }
 

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -194,6 +194,48 @@ func TestAppPlatformDriver_Update_Success(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate(t *testing.T) {
+	app := testApp()
+	app.ActiveDeployment.ID = "dep-old"
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}
+
+	if _, err := d.Update(context.Background(), ref, interfaces.ResourceSpec{
+		Name:   "my-app",
+		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheck reported old active deployment healthy while waiting for update deployment")
+	}
+	if !strings.Contains(result.Message, "waiting for deployment after update") {
+		t.Fatalf("HealthCheck message = %q, want waiting for deployment after update", result.Message)
+	}
+
+	mock.deployments = []*godo.Deployment{{
+		ID:                   "dep-new",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-old",
+	}}
+	result, err = d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck after deployment observed: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheck after new deployment active Healthy=false, message=%q", result.Message)
+	}
+}
+
 func TestAppPlatformDriver_Update_Error(t *testing.T) {
 	mock := &mockAppClient{err: fmt.Errorf("update failed")}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -28,6 +28,7 @@ func makeGodoErr(statusCode int) error {
 type mockAppClient struct {
 	app                    *godo.App
 	err                    error
+	updateErr              error
 	listApps               []*godo.App        // returned by List
 	listErr                error              // error returned by List
 	deployments            []*godo.Deployment // returned by ListDeployments
@@ -60,6 +61,9 @@ func (m *mockAppClient) List(_ context.Context, _ *godo.ListOptions) ([]*godo.Ap
 }
 func (m *mockAppClient) Update(_ context.Context, _ string, req *godo.AppUpdateRequest) (*godo.App, *godo.Response, error) {
 	m.lastUpdateReq = req
+	if m.updateErr != nil {
+		return m.app, nil, m.updateErr
+	}
 	return m.app, nil, m.err
 }
 func (m *mockAppClient) CreateDeployment(_ context.Context, _ string, reqs ...*godo.DeploymentCreateRequest) (*godo.Deployment, *godo.Response, error) {
@@ -237,7 +241,7 @@ func TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate(t *tes
 }
 
 func TestAppPlatformDriver_Update_Error(t *testing.T) {
-	mock := &mockAppClient{err: fmt.Errorf("update failed")}
+	mock := &mockAppClient{app: testApp(), updateErr: fmt.Errorf("update failed")}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{
@@ -258,7 +262,7 @@ func TestAppPlatformDriver_Update_Error(t *testing.T) {
 }
 
 func TestAppPlatformDriver_Update_ErrorSentinelPropagates(t *testing.T) {
-	mock := &mockAppClient{err: makeGodoErr(http.StatusTooManyRequests)}
+	mock := &mockAppClient{app: testApp(), updateErr: makeGodoErr(http.StatusTooManyRequests)}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
 
 	_, err := d.Update(context.Background(), interfaces.ResourceRef{


### PR DESCRIPTION
## Summary
- make AppPlatformDriver remember the deployment triggered by Update
- make HealthCheck wait for that deployment instead of accepting an older active deployment
- add regression coverage for stale active slot after an app update

## Verification
- GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_(HealthCheckWaitsForDeploymentTriggeredByUpdate|Update_Error|Update_ErrorSentinelPropagates|Update_UsesUUIDWhenProviderIDIsValid|Update_HealsStaleName)' -count=1
- GOWORK=off go test ./...

## TDD proof
With only the test added:
```
GOWORK=off go test ./internal/drivers -run TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate -count=1
FAIL: HealthCheck reported old active deployment healthy while waiting for update deployment
```

With the fix restored:
```
GOWORK=off go test ./internal/drivers -run TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate -count=1
ok github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers
```
