### PR TITLE
fix: normalize DO live log URLs

### DIFF
--- a/internal/logcapture.go
+++ b/internal/logcapture.go
@@ -132,6 +132,10 @@ func streamCaptureLiveURL(ctx context.Context, liveURL string, sink interfaces.L
 }
 
 func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink interfaces.LogCaptureSink, readLimit int64) error {
+	liveURL, err := normalizeCaptureLiveURL(liveURL)
+	if err != nil {
+		return err
+	}
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, liveURL, nil)
 	if err != nil {
 		return fmt.Errorf("digitalocean CaptureLogs: connect live logs: %s", redactCaptureURLError(err))
@@ -168,6 +172,25 @@ func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink int
 		if err := sink.WriteLogChunk(interfaces.LogChunk{Data: data, Source: "live"}); err != nil {
 			return err
 		}
+	}
+}
+
+func normalizeCaptureLiveURL(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return "", fmt.Errorf("digitalocean CaptureLogs: invalid live log URL")
+	}
+	switch u.Scheme {
+	case "ws", "wss":
+		return u.String(), nil
+	case "http":
+		u.Scheme = "ws"
+		return u.String(), nil
+	case "https":
+		u.Scheme = "wss"
+		return u.String(), nil
+	default:
+		return "", fmt.Errorf("digitalocean CaptureLogs: unsupported live log URL scheme %q", u.Scheme)
 	}
 }
 

--- a/internal/logcapture_test.go
+++ b/internal/logcapture_test.go
@@ -152,6 +152,57 @@ func TestStreamCaptureLiveURLStreamsMessage(t *testing.T) {
 	}
 }
 
+func TestDOProviderCaptureLogsNormalizesHTTPLiveURL(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	liveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte("live via http url\n")); err != nil {
+			t.Errorf("write websocket message: %v", err)
+		}
+		if err := conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+			t.Errorf("write websocket close: %v", err)
+		}
+	}))
+	t.Cleanup(liveSrv.Close)
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/apps":
+			_, _ = w.Write([]byte(`{"apps":[{"id":"app-123","spec":{"name":"bmw-staging"}}]}`))
+		case strings.HasPrefix(r.URL.Path, "/v2/apps/app-123/logs"):
+			_, _ = w.Write([]byte(`{"live_url":"` + liveSrv.URL + `"}`))
+		default:
+			t.Fatalf("unexpected API path: %s", r.URL.String())
+		}
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	p := NewDOProvider()
+	if err := p.Initialize(context.Background(), map[string]any{"token": "test-token"}); err != nil {
+		t.Fatal(err)
+	}
+	p.client.BaseURL = mustURL(t, apiSrv.URL+"/v2/")
+
+	var sink captureSink
+	err := p.CaptureLogs(context.Background(), interfaces.LogCaptureRequest{
+		ResourceName: "bmw-staging",
+		ResourceType: "infra.container_service",
+		LogType:      "RUN",
+		Follow:       true,
+	}, &sink)
+	if err != nil {
+		t.Fatalf("CaptureLogs: %v", err)
+	}
+	if got := sink.String(); got != "live via http url\n" {
+		t.Fatalf("captured live logs = %q", got)
+	}
+}
+
 func TestStreamCaptureLiveURLRejectsOversizedMessage(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- normalize DigitalOcean App Platform live log URLs before websocket dialing
- cover DO's `http(s)://` `live_url` response shape with a provider-level regression test

## Verification
- `GOWORK=off go test ./internal -run TestDOProviderCaptureLogsNormalizesHTTPLiveURL -count=1` failed before the fix with `malformed ws or wss URL`
- `GOWORK=off go test ./internal -run 'TestDOProviderCaptureLogsNormalizesHTTPLiveURL|TestStreamCaptureLiveURL' -count=1`
- `GOWORK=off go test ./... -count=1`
- `git diff --check`

## BMW impact
BMW's debug staging logs workflow currently reaches `workflow-plugin-digitalocean` v2.0.9 and fails on `connect live logs: malformed ws or wss URL`. This fix handles the live URL scheme returned by DigitalOcean.
