### PR TITLE
fix: follow superseding App Platform deployments

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -507,6 +507,10 @@ func (d *AppPlatformDriver) currentTargetDeployment(ctx context.Context, provide
 			state.targetDeploymentID = dep.ID
 			return dep, state.previousActiveDeploymentID, nil
 		}
+		if dep.PreviousDeploymentID == state.targetDeploymentID {
+			state.targetDeploymentID = dep.ID
+			return dep, state.previousActiveDeploymentID, nil
+		}
 	}
 	deployments, _, err := d.client.ListDeployments(ctx, providerID, &godo.ListOptions{Page: 1, PerPage: 20})
 	if err != nil {

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -240,6 +240,52 @@ func TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate(t *tes
 	}
 }
 
+func TestAppPlatformDriver_HealthCheckRetargetsWhenUpdateDeploymentIsSuperseded(t *testing.T) {
+	app := testApp()
+	app.ActiveDeployment.ID = "dep-old"
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}
+
+	if _, err := d.Update(context.Background(), ref, interfaces.ResourceSpec{
+		Name:   "my-app",
+		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	mock.deployments = []*godo.Deployment{{
+		ID:                   "dep-triggered",
+		Phase:                godo.DeploymentPhase_Superseded,
+		Cause:                "app spec updated",
+		PreviousDeploymentID: "dep-old",
+	}}
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck after superseded deployment observed: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheck should not report healthy while only the superseded deployment is known")
+	}
+
+	mock.app = testApp()
+	mock.app.ActiveDeployment = &godo.Deployment{
+		ID:                   "dep-replacement",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-triggered",
+	}
+	result, err = d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck after replacement deployment active: %v", err)
+	}
+	if !result.Healthy {
+		t.Fatalf("HealthCheck did not retarget to replacement active deployment, message=%q", result.Message)
+	}
+}
+
 func TestAppPlatformDriver_Update_Error(t *testing.T) {
 	mock := &mockAppClient{app: testApp(), updateErr: fmt.Errorf("update failed")}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")

--- a/internal/drivers/deploy.go
+++ b/internal/drivers/deploy.go
@@ -79,6 +79,10 @@ func (d *AppDeployDriver) currentTargetDeployment(ctx context.Context, app *godo
 			d.targetDeploymentID = dep.ID
 			return dep, nil
 		}
+		if dep.PreviousDeploymentID == d.targetDeploymentID {
+			d.targetDeploymentID = dep.ID
+			return dep, nil
+		}
 	}
 	deployments, _, err := d.client.ListDeployments(ctx, d.appID, &godo.ListOptions{Page: 1, PerPage: 20})
 	if err != nil {

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -241,6 +241,36 @@ func TestAppDeployDriver_HealthCheck_WaitsUntilNewDeploymentObserved(t *testing.
 	}
 }
 
+func TestAppDeployDriver_HealthCheck_RetargetsWhenUpdateDeploymentIsSuperseded(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.ActiveDeployment.ID = "dep-old"
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "app-1", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	m.deployments["app-1"] = []*godo.Deployment{{
+		ID:                   "dep-triggered",
+		Phase:                godo.DeploymentPhase_Superseded,
+		Cause:                "app spec updated",
+		PreviousDeploymentID: "dep-old",
+	}}
+	if err := d.HealthCheck(context.Background(), "/health"); err == nil {
+		t.Fatalf("HealthCheck should not pass while only superseded deployment is known")
+	}
+
+	app.ActiveDeployment = &godo.Deployment{
+		ID:                   "dep-replacement",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-triggered",
+	}
+	if err := d.HealthCheck(context.Background(), "/health"); err != nil {
+		t.Fatalf("HealthCheck should retarget to replacement active deployment, got: %v", err)
+	}
+}
+
 func TestAppDeployDriver_HealthCheck_IgnoresUnrelatedHistoricalDeployments(t *testing.T) {
 	m := newDeployMock()
 	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")


### PR DESCRIPTION
## Summary
- allow App Platform health wait to retarget when DigitalOcean supersedes the deployment created by `Apps.Update`
- keep waiting on the replacement deployment when its `previous_deployment_id` chains from the original target
- add regression coverage for the exact superseded-target behavior seen in BMW staging deploy 26142726006

## Verification
- Red: `GOWORK=off go test ./internal/drivers -run TestAppPlatformDriver_HealthCheckRetargetsWhenUpdateDeploymentIsSuperseded -count=1` failed with `deployment failed: SUPERSEDED`
- Green: `GOWORK=off go test ./internal/drivers -run 'HealthCheckWaitsForDeploymentTriggeredByUpdate|HealthCheckRetargetsWhenUpdateDeploymentIsSuperseded|UpdateDeploymentWaitStateIsScopedPerProviderID' -count=1`
- `GOWORK=off go test ./...`