### PR TITLE
Expose DigitalOcean DNS authority output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ resources:
 
 `data` is optional. When omitted, every record matching `type` and `name` is deleted. When set for hostname-like records such as `CNAME`, `MX`, `NS`, and `SRV`, matching ignores case and a trailing dot.
 
+DNS reads and imports preserve a provider-neutral `authority` output alongside the legacy `authoritative_nameservers` list:
+
+```json
+{
+  "authority": {
+    "role": "authoritative_dns",
+    "dns_host": "DigitalOcean",
+    "name_servers": ["ns1.digitalocean.com", "ns2.digitalocean.com", "ns3.digitalocean.com"]
+  }
+}
+```
+
+The nested shape matches Workflow DNS replay fixtures while keeping existing flat outputs stable for current consumers.
+
 ## Deployment strategies
 
 - [Deployment strategies](docs/DEPLOYMENT_STRATEGIES.md) — what `AppDeployDriver`, `AppBlueGreenDriver`, and `AppCanaryDriver` actually do on DO App Platform, including the in-rollout availability probe and the InstanceCount<2 single-instance non-guarantee.

--- a/internal/drivers/dns.go
+++ b/internal/drivers/dns.go
@@ -1215,12 +1215,18 @@ func dnsCanonicalRecordData(recordType, data string) string {
 }
 
 func dnsOutput(dom *godo.Domain, name string, records []godo.DomainRecord) *interfaces.ResourceOutput {
+	nameservers := digitalOceanAuthoritativeNameservers()
 	outputs := map[string]any{
 		"domain":                    dom.Name,
 		"ttl":                       dom.TTL,
 		"zone_file":                 dom.ZoneFile,
 		"record_count":              len(records),
-		"authoritative_nameservers": digitalOceanAuthoritativeNameservers(),
+		"authoritative_nameservers": append([]string(nil), nameservers...),
+		"authority": map[string]any{
+			"role":         "authoritative_dns",
+			"dns_host":     "DigitalOcean",
+			"name_servers": append([]string(nil), nameservers...),
+		},
 	}
 	if records != nil {
 		outputs["records"] = dnsRecordOutputs(records)

--- a/internal/drivers/dns_test.go
+++ b/internal/drivers/dns_test.go
@@ -355,6 +355,23 @@ func TestDNSDriver_Create(t *testing.T) {
 	if len(ns) != 3 || ns[0] != "ns1.digitalocean.com" {
 		t.Fatalf("authoritative_nameservers = %#v", ns)
 	}
+	authority, ok := out.Outputs["authority"].(map[string]any)
+	if !ok {
+		t.Fatalf("authority = %T, want map[string]any", out.Outputs["authority"])
+	}
+	if got := authority["role"]; got != "authoritative_dns" {
+		t.Fatalf("authority.role = %v, want authoritative_dns", got)
+	}
+	if got := authority["dns_host"]; got != "DigitalOcean" {
+		t.Fatalf("authority.dns_host = %v, want DigitalOcean", got)
+	}
+	authorityNS, ok := authority["name_servers"].([]string)
+	if !ok {
+		t.Fatalf("authority.name_servers = %T, want []string", authority["name_servers"])
+	}
+	if len(authorityNS) != 3 || authorityNS[0] != "ns1.digitalocean.com" {
+		t.Fatalf("authority.name_servers = %#v", authorityNS)
+	}
 }
 
 func TestDNSDriver_Create_Error(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a provider-neutral `authority` output for `infra.dns` reads/imports
- preserve the existing `authoritative_nameservers` output for compatibility
- document the authority shape used by DNS replay fixtures

## Verification
- watched `TestDNSDriver_Create` fail before implementation because `authority` was missing
- `GOWORK=off go test ./internal/drivers -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go build ./...`
- `git diff --check`

## Adversarial review
- fixed shared-slice aliasing between flat and nested nameserver outputs
- kept the change additive to avoid breaking current output consumers