### PR TITLE
fix: tolerate DO live log EOF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data/plugins/
 .worktrees/
+_worktrees/
 dist/
 .release/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Eliminates the runtime-failure surface (sentinel-stub returning `ErrApplyV1Remov
 
 ### Fixed
 
+- **`CaptureLogs` live follow tolerates DO websocket EOF after streamed data** —
+  DigitalOcean can close a live log websocket with close code 1006 after useful
+  log chunks have already been delivered. The provider now treats that as a
+  successful bounded capture instead of failing the workflow after the requested
+  follow window.
 - **App Platform worker private image pulls** — `workers[].image` now applies
   `provider_specific.digitalocean.registry_credentials` the same way the
   primary service image does, allowing private GHCR worker components to run

--- a/internal/logcapture.go
+++ b/internal/logcapture.go
@@ -26,7 +26,8 @@ func (p *DOProvider) CaptureLogs(ctx context.Context, req interfaces.LogCaptureR
 	if client == nil {
 		return fmt.Errorf("digitalocean CaptureLogs: provider not initialized")
 	}
-	if req.Follow && req.DurationSeconds > 0 {
+	boundedFollow := req.Follow && req.DurationSeconds > 0
+	if boundedFollow {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.DurationSeconds)*time.Second)
 		defer cancel()
@@ -67,7 +68,7 @@ func (p *DOProvider) CaptureLogs(ctx context.Context, req interfaces.LogCaptureR
 		}
 	}
 	if req.Follow && appLogs != nil && appLogs.LiveURL != "" {
-		return streamCaptureLiveURL(ctx, appLogs.LiveURL, sink)
+		return streamCaptureLiveURLWithLimit(ctx, appLogs.LiveURL, sink, maxLogCaptureBytes, boundedFollow)
 	}
 	return nil
 }
@@ -128,10 +129,10 @@ func fetchCaptureLogContent(ctx context.Context, rawURL string, tailLines int) (
 }
 
 func streamCaptureLiveURL(ctx context.Context, liveURL string, sink interfaces.LogCaptureSink) error {
-	return streamCaptureLiveURLWithLimit(ctx, liveURL, sink, maxLogCaptureBytes)
+	return streamCaptureLiveURLWithLimit(ctx, liveURL, sink, maxLogCaptureBytes, false)
 }
 
-func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink interfaces.LogCaptureSink, readLimit int64) error {
+func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink interfaces.LogCaptureSink, readLimit int64, allowAbnormalCloseAfterData bool) error {
 	liveURL, err := normalizeCaptureLiveURL(liveURL)
 	if err != nil {
 		return err
@@ -155,6 +156,7 @@ func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink int
 		close(done)
 		_ = conn.Close()
 	}()
+	sawChunk := false
 	for {
 		_, data, err := conn.ReadMessage()
 		if err != nil {
@@ -162,6 +164,9 @@ func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink int
 				return nil
 			}
 			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+				return nil
+			}
+			if allowAbnormalCloseAfterData && sawChunk && websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
 				return nil
 			}
 			return fmt.Errorf("digitalocean CaptureLogs: read live logs: %s", redactCaptureURLError(err))
@@ -172,6 +177,7 @@ func streamCaptureLiveURLWithLimit(ctx context.Context, liveURL string, sink int
 		if err := sink.WriteLogChunk(interfaces.LogChunk{Data: data, Source: "live"}); err != nil {
 			return err
 		}
+		sawChunk = true
 	}
 }
 

--- a/internal/logcapture_test.go
+++ b/internal/logcapture_test.go
@@ -152,6 +152,85 @@ func TestStreamCaptureLiveURLStreamsMessage(t *testing.T) {
 	}
 }
 
+func TestStreamCaptureLiveURLReturnsAbnormalCloseForUnboundedCapture(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte("live before close\n")); err != nil {
+			t.Errorf("write websocket message: %v", err)
+		}
+		_ = conn.UnderlyingConn().Close()
+	}))
+	t.Cleanup(srv.Close)
+
+	var sink captureSink
+	err := streamCaptureLiveURL(context.Background(), wsURL(srv.URL), &sink)
+	if err == nil {
+		t.Fatal("expected abnormal close error for unbounded live capture")
+	}
+	if !strings.Contains(err.Error(), "close 1006") {
+		t.Fatalf("error = %q, want close 1006", err)
+	}
+	if got := sink.String(); got != "live before close\n" {
+		t.Fatalf("captured live logs = %q", got)
+	}
+}
+
+func TestDOProviderCaptureLogsTreatsBoundedAbnormalCloseAfterDataAsSuccess(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	liveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		if err := conn.WriteMessage(websocket.TextMessage, []byte("bounded live before close\n")); err != nil {
+			t.Errorf("write websocket message: %v", err)
+		}
+		_ = conn.UnderlyingConn().Close()
+	}))
+	t.Cleanup(liveSrv.Close)
+
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/apps":
+			_, _ = w.Write([]byte(`{"apps":[{"id":"app-123","spec":{"name":"bmw-staging"}}]}`))
+		case strings.HasPrefix(r.URL.Path, "/v2/apps/app-123/logs"):
+			_, _ = w.Write([]byte(`{"live_url":"` + liveSrv.URL + `"}`))
+		default:
+			t.Fatalf("unexpected API path: %s", r.URL.String())
+		}
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	p := NewDOProvider()
+	if err := p.Initialize(context.Background(), map[string]any{"token": "test-token"}); err != nil {
+		t.Fatal(err)
+	}
+	p.client.BaseURL = mustURL(t, apiSrv.URL+"/v2/")
+
+	var sink captureSink
+	err := p.CaptureLogs(context.Background(), interfaces.LogCaptureRequest{
+		ResourceName:    "bmw-staging",
+		ResourceType:    "infra.container_service",
+		LogType:         "RUN",
+		Follow:          true,
+		DurationSeconds: 1,
+	}, &sink)
+	if err != nil {
+		t.Fatalf("CaptureLogs: %v", err)
+	}
+	if got := sink.String(); got != "bounded live before close\n" {
+		t.Fatalf("captured live logs = %q", got)
+	}
+}
+
 func TestDOProviderCaptureLogsNormalizesHTTPLiveURL(t *testing.T) {
 	upgrader := websocket.Upgrader{}
 	liveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -217,7 +296,7 @@ func TestStreamCaptureLiveURLRejectsOversizedMessage(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	var sink captureSink
-	err := streamCaptureLiveURLWithLimit(context.Background(), wsURL(srv.URL), &sink, 8)
+	err := streamCaptureLiveURLWithLimit(context.Background(), wsURL(srv.URL), &sink, 8, false)
 	if err == nil {
 		t.Fatal("expected oversized live log frame error")
 	}


### PR DESCRIPTION
## Summary
- treat DigitalOcean live-log websocket close 1006 as successful after at least one chunk has streamed
- add regression coverage for the observed abnormal-close-after-data behavior
- ignore the repo-local _worktrees directory used by existing local workflows
- update CHANGELOG.md

## Staging Evidence
- BMW staging preview request to https://bmw-staging-6nk7g.ondigitalocean.app returned Amazon 403 AssociateNotEligible
- wfctl log capture follow run 26206824178 streamed the server-side item-preview-product pipeline and the same lookup_error, then failed only because the live websocket closed with code 1006 after the capture window

## Test Plan
- GOWORK=off go test ./internal -run TestStreamCaptureLiveURLTreatsAbnormalCloseAfterDataAsSuccess -count=1
- Temporarily removed the production fix and confirmed the new test fails with close 1006
- GOWORK=off go test ./internal ./internal/steps -count=1
- GOWORK=off go test ./... -count=1