### PR TITLE
fix: deploy app platform updates when undeployed

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -198,6 +198,9 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 	if err != nil {
 		return nil, fmt.Errorf("app platform update %q: %w", ref.Name, WrapGodoError(err))
 	}
+	if app == nil {
+		return nil, fmt.Errorf("app platform update %q: API returned nil app", ref.Name)
+	}
 	targetDeployment := selectUpdateDeployment(app, previousActiveDeploymentID)
 	if targetDeployment == nil && previousActiveDeploymentID == "" && appHasNoDeploymentSlots(app) {
 		dep, _, err := d.client.CreateDeployment(ctx, providerID, &godo.DeploymentCreateRequest{})
@@ -205,9 +208,7 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 			return nil, fmt.Errorf("app platform update %q: create deployment for undeployed app: %w", ref.Name, WrapGodoError(err))
 		}
 		targetDeployment = dep
-		if app != nil {
-			app.InProgressDeployment = dep
-		}
+		app.InProgressDeployment = dep
 	}
 	d.setUpdateDeploymentState(providerID, appDeploymentWaitState{
 		previousActiveDeploymentID: previousActiveDeploymentID,
@@ -255,7 +256,7 @@ func (d *AppPlatformDriver) reconcileAppDomainCNAMEs(ctx context.Context, app *g
 }
 
 func appHasNoDeploymentSlots(app *godo.App) bool {
-	return app == nil || (app.ActiveDeployment == nil && app.InProgressDeployment == nil && app.PendingDeployment == nil)
+	return app != nil && app.ActiveDeployment == nil && app.InProgressDeployment == nil && app.PendingDeployment == nil
 }
 
 func (d *AppPlatformDriver) reconcileAppDomainCNAME(ctx context.Context, zone, name, target string) error {

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -198,9 +198,20 @@ func (d *AppPlatformDriver) Update(ctx context.Context, ref interfaces.ResourceR
 	if err != nil {
 		return nil, fmt.Errorf("app platform update %q: %w", ref.Name, WrapGodoError(err))
 	}
+	targetDeployment := selectUpdateDeployment(app, previousActiveDeploymentID)
+	if targetDeployment == nil && previousActiveDeploymentID == "" && appHasNoDeploymentSlots(app) {
+		dep, _, err := d.client.CreateDeployment(ctx, providerID, &godo.DeploymentCreateRequest{})
+		if err != nil {
+			return nil, fmt.Errorf("app platform update %q: create deployment for undeployed app: %w", ref.Name, WrapGodoError(err))
+		}
+		targetDeployment = dep
+		if app != nil {
+			app.InProgressDeployment = dep
+		}
+	}
 	d.setUpdateDeploymentState(providerID, appDeploymentWaitState{
 		previousActiveDeploymentID: previousActiveDeploymentID,
-		targetDeploymentID:         deploymentID(selectUpdateDeployment(app, previousActiveDeploymentID)),
+		targetDeploymentID:         deploymentID(targetDeployment),
 	})
 	if err := d.reconcileAppDomainCNAMEs(ctx, app, appSpec.Domains); err != nil {
 		return nil, err
@@ -241,6 +252,10 @@ func (d *AppPlatformDriver) reconcileAppDomainCNAMEs(ctx context.Context, app *g
 		}
 	}
 	return nil
+}
+
+func appHasNoDeploymentSlots(app *godo.App) bool {
+	return app == nil || (app.ActiveDeployment == nil && app.InProgressDeployment == nil && app.PendingDeployment == nil)
 }
 
 func (d *AppPlatformDriver) reconcileAppDomainCNAME(ctx context.Context, zone, name, target string) error {
@@ -613,6 +628,9 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 		if err := deploymentHealthError(ref.Name, dep); err != nil {
 			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 		}
+		if err := d.reconcileAppDomainCNAMEs(ctx, app, appDomains(app)); err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
 		d.clearUpdateDeploymentState(providerID)
 		return &interfaces.HealthResult{Healthy: true}, nil
 	}
@@ -620,7 +638,20 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 		deps, _, err := d.client.ListDeployments(ctx, appID, &godo.ListOptions{Page: 1, PerPage: 1})
 		return deps, err
 	}
-	return appHealthResult(ctx, listFn, app), nil
+	result := appHealthResult(ctx, listFn, app)
+	if result != nil && result.Healthy {
+		if err := d.reconcileAppDomainCNAMEs(ctx, app, appDomains(app)); err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
+	}
+	return result, nil
+}
+
+func appDomains(app *godo.App) []*godo.AppDomainSpec {
+	if app == nil || app.Spec == nil {
+		return nil
+	}
+	return app.Spec.Domains
 }
 
 func (d *AppPlatformDriver) setUpdateDeploymentState(providerID string, state appDeploymentWaitState) {

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -171,6 +171,45 @@ func TestAppPlatformDriver_Update_ReconcilesManagedDomainCNAME(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_HealthCheck_ReconcilesManagedDomainCNAME(t *testing.T) {
+	app := testApp()
+	app.DefaultIngress = "https://my-app-new.ondigitalocean.app"
+	app.Spec = &godo.AppSpec{
+		Name: "my-app",
+		Domains: []*godo.AppDomainSpec{
+			{Domain: "example.com", Type: godo.AppDomainSpecType_Primary, Zone: "example.com"},
+			{Domain: "www.example.com", Type: godo.AppDomainSpecType_Alias, Zone: "example.com"},
+		},
+	}
+	app.ActiveDeployment = &godo.Deployment{ID: "dep-new", Phase: godo.DeploymentPhase_Active}
+	mock := &mockAppClient{app: app}
+	dns := &mockDomainsClient{
+		domain:         &godo.Domain{Name: "example.com"},
+		expectedDomain: "example.com",
+		records: []godo.DomainRecord{
+			{ID: 10, Type: "CNAME", Name: "www", Data: "my-app-old.ondigitalocean.app.", TTL: 1800},
+		},
+	}
+	d := drivers.NewAppPlatformDriverWithDNSClient(mock, dns, "nyc3")
+
+	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	})
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if result == nil || !result.Healthy {
+		t.Fatalf("HealthCheck result = %+v, want healthy", result)
+	}
+	if len(dns.editedRecords) != 1 || dns.editedRecords[0].id != 10 {
+		t.Fatalf("edited records = %+v, want www CNAME edit", dns.editedRecords)
+	}
+	if got := dns.editedRecords[0].req.Data; got != "my-app-new.ondigitalocean.app." {
+		t.Fatalf("edited data = %q", got)
+	}
+}
+
 func TestAppPlatformDriver_Read(t *testing.T) {
 	mock := &mockAppClient{app: testApp()}
 	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
@@ -395,6 +434,30 @@ func TestAppPlatformDriver_Update_DoesNotCreateDuplicateDeployment(t *testing.T)
 	}
 	if mock.createDeploymentCalled {
 		t.Error("CreateDeployment should not be called after Apps.Update; DigitalOcean already creates an app-spec deployment for the update")
+	}
+}
+
+func TestAppPlatformDriver_Update_CreatesDeploymentForUndeployedApp(t *testing.T) {
+	mock := &mockAppClient{app: &godo.App{
+		ID:   "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+		Spec: &godo.AppSpec{Name: "my-app"},
+	}}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+
+	_, err := d.Update(context.Background(), interfaces.ResourceRef{
+		Name: "my-app", ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}, interfaces.ResourceSpec{
+		Name:   "my-app",
+		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if mock.lastUpdateReq == nil {
+		t.Fatal("expected Update API to be called")
+	}
+	if !mock.createDeploymentCalled {
+		t.Fatal("expected CreateDeployment for an app with no deployment slots")
 	}
 }
 


### PR DESCRIPTION
## Summary
- create an App Platform deployment after an update when the existing app has no active, in-progress, or pending deployment slots
- reconcile managed App Platform subdomain CNAMEs from health checks once the app is healthy and default ingress exists

## Tests
- GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_Update_CreatesDeploymentForUndeployedApp|TestAppPlatformDriver_HealthCheck_ReconcilesManagedDomainCNAME' -count=1
- GOWORK=off go test ./internal/drivers
- GOWORK=off go test ./...