### PR TITLE
fix: expose app platform deploy drivers

### DIFF
--- a/internal/drivers/deploy.go
+++ b/internal/drivers/deploy.go
@@ -13,6 +13,7 @@ import (
 // It manages a single App Platform application identified by its app ID.
 type AppDeployDriver struct {
 	client                     AppPlatformClient
+	regClient                  RegistryClient
 	region                     string
 	appID                      string
 	appName                    string
@@ -26,13 +27,30 @@ func NewAppDeployDriver(c AppPlatformClient, region, appID, appName string) *App
 	return &AppDeployDriver{client: c, region: region, appID: appID, appName: appName}
 }
 
+// NewAppDeployDriverWithRegistry creates a DeployDriver with a DOCR image
+// presence pre-flight. The registry client may be nil to skip the check.
+func NewAppDeployDriverWithRegistry(c AppPlatformClient, r RegistryClient, region, appID, appName string) *AppDeployDriver {
+	return &AppDeployDriver{client: c, regClient: r, region: region, appID: appID, appName: appName}
+}
+
 func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
-	app, _, err := d.client.Get(ctx, d.appID)
+	if d.regClient != nil {
+		if err := verifyImagePresentInDOCR(ctx, d.regClient, image); err != nil {
+			return err
+		}
+	}
+	app, err := d.getApp(ctx)
 	if err != nil {
 		return fmt.Errorf("app deploy: get %q: %w", d.appName, err)
 	}
 	d.previousActiveDeploymentID = deploymentID(app.ActiveDeployment)
-	spec := app.Spec
+	spec, err := cloneAppSpec(app.Spec)
+	if err != nil {
+		return fmt.Errorf("app deploy: clone app spec %q: %w", d.appName, err)
+	}
+	if spec == nil {
+		return fmt.Errorf("app deploy: %q has no app spec", d.appName)
+	}
 	for _, svc := range spec.Services {
 		if svc.Image != nil {
 			svc.Image.Repository = imageRepo(image)
@@ -49,7 +67,7 @@ func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
 }
 
 func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
-	app, _, err := d.client.Get(ctx, d.appID)
+	app, err := d.getApp(ctx)
 	if err != nil {
 		return fmt.Errorf("app deploy: health check %q: %w", d.appName, err)
 	}
@@ -84,7 +102,11 @@ func (d *AppDeployDriver) currentTargetDeployment(ctx context.Context, app *godo
 			return dep, nil
 		}
 	}
-	deployments, _, err := d.client.ListDeployments(ctx, d.appID, &godo.ListOptions{Page: 1, PerPage: 20})
+	appID, err := d.resolveAppID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	deployments, _, err := d.client.ListDeployments(ctx, appID, &godo.ListOptions{Page: 1, PerPage: 20})
 	if err != nil {
 		return nil, fmt.Errorf("app deploy: list deployments %q: %w", d.appName, err)
 	}
@@ -162,7 +184,7 @@ func deploymentID(dep *godo.Deployment) string {
 }
 
 func (d *AppDeployDriver) CurrentImage(ctx context.Context) (string, error) {
-	app, _, err := d.client.Get(ctx, d.appID)
+	app, err := d.getApp(ctx)
 	if err != nil {
 		return "", fmt.Errorf("app deploy: current image %q: %w", d.appName, err)
 	}
@@ -177,7 +199,7 @@ func (d *AppDeployDriver) CurrentImage(ctx context.Context) (string, error) {
 }
 
 func (d *AppDeployDriver) ReplicaCount(ctx context.Context) (int, error) {
-	app, _, err := d.client.Get(ctx, d.appID)
+	app, err := d.getApp(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("app deploy: replica count %q: %w", d.appName, err)
 	}
@@ -185,6 +207,42 @@ func (d *AppDeployDriver) ReplicaCount(ctx context.Context) (int, error) {
 		return 1, nil
 	}
 	return int(app.Spec.Services[0].InstanceCount), nil
+}
+
+func (d *AppDeployDriver) getApp(ctx context.Context) (*godo.App, error) {
+	appID, err := d.resolveAppID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	app, _, err := d.client.Get(ctx, appID)
+	return app, err
+}
+
+func (d *AppDeployDriver) resolveAppID(ctx context.Context) (string, error) {
+	if d.appID != "" {
+		return d.appID, nil
+	}
+	if d.appName == "" {
+		return "", fmt.Errorf("app deploy: app ID or app name is required")
+	}
+	opts := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		apps, resp, err := d.client.List(ctx, opts)
+		if err != nil {
+			return "", err
+		}
+		for _, app := range apps {
+			if app != nil && app.Spec != nil && app.Spec.Name == d.appName {
+				d.appID = app.ID
+				return d.appID, nil
+			}
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		opts.Page++
+	}
+	return "", fmt.Errorf("app %q not found", d.appName)
 }
 
 // ─── AppBlueGreenDriver ───────────────────────────────────────────────────────
@@ -199,6 +257,7 @@ func (d *AppDeployDriver) ReplicaCount(ctx context.Context) (int, error) {
 // The green app's live URL is returned from GreenEndpoint.
 type AppBlueGreenDriver struct {
 	client      AppPlatformClient
+	regClient   RegistryClient
 	region      string
 	blueID      string
 	blueName    string
@@ -212,6 +271,12 @@ type AppBlueGreenDriver struct {
 // NewAppBlueGreenDriver creates a BlueGreenDriver for DO App Platform.
 func NewAppBlueGreenDriver(c AppPlatformClient, region, blueID, blueName string) *AppBlueGreenDriver {
 	return &AppBlueGreenDriver{client: c, region: region, blueID: blueID, blueName: blueName}
+}
+
+// NewAppBlueGreenDriverWithRegistry creates a BlueGreenDriver with DOCR image
+// presence pre-flight. The registry client may be nil to skip the check.
+func NewAppBlueGreenDriverWithRegistry(c AppPlatformClient, r RegistryClient, region, blueID, blueName string) *AppBlueGreenDriver {
+	return &AppBlueGreenDriver{client: c, regClient: r, region: region, blueID: blueID, blueName: blueName}
 }
 
 // DeployDriver methods delegate to the blue (stable) app.
@@ -238,12 +303,23 @@ func (d *AppBlueGreenDriver) ReplicaCount(ctx context.Context) (int, error) {
 // CreateGreen creates a new App Platform app with the "-green" name suffix and
 // the given image, recording the green app ID and live URL for later use.
 func (d *AppBlueGreenDriver) CreateGreen(ctx context.Context, image string) error {
-	blueApp, _, err := d.client.Get(ctx, d.blueID)
+	if d.regClient != nil {
+		if err := verifyImagePresentInDOCR(ctx, d.regClient, image); err != nil {
+			return err
+		}
+	}
+	blueApp, err := d.blueDriver().getApp(ctx)
 	if err != nil {
 		return fmt.Errorf("app blue-green: get blue %q: %w", d.blueName, err)
 	}
 
-	greenSpec := blueApp.Spec
+	greenSpec, err := cloneAppSpec(blueApp.Spec)
+	if err != nil {
+		return fmt.Errorf("app blue-green: clone blue spec %q: %w", d.blueName, err)
+	}
+	if greenSpec == nil {
+		return fmt.Errorf("app blue-green: blue app %q has no app spec", d.blueName)
+	}
 	greenSpec.Name = d.blueName + "-green"
 	for _, svc := range greenSpec.Services {
 		if svc.Image != nil {
@@ -258,7 +334,7 @@ func (d *AppBlueGreenDriver) CreateGreen(ctx context.Context, image string) erro
 	}
 	d.greenID = greenApp.ID
 	d.greenURL = greenApp.LiveURL
-	d.greenDeploy = NewAppDeployDriver(d.client, d.region, d.greenID, d.blueName+"-green")
+	d.greenDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.greenID, d.blueName+"-green")
 	d.stableCheck = false
 	return nil
 }
@@ -302,14 +378,14 @@ func (d *AppBlueGreenDriver) GreenEndpoint(_ context.Context) (string, error) {
 
 func (d *AppBlueGreenDriver) blueDriver() *AppDeployDriver {
 	if d.blueDeploy == nil {
-		d.blueDeploy = NewAppDeployDriver(d.client, d.region, d.blueID, d.blueName)
+		d.blueDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.blueID, d.blueName)
 	}
 	return d.blueDeploy
 }
 
 func (d *AppBlueGreenDriver) greenDriver() *AppDeployDriver {
 	if d.greenDeploy == nil {
-		d.greenDeploy = NewAppDeployDriver(d.client, d.region, d.greenID, d.blueName+"-green")
+		d.greenDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.greenID, d.blueName+"-green")
 	}
 	return d.greenDeploy
 }
@@ -326,6 +402,7 @@ func (d *AppBlueGreenDriver) greenDriver() *AppDeployDriver {
 // create/promote/delete pattern using two separate apps.
 type AppCanaryDriver struct {
 	client       AppPlatformClient
+	regClient    RegistryClient
 	region       string
 	stableID     string
 	stableName   string
@@ -337,6 +414,12 @@ type AppCanaryDriver struct {
 // NewAppCanaryDriver creates a CanaryDriver for DO App Platform.
 func NewAppCanaryDriver(c AppPlatformClient, region, stableID, stableName string) *AppCanaryDriver {
 	return &AppCanaryDriver{client: c, region: region, stableID: stableID, stableName: stableName}
+}
+
+// NewAppCanaryDriverWithRegistry creates a CanaryDriver with DOCR image
+// presence pre-flight. The registry client may be nil to skip the check.
+func NewAppCanaryDriverWithRegistry(c AppPlatformClient, r RegistryClient, region, stableID, stableName string) *AppCanaryDriver {
+	return &AppCanaryDriver{client: c, regClient: r, region: region, stableID: stableID, stableName: stableName}
 }
 
 // DeployDriver methods delegate to the stable app.
@@ -363,12 +446,23 @@ func (d *AppCanaryDriver) ReplicaCount(ctx context.Context) (int, error) {
 // CreateCanary creates a new App Platform app with the "-canary" name suffix
 // and the given image.
 func (d *AppCanaryDriver) CreateCanary(ctx context.Context, image string) error {
-	stableApp, _, err := d.client.Get(ctx, d.stableID)
+	if d.regClient != nil {
+		if err := verifyImagePresentInDOCR(ctx, d.regClient, image); err != nil {
+			return err
+		}
+	}
+	stableApp, err := d.stableDriver().getApp(ctx)
 	if err != nil {
 		return fmt.Errorf("app canary: get stable %q: %w", d.stableName, err)
 	}
 
-	canarySpec := stableApp.Spec
+	canarySpec, err := cloneAppSpec(stableApp.Spec)
+	if err != nil {
+		return fmt.Errorf("app canary: clone stable spec %q: %w", d.stableName, err)
+	}
+	if canarySpec == nil {
+		return fmt.Errorf("app canary: stable app %q has no app spec", d.stableName)
+	}
 	canarySpec.Name = d.stableName + "-canary"
 	for _, svc := range canarySpec.Services {
 		if svc.Image != nil {
@@ -382,7 +476,7 @@ func (d *AppCanaryDriver) CreateCanary(ctx context.Context, image string) error 
 		return fmt.Errorf("app canary: create canary: %w", err)
 	}
 	d.canaryID = canaryApp.ID
-	d.canaryDeploy = NewAppDeployDriver(d.client, d.region, d.canaryID, d.stableName+"-canary")
+	d.canaryDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.canaryID, d.stableName+"-canary")
 	return nil
 }
 
@@ -428,14 +522,14 @@ func (d *AppCanaryDriver) DestroyCanary(ctx context.Context) error {
 
 func (d *AppCanaryDriver) stableDriver() *AppDeployDriver {
 	if d.stableDeploy == nil {
-		d.stableDeploy = NewAppDeployDriver(d.client, d.region, d.stableID, d.stableName)
+		d.stableDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.stableID, d.stableName)
 	}
 	return d.stableDeploy
 }
 
 func (d *AppCanaryDriver) canaryDriver() *AppDeployDriver {
 	if d.canaryDeploy == nil {
-		d.canaryDeploy = NewAppDeployDriver(d.client, d.region, d.canaryID, d.stableName+"-canary")
+		d.canaryDeploy = NewAppDeployDriverWithRegistry(d.client, d.regClient, d.region, d.canaryID, d.stableName+"-canary")
 	}
 	return d.canaryDeploy
 }

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -167,6 +167,23 @@ func TestAppDeployDriver_Update(t *testing.T) {
 	}
 }
 
+func TestAppDeployDriver_Update_ResolvesAppByNameWhenIDEmpty(t *testing.T) {
+	m := newDeployMock()
+	seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+
+	d := drivers.NewAppDeployDriver(m, "nyc3", "", "myapp")
+	if err := d.Update(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	img, err := d.CurrentImage(context.Background())
+	if err != nil {
+		t.Fatalf("CurrentImage: %v", err)
+	}
+	if img != "registry.digitalocean.com/myrepo/myapp:v2" {
+		t.Errorf("CurrentImage = %q, want v2", img)
+	}
+}
+
 func TestAppDeployDriver_HealthCheck_WaitsForUpdateDeployment(t *testing.T) {
 	m := newDeployMock()
 	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
@@ -364,6 +381,19 @@ func TestAppBlueGreenDriver_CreateGreen(t *testing.T) {
 	}
 	if ep == "" {
 		t.Error("expected non-empty green endpoint")
+	}
+}
+
+func TestAppBlueGreenDriver_CreateGreen_ResolvesBlueByNameWhenIDEmpty(t *testing.T) {
+	m := newDeployMock()
+	seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+
+	d := drivers.NewAppBlueGreenDriver(m, "nyc3", "", "myapp")
+	if err := d.CreateGreen(context.Background(), "registry.digitalocean.com/myrepo/myapp:v2"); err != nil {
+		t.Fatalf("CreateGreen: %v", err)
+	}
+	if len(m.apps) != 2 {
+		t.Errorf("expected 2 apps after CreateGreen, got %d", len(m.apps))
 	}
 }
 

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/steps"
 	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/module"
 	"github.com/GoCodeAlone/workflow/platform"
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
@@ -51,6 +52,9 @@ var _ interfaces.EnumeratorAll = (*DOProvider)(nil)
 var _ interfaces.DriftConfigDetector = (*DOProvider)(nil)
 var _ interfaces.ProviderCredentialRevoker = (*DOProvider)(nil)
 var _ interfaces.LogCaptureProvider = (*DOProvider)(nil)
+var _ module.DeployDriverProvider = (*DOProvider)(nil)
+var _ module.BlueGreenDriverProvider = (*DOProvider)(nil)
+var _ module.CanaryDriverProvider = (*DOProvider)(nil)
 
 // NewDOProvider creates an uninitialised DOProvider.
 func NewDOProvider() *DOProvider {
@@ -178,6 +182,35 @@ func (p *DOProvider) ResourceDriver(resourceType string) (interfaces.ResourceDri
 		return nil, fmt.Errorf("digitalocean: unsupported resource type %q", resourceType)
 	}
 	return d, nil
+}
+
+// ProvideDeployDriver exposes a provider-native App Platform deploy driver to
+// Workflow deployment steps. The resource name is resolved to the DO app ID at
+// execution time so callers do not need to persist provider IDs in pipeline YAML.
+func (p *DOProvider) ProvideDeployDriver(resourceName string) module.DeployDriver {
+	if p.client == nil || resourceName == "" {
+		return nil
+	}
+	return drivers.NewAppDeployDriverWithRegistry(p.client.Apps, p.client.Registry, p.region, "", resourceName)
+}
+
+// ProvideBlueGreenDriver exposes App Platform blue/green deployment support to
+// Workflow deployment steps.
+func (p *DOProvider) ProvideBlueGreenDriver(resourceName string) module.BlueGreenDriver {
+	if p.client == nil || resourceName == "" {
+		return nil
+	}
+	return drivers.NewAppBlueGreenDriverWithRegistry(p.client.Apps, p.client.Registry, p.region, "", resourceName)
+}
+
+// ProvideCanaryDriver exposes App Platform canary lifecycle support. App
+// Platform does not support weighted traffic, so the driver reports a clear
+// unsupported error for traffic-split operations.
+func (p *DOProvider) ProvideCanaryDriver(resourceName string) module.CanaryDriver {
+	if p.client == nil || resourceName == "" {
+		return nil
+	}
+	return drivers.NewAppCanaryDriverWithRegistry(p.client.Apps, p.client.Registry, p.region, "", resourceName)
 }
 
 func (p *DOProvider) RepairDirtyMigration(ctx context.Context, req interfaces.MigrationRepairRequest) (*interfaces.MigrationRepairResult, error) {

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/GoCodeAlone/workflow-plugin-digitalocean/internal/drivers"
 	"github.com/GoCodeAlone/workflow/interfaces"
+	"github.com/GoCodeAlone/workflow/module"
 	"github.com/digitalocean/godo"
 	"golang.org/x/oauth2"
 )
@@ -33,6 +34,9 @@ func TestMain(m *testing.M) {
 
 // compile-time interface check
 var _ interfaces.IaCProvider = (*DOProvider)(nil)
+var _ module.DeployDriverProvider = (*DOProvider)(nil)
+var _ module.BlueGreenDriverProvider = (*DOProvider)(nil)
+var _ module.CanaryDriverProvider = (*DOProvider)(nil)
 
 func TestDOProvider_Name(t *testing.T) {
 	p := NewDOProvider()


### PR DESCRIPTION
## Summary
- expose DigitalOcean App Platform rolling, blue/green, and canary deploy drivers through Workflow's provider bridge
- resolve App Platform apps by resource name when deploy steps do not have provider IDs
- add DOCR image-presence preflight to provider-native deploy paths and clone AppSpec before mutation

## Verification
- GOWORK=off go test ./internal/... -run 'TestAppDeployDriver_Update_ResolvesAppByNameWhenIDEmpty|TestAppBlueGreenDriver_CreateGreen_ResolvesBlueByNameWhenIDEmpty|TestDOProvider_Name' -count=1
- GOWORK=off go test ./...