### PR TITLE
Fix App Platform domain CNAME reconciliation

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -55,6 +55,7 @@ type appPlatformMigrationRepairClient interface {
 type AppPlatformDriver struct {
 	client             AppPlatformClient
 	regClient          RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
+	dnsClient          DomainsClient
 	region             string
 	deploymentMu       sync.Mutex
 	waitingDeployments map[string]*appDeploymentWaitState
@@ -67,7 +68,7 @@ type appDeploymentWaitState struct {
 
 // NewAppPlatformDriver creates an AppPlatformDriver backed by a real godo client.
 func NewAppPlatformDriver(c *godo.Client, region string) *AppPlatformDriver {
-	return &AppPlatformDriver{client: c.Apps, regClient: c.Registry, region: region}
+	return &AppPlatformDriver{client: c.Apps, regClient: c.Registry, dnsClient: c.Domains, region: region}
 }
 
 // NewAppPlatformDriverWithClient creates a driver with an injected apps client (for tests).
@@ -79,6 +80,11 @@ func NewAppPlatformDriverWithClient(c AppPlatformClient, region string) *AppPlat
 // NewAppPlatformDriverWithClients creates a driver with both clients injected (for tests).
 func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, region string) *AppPlatformDriver {
 	return &AppPlatformDriver{client: c, regClient: r, region: region}
+}
+
+// NewAppPlatformDriverWithDNSClient creates a test driver with injected app and DNS clients.
+func NewAppPlatformDriverWithDNSClient(c AppPlatformClient, dns DomainsClient, region string) *AppPlatformDriver {
+	return &AppPlatformDriver{client: c, dnsClient: dns, region: region}
 }
 
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -109,6 +115,9 @@ func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.Resource
 	}
 	if app == nil || app.ID == "" {
 		return nil, fmt.Errorf("app platform create %q: API returned app with empty ID", spec.Name)
+	}
+	if err := d.reconcileAppDomainCNAMEs(ctx, app, appSpec.Domains); err != nil {
+		return nil, err
 	}
 	return appOutput(app), nil
 }
@@ -193,6 +202,9 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 		previousActiveDeploymentID: previousActiveDeploymentID,
 		targetDeploymentID:         deploymentID(selectUpdateDeployment(app, previousActiveDeploymentID)),
 	})
+	if err := d.reconcileAppDomainCNAMEs(ctx, app, appSpec.Domains); err != nil {
+		return nil, err
+	}
 	return appOutput(app), nil
 }
 
@@ -206,6 +218,144 @@ func (d *AppPlatformDriver) Delete(ctx context.Context, ref interfaces.ResourceR
 		return fmt.Errorf("app platform delete %q: %w", ref.Name, WrapGodoError(err))
 	}
 	return nil
+}
+
+func (d *AppPlatformDriver) reconcileAppDomainCNAMEs(ctx context.Context, app *godo.App, domains []*godo.AppDomainSpec) error {
+	if d.dnsClient == nil || app == nil || len(domains) == 0 {
+		return nil
+	}
+	target := appDefaultIngressCNAME(app.DefaultIngress)
+	if target == "" {
+		return nil
+	}
+	for _, domain := range domains {
+		if domain == nil || strings.TrimSpace(domain.Zone) == "" {
+			continue
+		}
+		name, ok := appDomainDNSRecordName(domain.Domain, domain.Zone)
+		if !ok {
+			continue
+		}
+		if err := d.reconcileAppDomainCNAME(ctx, domain.Zone, name, target); err != nil {
+			return fmt.Errorf("app platform reconcile DNS %q: %w", domain.Domain, err)
+		}
+	}
+	return nil
+}
+
+func (d *AppPlatformDriver) reconcileAppDomainCNAME(ctx context.Context, zone, name, target string) error {
+	records, err := listAppDomainRecords(ctx, d.dnsClient, zone)
+	if err != nil {
+		return err
+	}
+	var matching []godo.DomainRecord
+	for _, record := range records {
+		if !strings.EqualFold(record.Type, "CNAME") || record.Name != name {
+			continue
+		}
+		matching = append(matching, record)
+	}
+	if len(matching) == 0 {
+		_, _, err := d.dnsClient.CreateRecord(ctx, zone, &godo.DomainRecordEditRequest{
+			Type: "CNAME",
+			Name: name,
+			Data: target,
+			TTL:  1800,
+		})
+		if err != nil {
+			return fmt.Errorf("dns create app domain CNAME %q/%s: %w", zone, name, WrapGodoError(err))
+		}
+		return nil
+	}
+
+	hasTarget := false
+	for _, record := range matching {
+		if dnsRecordDataEqual(record.Data, target) {
+			hasTarget = true
+			break
+		}
+	}
+
+	keptTarget := hasTarget
+	for i, record := range matching {
+		if dnsRecordDataEqual(record.Data, target) {
+			if keptTarget {
+				keptTarget = false
+				continue
+			}
+		}
+		if !hasTarget && i == 0 {
+			_, _, err := d.dnsClient.EditRecord(ctx, zone, record.ID, &godo.DomainRecordEditRequest{
+				Type: "CNAME",
+				Name: name,
+				Data: target,
+				TTL:  1800,
+			})
+			if err != nil {
+				return fmt.Errorf("dns update app domain CNAME %q/%s: %w", zone, name, WrapGodoError(err))
+			}
+			hasTarget = true
+			continue
+		}
+		if _, err := d.dnsClient.DeleteRecord(ctx, zone, record.ID); err != nil {
+			return fmt.Errorf("dns delete stale app domain CNAME %q/%s id %d: %w", zone, name, record.ID, WrapGodoError(err))
+		}
+	}
+	return nil
+}
+
+func listAppDomainRecords(ctx context.Context, client DomainsClient, domain string) ([]godo.DomainRecord, error) {
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	var out []godo.DomainRecord
+	for {
+		records, resp, err := client.Records(ctx, domain, opts)
+		if err != nil {
+			return nil, fmt.Errorf("dns list records %q: %w", domain, WrapGodoError(err))
+		}
+		out = append(out, records...)
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return out, nil
+}
+
+func appDefaultIngressCNAME(defaultIngress string) string {
+	defaultIngress = strings.TrimSpace(defaultIngress)
+	if defaultIngress == "" {
+		return ""
+	}
+	if u, err := url.Parse(defaultIngress); err == nil && u.Host != "" {
+		defaultIngress = u.Host
+	}
+	defaultIngress = strings.TrimSuffix(defaultIngress, "/")
+	defaultIngress = strings.TrimSuffix(defaultIngress, ".")
+	if defaultIngress == "" {
+		return ""
+	}
+	return strings.ToLower(defaultIngress) + "."
+}
+
+func appDomainDNSRecordName(domain, zone string) (string, bool) {
+	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")
+	zone = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(zone)), ".")
+	if domain == "" || zone == "" || domain == zone {
+		return "", false
+	}
+	suffix := "." + zone
+	if !strings.HasSuffix(domain, suffix) {
+		return "", false
+	}
+	name := strings.TrimSuffix(domain, suffix)
+	if name == "" {
+		return "", false
+	}
+	return name, true
+}
+
+func dnsRecordDataEqual(a, b string) bool {
+	return strings.EqualFold(strings.TrimSuffix(strings.TrimSpace(a), "."), strings.TrimSuffix(strings.TrimSpace(b), "."))
 }
 
 // resolveProviderID returns a UUID-like ProviderID for the given ref.

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -122,6 +122,55 @@ func TestAppPlatformDriver_Create(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_Update_ReconcilesManagedDomainCNAME(t *testing.T) {
+	app := testApp()
+	app.DefaultIngress = "https://my-app-new.ondigitalocean.app"
+	app.Spec = &godo.AppSpec{Name: "my-app"}
+	app.ActiveDeployment = &godo.Deployment{ID: "dep-new", Phase: godo.DeploymentPhase_Active}
+	mock := &mockAppClient{app: app}
+	dns := &mockDomainsClient{
+		domain:         &godo.Domain{Name: "example.com"},
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "my-app-old.ondigitalocean.app.", TTL: 1800},
+			{ID: 11, Type: "CNAME", Name: "www", Data: "my-app-new.ondigitalocean.app.", TTL: 1800},
+			{ID: 12, Type: "CNAME", Name: "admin", Data: "my-app-old.ondigitalocean.app.", TTL: 1800},
+		},
+	}
+	d := drivers.NewAppPlatformDriverWithDNSClient(mock, dns, "nyc3")
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}, interfaces.ResourceSpec{
+		Name: "my-app",
+		Type: "infra.container_service",
+		Config: map[string]any{
+			"image": "registry.digitalocean.com/myrepo/myapp:v1",
+			"domains": []any{
+				map[string]any{"domain": "example.com", "type": "PRIMARY", "zone": "example.com"},
+				map[string]any{"domain": "www.example.com", "type": "ALIAS", "zone": "example.com"},
+				map[string]any{"domain": "admin.example.com", "type": "ALIAS", "zone": "example.com"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dns.deletedRecords) != 1 || dns.deletedRecords[0].id != 10 {
+		t.Fatalf("deleted records = %+v, want stale www CNAME id 10", dns.deletedRecords)
+	}
+	if len(dns.editedRecords) != 1 || dns.editedRecords[0].id != 12 {
+		t.Fatalf("edited records = %+v, want admin CNAME id 12", dns.editedRecords)
+	}
+	if got := dns.editedRecords[0].req.Data; got != "my-app-new.ondigitalocean.app." {
+		t.Fatalf("edited data = %q", got)
+	}
+	if len(dns.createdRecords) != 0 {
+		t.Fatalf("created records = %+v, want none", dns.createdRecords)
+	}
+}
+
 func TestAppPlatformDriver_Read(t *testing.T) {
 	mock := &mockAppClient{app: testApp()}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")


### PR DESCRIPTION
## Summary
- Wire App Platform driver to the DO Domains client.
- Reconcile managed subdomain CNAME records to the app default ingress after create/update.
- Remove stale duplicate CNAMEs so App Platform hostname changes do not leave domains pointing at an old ingress.

## Validation
- `GOWORK=off go test ./...`