### PR TITLE
ci(release): notify workflow-registry on tag publish (G1 / workflow-registry#79)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,10 @@ jobs:
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: release
-    if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
+    if: ${{ !contains(github.ref_name, '-') }}
     steps:
       - name: Trigger registry manifest sync
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,3 +29,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ github.ref_name }} --draft=false --repo ${{ github.repository }}
+
+  notify-workflow-registry:
+    name: Notify workflow-registry
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ !contains(inputs.tag_name || github.ref_name, '-') }}
+    steps:
+      - name: Trigger registry manifest sync
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.repo_dispatch_token }}
+          repository: GoCodeAlone/workflow-registry
+          event-type: plugin-release
+          client-payload: '{"plugin": "digitalocean"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,16 @@ jobs:
     permissions:
       contents: read
     needs: release
-    if: ${{ !contains(github.ref_name, '-') }}
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-digitalocean'
     steps:
       - name: Trigger registry manifest sync
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
         with:
           token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry
           event-type: plugin-release
-          client-payload: '{"plugin": "digitalocean"}'
+          client-payload: |-
+            {"plugin": "digitalocean", "tag": "${{ github.ref_name }}"}


### PR DESCRIPTION
## Summary

- Fires a `repository_dispatch` event (`event-type: plugin-release`) to GoCodeAlone/workflow-registry on every non-prerelease tag push.
- `client_payload.plugin` = `digitalocean` — consumed by the registry's `sync-registry-manifests.yml` handler (shipped in GoCodeAlone/workflow-registry#84) to update `plugins/digitalocean/manifest.json` and open a targeted sync PR in real-time.
- The `if:` condition gates on tag not being a pre-release (no hyphen), so `v1.2.3` fires but `v1.2.3-rc1` does not.
- The `secrets.repo_dispatch_token` is an org-level secret pre-configured for all GoCodeAlone repos.

Reference: GoCodeAlone/workflow-registry#79 (G2 dispatch handler)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)