### PR TITLE
fix: wait for App Platform custom domain readiness

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -57,6 +57,7 @@ type AppPlatformDriver struct {
 	regClient          RegistryClient // NEW: image-presence pre-flight; nil-safe (skips check if nil)
 	dnsClient          DomainsClient
 	region             string
+	domainProbe        AppPlatformDomainProbe
 	deploymentMu       sync.Mutex
 	waitingDeployments map[string]*appDeploymentWaitState
 }
@@ -77,6 +78,12 @@ func NewAppPlatformDriverWithClient(c AppPlatformClient, region string) *AppPlat
 	return &AppPlatformDriver{client: c, region: region}
 }
 
+// NewAppPlatformDriverWithDomainProbe creates a test driver with an injected
+// custom-domain readiness probe.
+func NewAppPlatformDriverWithDomainProbe(c AppPlatformClient, region string, probe AppPlatformDomainProbe) *AppPlatformDriver {
+	return &AppPlatformDriver{client: c, region: region, domainProbe: probe}
+}
+
 // NewAppPlatformDriverWithClients creates a driver with both clients injected (for tests).
 func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, region string) *AppPlatformDriver {
 	return &AppPlatformDriver{client: c, regClient: r, region: region}
@@ -85,6 +92,12 @@ func NewAppPlatformDriverWithClients(c AppPlatformClient, r RegistryClient, regi
 // NewAppPlatformDriverWithDNSClient creates a test driver with injected app and DNS clients.
 func NewAppPlatformDriverWithDNSClient(c AppPlatformClient, dns DomainsClient, region string) *AppPlatformDriver {
 	return &AppPlatformDriver{client: c, dnsClient: dns, region: region}
+}
+
+// NewAppPlatformDriverWithDNSClientAndDomainProbe creates a test driver with
+// injected app, DNS, and custom-domain readiness clients.
+func NewAppPlatformDriverWithDNSClientAndDomainProbe(c AppPlatformClient, dns DomainsClient, region string, probe AppPlatformDomainProbe) *AppPlatformDriver {
+	return &AppPlatformDriver{client: c, dnsClient: dns, region: region, domainProbe: probe}
 }
 
 func (d *AppPlatformDriver) Create(ctx context.Context, spec interfaces.ResourceSpec) (*interfaces.ResourceOutput, error) {
@@ -632,6 +645,9 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 		if err := d.reconcileAppDomainCNAMEs(ctx, app, appDomains(app)); err != nil {
 			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 		}
+		if err := appPlatformCustomDomainReadinessError(ctx, ref.Name, app, d.domainProbe, ""); err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
 		d.clearUpdateDeploymentState(providerID)
 		return &interfaces.HealthResult{Healthy: true}, nil
 	}
@@ -642,6 +658,9 @@ func (d *AppPlatformDriver) HealthCheck(ctx context.Context, ref interfaces.Reso
 	result := appHealthResult(ctx, listFn, app)
 	if result != nil && result.Healthy {
 		if err := d.reconcileAppDomainCNAMEs(ctx, app, appDomains(app)); err != nil {
+			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
+		}
+		if err := appPlatformCustomDomainReadinessError(ctx, ref.Name, app, d.domainProbe, ""); err != nil {
 			return &interfaces.HealthResult{Healthy: false, Message: err.Error()}, nil
 		}
 	}

--- a/internal/drivers/app_platform_readiness.go
+++ b/internal/drivers/app_platform_readiness.go
@@ -1,0 +1,134 @@
+package drivers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/godo"
+)
+
+const appPlatformDomainProbeTimeout = 5 * time.Second
+
+// AppPlatformDomainProbe checks whether a custom domain is user-visible over
+// HTTPS for the app's readiness path.
+type AppPlatformDomainProbe func(ctx context.Context, domain, path string) error
+
+var appPlatformDomainHTTPClient = &http.Client{Timeout: appPlatformDomainProbeTimeout}
+
+func appPlatformCustomDomainReadinessError(ctx context.Context, appName string, app *godo.App, probe AppPlatformDomainProbe, pathOverride string) error {
+	domains := appPlatformCustomDomains(app)
+	if len(domains) == 0 {
+		return nil
+	}
+	for _, spec := range domains {
+		live := findLiveAppDomain(app, spec.Domain)
+		if live == nil {
+			return fmt.Errorf("app %q custom domain %q waiting for live domain status", appName, spec.Domain)
+		}
+		if live.Phase != godo.AppJobSpecKindPHASE_Active {
+			return fmt.Errorf("app %q custom domain %q %s", appName, spec.Domain, liveDomainHealthMessage(live))
+		}
+	}
+	if probe == nil {
+		probe = defaultAppPlatformDomainProbe
+	}
+	path := appPlatformReadinessPath(app, pathOverride)
+	for _, spec := range domains {
+		if spec.Wildcard {
+			continue
+		}
+		if err := probe(ctx, spec.Domain, path); err != nil {
+			return fmt.Errorf("app %q custom domain %q HTTPS readiness %s: %w", appName, spec.Domain, path, err)
+		}
+	}
+	return nil
+}
+
+func appPlatformCustomDomains(app *godo.App) []*godo.AppDomainSpec {
+	if app == nil || app.Spec == nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	out := make([]*godo.AppDomainSpec, 0, len(app.Spec.Domains))
+	for _, spec := range app.Spec.Domains {
+		if spec == nil || strings.TrimSpace(spec.Domain) == "" || spec.Type == godo.AppDomainSpecType_Default {
+			continue
+		}
+		domain := strings.ToLower(strings.TrimSpace(spec.Domain))
+		if seen[domain] {
+			continue
+		}
+		seen[domain] = true
+		out = append(out, spec)
+	}
+	return out
+}
+
+func appPlatformReadinessPath(app *godo.App, override string) string {
+	if path := normalizeReadinessPath(override); path != "" {
+		return path
+	}
+	if app != nil && app.Spec != nil {
+		for _, svc := range app.Spec.Services {
+			if svc == nil || svc.HealthCheck == nil {
+				continue
+			}
+			if path := normalizeReadinessPath(svc.HealthCheck.HTTPPath); path != "" {
+				return path
+			}
+		}
+	}
+	return "/"
+}
+
+func normalizeReadinessPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		parsed, err := url.Parse(path)
+		if err == nil {
+			path = parsed.RequestURI()
+		}
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return path
+}
+
+func defaultAppPlatformDomainProbe(ctx context.Context, domain, path string) error {
+	u := appPlatformDomainReadinessURL(domain, path)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "workflow-plugin-digitalocean/readiness")
+	resp, err := appPlatformDomainHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("GET %s returned %s", u, resp.Status)
+	}
+	return nil
+}
+
+func appPlatformDomainReadinessURL(domain, path string) string {
+	u := &url.URL{Scheme: "https", Host: strings.TrimSpace(domain)}
+	if parsed, err := url.ParseRequestURI(appPlatformReadinessPath(nil, path)); err == nil {
+		u.Path = parsed.Path
+		u.RawQuery = parsed.RawQuery
+	} else {
+		u.Path = "/"
+	}
+	return u.String()
+}

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -181,6 +181,10 @@ func TestAppPlatformDriver_HealthCheck_ReconcilesManagedDomainCNAME(t *testing.T
 			{Domain: "www.example.com", Type: godo.AppDomainSpecType_Alias, Zone: "example.com"},
 		},
 	}
+	app.Domains = []*godo.AppDomain{
+		{Spec: app.Spec.Domains[0], Phase: godo.AppJobSpecKindPHASE_Active},
+		{Spec: app.Spec.Domains[1], Phase: godo.AppJobSpecKindPHASE_Active},
+	}
 	app.ActiveDeployment = &godo.Deployment{ID: "dep-new", Phase: godo.DeploymentPhase_Active}
 	mock := &mockAppClient{app: app}
 	dns := &mockDomainsClient{
@@ -190,7 +194,9 @@ func TestAppPlatformDriver_HealthCheck_ReconcilesManagedDomainCNAME(t *testing.T
 			{ID: 10, Type: "CNAME", Name: "www", Data: "my-app-old.ondigitalocean.app.", TTL: 1800},
 		},
 	}
-	d := drivers.NewAppPlatformDriverWithDNSClient(mock, dns, "nyc3")
+	d := drivers.NewAppPlatformDriverWithDNSClientAndDomainProbe(mock, dns, "nyc3", func(context.Context, string, string) error {
+		return nil
+	})
 
 	result, err := d.HealthCheck(context.Background(), interfaces.ResourceRef{
 		Name:       "my-app",
@@ -325,6 +331,104 @@ func TestAppPlatformDriver_HealthCheckWaitsForDeploymentTriggeredByUpdate(t *tes
 	}
 	if !result.Healthy {
 		t.Fatalf("HealthCheck after new deployment active Healthy=false, message=%q", result.Message)
+	}
+}
+
+func TestAppPlatformDriver_HealthCheckWaitsForCustomDomainPhaseAfterUpdate(t *testing.T) {
+	app := testApp()
+	app.ActiveDeployment.ID = "dep-old"
+	app.Spec.Domains = []*godo.AppDomainSpec{{
+		Domain: "example.com",
+		Type:   godo.AppDomainSpecType_Primary,
+	}}
+	app.Domains = []*godo.AppDomain{{
+		Spec:  app.Spec.Domains[0],
+		Phase: godo.AppJobSpecKindPHASE_Configuring,
+	}}
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc3")
+	ref := interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}
+
+	if _, err := d.Update(context.Background(), ref, interfaces.ResourceSpec{
+		Name:   "my-app",
+		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	mock.deployments = []*godo.Deployment{{
+		ID:                   "dep-new",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-old",
+	}}
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheck should wait for custom domain phase before reporting healthy")
+	}
+	if !strings.Contains(result.Message, "example.com") || !strings.Contains(result.Message, "CONFIGURING") {
+		t.Fatalf("HealthCheck message = %q, want domain and phase", result.Message)
+	}
+}
+
+func TestAppPlatformDriver_HealthCheckWaitsForCustomDomainHTTPSAfterUpdate(t *testing.T) {
+	app := testApp()
+	app.ActiveDeployment.ID = "dep-old"
+	app.Spec.Services = []*godo.AppServiceSpec{{
+		Name: "web",
+		HealthCheck: &godo.AppServiceSpecHealthCheck{
+			HTTPPath: "/healthz",
+		},
+	}}
+	app.Spec.Domains = []*godo.AppDomainSpec{{
+		Domain: "example.com",
+		Type:   godo.AppDomainSpecType_Primary,
+	}}
+	app.Domains = []*godo.AppDomain{{
+		Spec:  app.Spec.Domains[0],
+		Phase: godo.AppJobSpecKindPHASE_Active,
+	}}
+	mock := &mockAppClient{app: app}
+	var probeCalls []string
+	probeErr := errors.New("tls handshake failed")
+	d := drivers.NewAppPlatformDriverWithDomainProbe(mock, "nyc3", func(_ context.Context, domain, path string) error {
+		probeCalls = append(probeCalls, domain+path)
+		return probeErr
+	})
+	ref := interfaces.ResourceRef{
+		Name:       "my-app",
+		ProviderID: "f8b6200c-3bba-48a7-8bf1-7a3e3a885eb5",
+	}
+
+	if _, err := d.Update(context.Background(), ref, interfaces.ResourceSpec{
+		Name:   "my-app",
+		Config: map[string]any{"image": "registry.digitalocean.com/myrepo/myapp:v2"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	mock.deployments = []*godo.Deployment{{
+		ID:                   "dep-new",
+		Phase:                godo.DeploymentPhase_Active,
+		PreviousDeploymentID: "dep-old",
+	}}
+	result, err := d.HealthCheck(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("HealthCheck: %v", err)
+	}
+	if result.Healthy {
+		t.Fatalf("HealthCheck should wait for custom domain HTTPS before reporting healthy")
+	}
+	if !strings.Contains(result.Message, "example.com") || !strings.Contains(result.Message, "tls handshake failed") {
+		t.Fatalf("HealthCheck message = %q, want domain and TLS error", result.Message)
+	}
+	if len(probeCalls) != 1 || probeCalls[0] != "example.com/healthz" {
+		t.Fatalf("probe calls = %#v, want example.com/healthz", probeCalls)
 	}
 }
 

--- a/internal/drivers/deploy.go
+++ b/internal/drivers/deploy.go
@@ -17,6 +17,7 @@ type AppDeployDriver struct {
 	region                     string
 	appID                      string
 	appName                    string
+	domainProbe                AppPlatformDomainProbe
 	targetDeploymentID         string
 	previousActiveDeploymentID string
 	waitingForDeployment       bool
@@ -31,6 +32,12 @@ func NewAppDeployDriver(c AppPlatformClient, region, appID, appName string) *App
 // presence pre-flight. The registry client may be nil to skip the check.
 func NewAppDeployDriverWithRegistry(c AppPlatformClient, r RegistryClient, region, appID, appName string) *AppDeployDriver {
 	return &AppDeployDriver{client: c, regClient: r, region: region, appID: appID, appName: appName}
+}
+
+// NewAppDeployDriverWithDomainProbe creates a DeployDriver with an injected
+// custom-domain readiness probe for tests.
+func NewAppDeployDriverWithDomainProbe(c AppPlatformClient, region, appID, appName string, probe AppPlatformDomainProbe) *AppDeployDriver {
+	return &AppDeployDriver{client: c, region: region, appID: appID, appName: appName, domainProbe: probe}
 }
 
 func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
@@ -66,7 +73,7 @@ func (d *AppDeployDriver) Update(ctx context.Context, image string) error {
 	return nil
 }
 
-func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
+func (d *AppDeployDriver) HealthCheck(ctx context.Context, path string) error {
 	app, err := d.getApp(ctx)
 	if err != nil {
 		return fmt.Errorf("app deploy: health check %q: %w", d.appName, err)
@@ -79,7 +86,10 @@ func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
 		if dep == nil {
 			return fmt.Errorf("app deploy: %q waiting for deployment after update", d.appName)
 		}
-		return deploymentHealthError(d.appName, dep)
+		if err := deploymentHealthError(d.appName, dep); err != nil {
+			return err
+		}
+		return appPlatformCustomDomainReadinessError(ctx, d.appName, app, d.domainProbe, path)
 	}
 	if app.ActiveDeployment == nil || app.ActiveDeployment.Phase != godo.DeploymentPhase_Active {
 		phase := ""
@@ -88,7 +98,7 @@ func (d *AppDeployDriver) HealthCheck(ctx context.Context, _ string) error {
 		}
 		return fmt.Errorf("app deploy: %q not active (phase: %q)", d.appName, phase)
 	}
-	return nil
+	return appPlatformCustomDomainReadinessError(ctx, d.appName, app, d.domainProbe, path)
 }
 
 func (d *AppDeployDriver) currentTargetDeployment(ctx context.Context, app *godo.App) (*godo.Deployment, error) {

--- a/internal/drivers/deploy_test.go
+++ b/internal/drivers/deploy_test.go
@@ -258,6 +258,33 @@ func TestAppDeployDriver_HealthCheck_WaitsUntilNewDeploymentObserved(t *testing.
 	}
 }
 
+func TestAppDeployDriver_HealthCheck_WaitsForCustomDomainHTTPS(t *testing.T) {
+	m := newDeployMock()
+	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")
+	app.Spec.Domains = []*godo.AppDomainSpec{{
+		Domain: "example.com",
+		Type:   godo.AppDomainSpecType_Primary,
+	}}
+	app.Domains = []*godo.AppDomain{{
+		Spec:  app.Spec.Domains[0],
+		Phase: godo.AppJobSpecKindPHASE_Active,
+	}}
+	var probeCalls []string
+	d := drivers.NewAppDeployDriverWithDomainProbe(m, "nyc3", "app-1", "myapp", func(_ context.Context, domain, path string) error {
+		probeCalls = append(probeCalls, domain+path)
+		return fmt.Errorf("tls handshake failed")
+	})
+
+	if err := d.HealthCheck(context.Background(), "/healthz"); err == nil ||
+		!strings.Contains(err.Error(), "example.com") ||
+		!strings.Contains(err.Error(), "tls handshake failed") {
+		t.Fatalf("HealthCheck should wait for custom domain HTTPS, got: %v", err)
+	}
+	if len(probeCalls) != 1 || probeCalls[0] != "example.com/healthz" {
+		t.Fatalf("probe calls = %#v, want example.com/healthz", probeCalls)
+	}
+}
+
 func TestAppDeployDriver_HealthCheck_RetargetsWhenUpdateDeploymentIsSuperseded(t *testing.T) {
 	m := newDeployMock()
 	app := seedApp(m, "app-1", "myapp", "registry.digitalocean.com/myrepo/myapp:v1")


### PR DESCRIPTION
## Summary
- require App Platform custom domains to reach live `ACTIVE` phase before health reports ready
- probe declared custom domains over HTTPS using the app health path before `wfctl --wait` succeeds
- apply the same readiness gate to provider-native deploy drivers

## Evidence
Latest multisite deploy reported DO deployment healthy at 11:56:15, then public smoke hit TLS handshake failures on `https://gocodealone.tech/healthz` until 11:57:55. DO health checks cover component readiness, but custom-domain browser readiness lagged behind.

DigitalOcean docs describe App Platform health checks as readiness probes for application traffic and custom domains as separate app spec/domain configuration, so provider health must cover both for a browser-ready custom domain.

## Verification
- `GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_HealthCheckWaitsForCustomDomain|TestAppDeployDriver_HealthCheck_WaitsForCustomDomainHTTPS' -count=1`
- `GOWORK=off go test ./internal/drivers -count=1`
- `GOWORK=off go test ./...`

## Regression proof
With production readiness code reverted and tests kept, the targeted test command fails to compile because the new custom-domain readiness constructors/helpers are absent. With the fix restored, the targeted tests pass.

## Limits
This makes provider readiness accurate for custom-domain HTTPS. It does not by itself prove true zero-downtime App Platform domain handoff if DO temporarily breaks an existing custom domain during an in-place app update; that requires validating the next multisite deploy and likely a follow-up deployment-strategy change if the domain still drops while the provider is waiting.
