### PR TITLE
chore: bump plugin.json v2.1.1 (C5 post-release cleanup)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,225 +1,225 @@
 {
-  "name": "workflow-plugin-digitalocean",
-  "version": "0.0.0",
-  "description": "DigitalOcean IaC provider: App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
-  "author": "GoCodeAlone",
-  "license": "MIT",
-  "type": "external",
-  "tier": "community",
-  "minEngineVersion": "0.64.0",
-  "iacServices": [
-    "workflow.plugin.external.iac.IaCProviderRequired",
-    "workflow.plugin.external.iac.IaCProviderEnumerator",
-    "workflow.plugin.external.iac.IaCProviderDriftDetector",
-    "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
-    "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
-    "workflow.plugin.external.iac.IaCProviderValidator",
-    "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
-    "workflow.plugin.external.iac.IaCProviderLogCapture",
-    "workflow.plugin.external.iac.IaCProviderFinalizer",
-    "workflow.plugin.external.iac.IaCStateBackend"
-  ],
-  "keywords": [
-    "digitalocean",
-    "iac",
-    "infra",
-    "kubernetes",
-    "database",
-    "app-platform",
-    "spaces",
-    "redis"
-  ],
-  "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
-  "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
-  "downloads": [
-    {
-      "os": "linux",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-linux-amd64.tar.gz"
-    },
-    {
-      "os": "linux",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-linux-arm64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "amd64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
-    },
-    {
-      "os": "darwin",
-      "arch": "arm64",
-      "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
-    }
-  ],
-  "iacProvider": {
-    "computePlanVersion": "v2"
-  },
-  "capabilities": {
-    "configProvider": false,
-    "moduleTypes": [
-      "iac.provider"
+    "name": "workflow-plugin-digitalocean",
+    "version": "2.1.1",
+    "description": "DigitalOcean IaC provider: App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
+    "author": "GoCodeAlone",
+    "license": "MIT",
+    "type": "external",
+    "tier": "community",
+    "minEngineVersion": "0.64.0",
+    "iacServices": [
+        "workflow.plugin.external.iac.IaCProviderRequired",
+        "workflow.plugin.external.iac.IaCProviderEnumerator",
+        "workflow.plugin.external.iac.IaCProviderDriftDetector",
+        "workflow.plugin.external.iac.IaCProviderCredentialRevoker",
+        "workflow.plugin.external.iac.IaCProviderMigrationRepairer",
+        "workflow.plugin.external.iac.IaCProviderValidator",
+        "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
+        "workflow.plugin.external.iac.IaCProviderLogCapture",
+        "workflow.plugin.external.iac.IaCProviderFinalizer",
+        "workflow.plugin.external.iac.IaCStateBackend"
     ],
-    "stepTypes": [
-      "step.iac_logs",
-      "step.iac_scale"
+    "keywords": [
+        "digitalocean",
+        "iac",
+        "infra",
+        "kubernetes",
+        "database",
+        "app-platform",
+        "spaces",
+        "redis"
     ],
-    "triggerTypes": [],
-    "iacStateBackends": [
-      "spaces"
+    "homepage": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
+    "repository": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean",
+    "downloads": [
+        {
+            "os": "linux",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-linux-amd64.tar.gz"
+        },
+        {
+            "os": "linux",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-linux-arm64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "amd64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-darwin-amd64.tar.gz"
+        },
+        {
+            "os": "darwin",
+            "arch": "arm64",
+            "url": "https://github.com/GoCodeAlone/workflow-plugin-digitalocean/releases/download/v2.0.15/workflow-plugin-digitalocean-darwin-arm64.tar.gz"
+        }
     ],
     "iacProvider": {
-      "name": "digitalocean",
-      "resourceTypes": [
-        "infra.container_service",
-        "infra.app_domain",
-        "infra.k8s_cluster",
-        "infra.database",
-        "infra.cache",
-        "infra.load_balancer",
-        "infra.vpc",
-        "infra.firewall",
-        "infra.dns",
-        "infra.storage",
-        "infra.registry",
-        "infra.certificate",
-        "infra.droplet",
-        "infra.volume",
-        "infra.iam_role",
-        "infra.api_gateway"
-      ],
-      "configSchema": {
-        "infra.container_service": {
-          "expose": {
-            "type": "string",
-            "enum": [
-              "public",
-              "internal"
+        "computePlanVersion": "v2"
+    },
+    "capabilities": {
+        "configProvider": false,
+        "moduleTypes": [
+            "iac.provider"
+        ],
+        "stepTypes": [
+            "step.iac_logs",
+            "step.iac_scale"
+        ],
+        "triggerTypes": [],
+        "iacStateBackends": [
+            "spaces"
+        ],
+        "iacProvider": {
+            "name": "digitalocean",
+            "resourceTypes": [
+                "infra.container_service",
+                "infra.app_domain",
+                "infra.k8s_cluster",
+                "infra.database",
+                "infra.cache",
+                "infra.load_balancer",
+                "infra.vpc",
+                "infra.firewall",
+                "infra.dns",
+                "infra.storage",
+                "infra.registry",
+                "infra.certificate",
+                "infra.droplet",
+                "infra.volume",
+                "infra.iam_role",
+                "infra.api_gateway"
             ],
-            "default": "public",
-            "description": "Whether the service has a public edge route (public, default) or is reachable only from sibling components via DO App Platform internal DNS (<name>.internal:<port>) (internal)."
-          }
-        },
-        "infra.app_domain": {
-          "description": "DigitalOcean App Platform domain binding. Updates only AppSpec.Domains on an existing App Platform app so DNS/domain aliases can be reconciled without rebuilding service images or runtime environment variables.",
-          "fields": {
-            "app": {
-              "type": "string",
-              "required": false,
-              "description": "Existing App Platform app name. Required unless app_id is set."
-            },
-            "app_id": {
-              "type": "string",
-              "required": false,
-              "description": "Existing App Platform app UUID. Required unless app is set."
-            },
-            "domain": {
-              "type": "string",
-              "required": true,
-              "description": "Fully qualified domain name to attach to the app."
-            },
-            "type": {
-              "type": "string",
-              "required": false,
-              "enum": [
-                "PRIMARY",
-                "ALIAS"
-              ],
-              "description": "App Platform custom domain type. Use PRIMARY for the app's primary custom domain or ALIAS for a non-primary custom domain."
-            },
-            "zone": {
-              "type": "string",
-              "required": false,
-              "description": "DigitalOcean DNS zone for provider-managed DNS validation."
-            },
-            "wildcard": {
-              "type": "bool",
-              "required": false,
-              "description": "Whether the domain is a wildcard binding."
-            },
-            "certificate": {
-              "type": "string",
-              "required": false,
-              "description": "Certificate ID to attach when using a custom certificate."
-            },
-            "minimum_tls_version": {
-              "type": "string",
-              "required": false,
-              "enum": [
-                "1.2",
-                "1.3"
-              ],
-              "description": "Minimum TLS version for this domain."
-            }
-          }
-        },
-        "infra.dns": {
-          "description": "DigitalOcean DNS zone and record reconciliation. Declared records are upserted; absent_records deletes targeted stale records without making the whole zone authoritative.",
-          "fields": {
-            "domain": {
-              "type": "string",
-              "required": true,
-              "description": "DNS zone name."
-            },
-            "records": {
-              "type": "array<object>",
-              "required": false,
-              "description": "Records to create or update. Each record supports type, name, data, ttl, and type-specific fields."
-            },
-            "absent_records": {
-              "type": "array<object>",
-              "required": false,
-              "description": "Records to delete when present. Each entry supports type, name, and optional data for exact-value matching."
-            }
-          }
-        },
-        "infra.firewall": {
-          "description": "DigitalOcean cloud firewall. Attaches to Droplets by ID or by tag (which auto-attaches future Droplets / DOKS pools that receive the tag). Either `droplet_ids` or `tags` is REQUIRED; `wfctl infra apply` rejects firewalls with no targets before any DO API call. NOTE: DO firewalls do not attach to App Platform apps \u2014 for App-Platform-only deployments, use `expose: internal` services plus `trusted_sources` on managed databases.",
-          "fields": {
-            "droplet_ids": {
-              "type": "array<int>",
-              "required": false,
-              "description": "Droplet IDs the firewall attaches to. At least one of `droplet_ids` or `tags` must be set."
-            },
-            "tags": {
-              "type": "array<string>",
-              "required": false,
-              "description": "Droplet/DOKS-pool tag strings. Resources receiving any listed tag auto-join the firewall. Example: [\"bmw-prod\"]."
-            },
-            "inbound_rules": {
-              "type": "array<object>",
-              "required": false,
-              "description": "Each rule: {protocol: tcp|udp|icmp, ports: \"<n>|<a-b>|all\", sources: [<CIDR>...]}."
-            },
-            "outbound_rules": {
-              "type": "array<object>",
-              "required": false,
-              "description": "Each rule: {protocol: tcp|udp|icmp, ports: \"<n>|<a-b>|all\", destinations: [<CIDR>...]}."
-            }
-          },
-          "examples": [
-            {
-              "name": "tag-based-firewall",
-              "comment": "Tag-based attachment so future Droplets / DOKS pools auto-join.",
-              "spec": {
-                "tags": [
-                  "bmw-prod"
-                ],
-                "inbound_rules": [
-                  {
-                    "protocol": "tcp",
-                    "ports": "443",
-                    "sources": [
-                      "0.0.0.0/0"
+            "configSchema": {
+                "infra.container_service": {
+                    "expose": {
+                        "type": "string",
+                        "enum": [
+                            "public",
+                            "internal"
+                        ],
+                        "default": "public",
+                        "description": "Whether the service has a public edge route (public, default) or is reachable only from sibling components via DO App Platform internal DNS (<name>.internal:<port>) (internal)."
+                    }
+                },
+                "infra.app_domain": {
+                    "description": "DigitalOcean App Platform domain binding. Updates only AppSpec.Domains on an existing App Platform app so DNS/domain aliases can be reconciled without rebuilding service images or runtime environment variables.",
+                    "fields": {
+                        "app": {
+                            "type": "string",
+                            "required": false,
+                            "description": "Existing App Platform app name. Required unless app_id is set."
+                        },
+                        "app_id": {
+                            "type": "string",
+                            "required": false,
+                            "description": "Existing App Platform app UUID. Required unless app is set."
+                        },
+                        "domain": {
+                            "type": "string",
+                            "required": true,
+                            "description": "Fully qualified domain name to attach to the app."
+                        },
+                        "type": {
+                            "type": "string",
+                            "required": false,
+                            "enum": [
+                                "PRIMARY",
+                                "ALIAS"
+                            ],
+                            "description": "App Platform custom domain type. Use PRIMARY for the app's primary custom domain or ALIAS for a non-primary custom domain."
+                        },
+                        "zone": {
+                            "type": "string",
+                            "required": false,
+                            "description": "DigitalOcean DNS zone for provider-managed DNS validation."
+                        },
+                        "wildcard": {
+                            "type": "bool",
+                            "required": false,
+                            "description": "Whether the domain is a wildcard binding."
+                        },
+                        "certificate": {
+                            "type": "string",
+                            "required": false,
+                            "description": "Certificate ID to attach when using a custom certificate."
+                        },
+                        "minimum_tls_version": {
+                            "type": "string",
+                            "required": false,
+                            "enum": [
+                                "1.2",
+                                "1.3"
+                            ],
+                            "description": "Minimum TLS version for this domain."
+                        }
+                    }
+                },
+                "infra.dns": {
+                    "description": "DigitalOcean DNS zone and record reconciliation. Declared records are upserted; absent_records deletes targeted stale records without making the whole zone authoritative.",
+                    "fields": {
+                        "domain": {
+                            "type": "string",
+                            "required": true,
+                            "description": "DNS zone name."
+                        },
+                        "records": {
+                            "type": "array<object>",
+                            "required": false,
+                            "description": "Records to create or update. Each record supports type, name, data, ttl, and type-specific fields."
+                        },
+                        "absent_records": {
+                            "type": "array<object>",
+                            "required": false,
+                            "description": "Records to delete when present. Each entry supports type, name, and optional data for exact-value matching."
+                        }
+                    }
+                },
+                "infra.firewall": {
+                    "description": "DigitalOcean cloud firewall. Attaches to Droplets by ID or by tag (which auto-attaches future Droplets / DOKS pools that receive the tag). Either `droplet_ids` or `tags` is REQUIRED; `wfctl infra apply` rejects firewalls with no targets before any DO API call. NOTE: DO firewalls do not attach to App Platform apps \u2014 for App-Platform-only deployments, use `expose: internal` services plus `trusted_sources` on managed databases.",
+                    "fields": {
+                        "droplet_ids": {
+                            "type": "array<int>",
+                            "required": false,
+                            "description": "Droplet IDs the firewall attaches to. At least one of `droplet_ids` or `tags` must be set."
+                        },
+                        "tags": {
+                            "type": "array<string>",
+                            "required": false,
+                            "description": "Droplet/DOKS-pool tag strings. Resources receiving any listed tag auto-join the firewall. Example: [\"bmw-prod\"]."
+                        },
+                        "inbound_rules": {
+                            "type": "array<object>",
+                            "required": false,
+                            "description": "Each rule: {protocol: tcp|udp|icmp, ports: \"<n>|<a-b>|all\", sources: [<CIDR>...]}."
+                        },
+                        "outbound_rules": {
+                            "type": "array<object>",
+                            "required": false,
+                            "description": "Each rule: {protocol: tcp|udp|icmp, ports: \"<n>|<a-b>|all\", destinations: [<CIDR>...]}."
+                        }
+                    },
+                    "examples": [
+                        {
+                            "name": "tag-based-firewall",
+                            "comment": "Tag-based attachment so future Droplets / DOKS pools auto-join.",
+                            "spec": {
+                                "tags": [
+                                    "bmw-prod"
+                                ],
+                                "inbound_rules": [
+                                    {
+                                        "protocol": "tcp",
+                                        "ports": "443",
+                                        "sources": [
+                                            "0.0.0.0/0"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
                     ]
-                  }
-                ]
-              }
+                }
             }
-          ]
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
## Summary
- Bumps `plugin.json` version to v2.1.1

## Test plan
- [ ] CI passes on merge
- [ ] Tag v2.1.1 triggers release workflow