### PR TITLE
feat: enrich DigitalOcean DNS import outputs

### DIFF
--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -1216,8 +1216,11 @@ func dnsCanonicalRecordData(recordType, data string) string {
 
 func dnsOutput(dom *godo.Domain, name string, records []godo.DomainRecord) *interfaces.ResourceOutput {
 	outputs := map[string]any{
-		"domain": dom.Name,
-		"ttl":    dom.TTL,
+		"domain":                    dom.Name,
+		"ttl":                       dom.TTL,
+		"zone_file":                 dom.ZoneFile,
+		"record_count":              len(records),
+		"authoritative_nameservers": digitalOceanAuthoritativeNameservers(),
 	}
 	if records != nil {
 		outputs["records"] = dnsRecordOutputs(records)
@@ -1235,6 +1238,7 @@ func dnsRecordOutputs(records []godo.DomainRecord) []map[string]any {
 	out := make([]map[string]any, 0, len(records))
 	for _, record := range records {
 		out = append(out, map[string]any{
+			"id":       record.ID,
 			"type":     record.Type,
 			"name":     record.Name,
 			"data":     record.Data,
@@ -1247,6 +1251,10 @@ func dnsRecordOutputs(records []godo.DomainRecord) []map[string]any {
 		})
 	}
 	return out
+}
+
+func digitalOceanAuthoritativeNameservers() []string {
+	return []string{"ns1.digitalocean.com", "ns2.digitalocean.com", "ns3.digitalocean.com"}
 }
 
 func (d *DNSDriver) SensitiveKeys() []string { return nil }

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -297,8 +297,9 @@ func recordPageResponse(domain string, page, pageCount int) *godo.Response {
 
 func testDomain() *godo.Domain {
 	return &godo.Domain{
-		Name: "example.com",
-		TTL:  1800,
+		Name:     "example.com",
+		TTL:      1800,
+		ZoneFile: "$ORIGIN example.com.\n",
 	}
 }
 
@@ -337,6 +338,22 @@ func TestDNSDriver_Create(t *testing.T) {
 	}
 	if got := records[0]["data"]; got != "1.2.3.4" {
 		t.Errorf("created output record data = %v, want 1.2.3.4", got)
+	}
+	if got := records[0]["id"]; got == nil {
+		t.Errorf("created output record id missing from %+v", records[0])
+	}
+	if got := out.Outputs["zone_file"]; got != "$ORIGIN example.com.\n" {
+		t.Errorf("zone_file = %q, want exported zone file", got)
+	}
+	if got := out.Outputs["record_count"]; got != 1 {
+		t.Errorf("record_count = %v, want 1", got)
+	}
+	ns, ok := out.Outputs["authoritative_nameservers"].([]string)
+	if !ok {
+		t.Fatalf("authoritative_nameservers = %T, want []string", out.Outputs["authoritative_nameservers"])
+	}
+	if len(ns) != 3 || ns[0] != "ns1.digitalocean.com" {
+		t.Fatalf("authoritative_nameservers = %#v", ns)
 	}
 }
 

--- a/internal/provider_test.go
+++ b/internal/provider_test.go
@@ -558,7 +558,7 @@ func TestDOProvider_Plan_DNSDriverDiffNoopsWhenImportedRecordStateMatches(t *tes
 
 func TestDOProvider_Import_DNSIncludesExistingRecords(t *testing.T) {
 	mock := &providerDNSMock{
-		domain:  &godo.Domain{Name: "example.com"},
+		domain:  &godo.Domain{Name: "example.com", ZoneFile: "$ORIGIN example.com.\n"},
 		records: []godo.DomainRecord{{ID: 10, Type: "TXT", Name: "@", Data: "imported", TTL: 300}},
 	}
 	p := &DOProvider{drivers: map[string]interfaces.ResourceDriver{
@@ -575,6 +575,15 @@ func TestDOProvider_Import_DNSIncludesExistingRecords(t *testing.T) {
 	}
 	if len(records) != 1 || records[0]["data"] != "imported" {
 		t.Fatalf("records = %#v, want imported TXT record", records)
+	}
+	if records[0]["id"] != 10 {
+		t.Fatalf("record id = %#v, want 10", records[0]["id"])
+	}
+	if state.Outputs["zone_file"] != "$ORIGIN example.com.\n" {
+		t.Fatalf("zone_file = %#v, want exported zone", state.Outputs["zone_file"])
+	}
+	if state.Outputs["record_count"] != 1 {
+		t.Fatalf("record_count = %#v, want 1", state.Outputs["record_count"])
 	}
 }
 


### PR DESCRIPTION
## Summary\n- include zone_file and record_count in infra.dns outputs\n- preserve DigitalOcean record IDs in imported state\n- expose DigitalOcean authoritative nameserver guidance metadata\n\n## Verification\n- GOWORK=off go vet ./...\n- GOWORK=off go test ./... -race -count=1