### PR TITLE
ci: fix Layer 3b verify-capabilities wiring + bump setup-wfctl to v0.63.2 (workflow#765)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.61.0
+          version: v0.63.2
       - name: Validate plugin contract for publish (pre-build)
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
       - uses: goreleaser/goreleaser-action@v7
@@ -42,7 +42,7 @@ jobs:
             jq '.[] | {name, type, goos, goarch, path}' dist/artifacts.json
             exit 0
           fi
-          "${{ runner.temp }}/wfctl-bin/wfctl" plugin verify-capabilities --binary "$BIN" .
+          wfctl plugin verify-capabilities --binary "$BIN" .
       - name: Verify shipped plugin.json carries tag (post-build)
         run: |
           if [ -f .release/plugin.json ]; then


### PR DESCRIPTION
Layer 3b extension's verify-capabilities step references ${{ runner.temp }}/wfctl-bin/wfctl but no curl-install step exists in this repo (uses setup-wfctl@v1 PATH install pattern instead). Fix by (a) bumping setup-wfctl pin → v0.63.2 (carries actual subcommand per #769) and (b) switching verify-capabilities invocation to PATH wfctl.