### PR TITLE
feat: map observability requirements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoCodeAlone/workflow-plugin-digitalocean
 go 1.26.0
 
 require (
-	github.com/GoCodeAlone/workflow v0.64.0
+	github.com/GoCodeAlone/workflow v0.64.3
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.16
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.15

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0 h1:xb1mI4NZkzvNKQ2F6nk
 github.com/GoCodeAlone/modular/modules/jsonschema v1.15.0/go.mod h1:hhGouwAVsonmJ4Lain4jINZ9nZCoc9l9eF3BHbmR8eE=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0 h1:cvdLHbM/vzvygQTcAWSJsy+dAPzzwWyjzKMmTBFcFIo=
 github.com/GoCodeAlone/modular/modules/reverseproxy/v2 v2.8.0/go.mod h1:/9ipMG4qM2CHQ14BfXKdVlYRJelef6M8MFI5TbZv67M=
-github.com/GoCodeAlone/workflow v0.64.0 h1:2CpbYPwIqdGDb3xi3YJpwcteIum4ehBSrnRql/1YvB4=
-github.com/GoCodeAlone/workflow v0.64.0/go.mod h1:659GGDrw3QJ7b625y9rf8QhKIpt1VCoEG0MxKu5tGQs=
+github.com/GoCodeAlone/workflow v0.64.3 h1:r0jMoRJXJI8lz44c70mFjGcpy24IWpOTtkX7BC0/fas=
+github.com/GoCodeAlone/workflow v0.64.3/go.mod h1:659GGDrw3QJ7b625y9rf8QhKIpt1VCoEG0MxKu5tGQs=
 github.com/GoCodeAlone/yaegi v0.17.2 h1:WK6Y6e0t1a6U7r+S2dN3CGWW1PizYD3zO0zneToZPxM=
 github.com/GoCodeAlone/yaegi v0.17.2/go.mod h1:z5Pr6Wse6QJcQvpgxTxzMAevFarH0N37TG88Y9dprx0=
 github.com/IBM/sarama v1.47.0 h1:GcQFEd12+KzfPYeLgN69Fh7vLCtYRhVIx0rO4TZO318=

--- a/internal/iacserver.go
+++ b/internal/iacserver.go
@@ -55,6 +55,7 @@ type doIaCServer struct {
 	pb.UnimplementedIaCProviderValidatorServer
 	pb.UnimplementedIaCProviderDriftConfigDetectorServer
 	pb.UnimplementedIaCProviderLogCaptureServer
+	pb.UnimplementedIaCProviderRequirementMapperServer
 	// pb.UnimplementedIaCProviderFinalizerServer satisfies the
 	// mustEmbedUnimplementedIaCProviderFinalizerServer() forward-compat
 	// requirement on pb.IaCProviderFinalizerServer (workflow#695 Phase 2.5).
@@ -117,6 +118,7 @@ var (
 	_ pb.IaCProviderValidatorServer           = (*doIaCServer)(nil)
 	_ pb.IaCProviderDriftConfigDetectorServer = (*doIaCServer)(nil)
 	_ pb.IaCProviderLogCaptureServer          = (*doIaCServer)(nil)
+	_ pb.IaCProviderRequirementMapperServer   = (*doIaCServer)(nil)
 	// IaCProviderFinalizer is the workflow#695 Phase 2.5 optional service
 	// — DO plugin implements FinalizeApply server-side to host the
 	// deferred-flush iteration previously held inline in the v1

--- a/internal/iacserver_mapper.go
+++ b/internal/iacserver_mapper.go
@@ -1,0 +1,293 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	collectorModuleName    = "observability-collector"
+	collectorImage         = "otel/opentelemetry-collector-contrib:latest"
+	collectorRunCommand    = "otelcol-contrib --config=env:OTELCOL_CONFIG"
+	collectorRequirementTy = "infra.container_service"
+)
+
+// MapRequirements implements the optional derived-IaC mapper contract for
+// DigitalOcean. The only derived shape currently emitted is an App Platform
+// OpenTelemetry Collector service. App-specific names stay with applications:
+// the module name and satisfies keys are generic and overrideable in YAML.
+func (s *doIaCServer) MapRequirements(_ context.Context, req *pb.MapRequirementsRequest) (*pb.MapRequirementsResponse, error) {
+	if req.GetProvider() != "" && req.GetProvider() != "digitalocean" {
+		return nil, status.Errorf(codes.InvalidArgument, "digitalocean mapper cannot satisfy provider %q", req.GetProvider())
+	}
+
+	resp := &pb.MapRequirementsResponse{}
+	var accepted []*pb.IaCRequirement
+	for _, requirement := range req.GetRequirements() {
+		switch diag := rejectUnsupportedRequirement(req.GetRuntime(), requirement); {
+		case diag != nil:
+			resp.Rejected = append(resp.Rejected, diag)
+		default:
+			accepted = append(accepted, requirement)
+			resp.AcceptedKeys = append(resp.AcceptedKeys, requirement.GetKey())
+		}
+	}
+	if len(accepted) == 0 {
+		return resp, nil
+	}
+
+	cfg, err := collectorModuleConfig(accepted)
+	if err != nil {
+		return nil, err
+	}
+	configJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("digitalocean requirement mapper: encode collector config: %w", err)
+	}
+	resp.Modules = append(resp.Modules, &pb.DerivedModuleSpec{
+		Name:       collectorModuleName,
+		Type:       collectorRequirementTy,
+		Satisfies:  append([]string(nil), resp.GetAcceptedKeys()...),
+		ConfigJson: configJSON,
+	})
+	resp.Notes = append(resp.Notes, &pb.RequirementNote{
+		Key:         strings.Join(resp.GetAcceptedKeys(), ","),
+		Message:     "DigitalOcean App Platform has no native sidecars; this derives a generic internal OTel Collector service that can be overridden with an explicit module using the same satisfies keys.",
+		Interactive: false,
+	})
+	return resp, nil
+}
+
+func rejectUnsupportedRequirement(runtime pb.RequirementRuntime, req *pb.IaCRequirement) *pb.RequirementDiagnostic {
+	key := req.GetKey()
+	if req.GetKind() != pb.RequirementKind_REQUIREMENT_KIND_OBSERVABILITY {
+		return requirementDiagnostic(key, "unsupported_kind", "digitalocean can only derive observability requirements today")
+	}
+	if hint := req.GetResourceTypeHint(); hint != "" && hint != collectorRequirementTy {
+		return requirementDiagnostic(key, "unsupported_resource_type_hint",
+			fmt.Sprintf("digitalocean observability derivation emits %s, not %s", collectorRequirementTy, hint))
+	}
+	if runtime != pb.RequirementRuntime_REQUIREMENT_RUNTIME_DIGITALOCEAN_APP_PLATFORM {
+		return requirementDiagnostic(key, "unsupported_runtime", "digitalocean observability derivation currently targets App Platform")
+	}
+	if !requirementAllowsRuntime(req, runtime) {
+		return requirementDiagnostic(key, "unsupported_runtime", "requirement does not allow DigitalOcean App Platform")
+	}
+	if !requirementAllowsDeploymentMode(req) {
+		return requirementDiagnostic(key, "unsupported_deployment_mode",
+			"digitalocean App Platform maps sidecar intent to a sibling collector service")
+	}
+	return nil
+}
+
+func requirementAllowsRuntime(req *pb.IaCRequirement, runtime pb.RequirementRuntime) bool {
+	if len(req.GetRuntimes()) == 0 {
+		return true
+	}
+	for _, candidate := range req.GetRuntimes() {
+		if candidate == runtime {
+			return true
+		}
+	}
+	return false
+}
+
+func requirementAllowsDeploymentMode(req *pb.IaCRequirement) bool {
+	modes := req.GetDeploymentModes()
+	if len(modes) == 0 {
+		return true
+	}
+	for _, mode := range modes {
+		switch mode {
+		case pb.DeploymentMode_DEPLOYMENT_MODE_SIDECAR,
+			pb.DeploymentMode_DEPLOYMENT_MODE_SIBLING_SERVICE,
+			pb.DeploymentMode_DEPLOYMENT_MODE_MANAGED:
+			return true
+		}
+	}
+	return false
+}
+
+func requirementDiagnostic(key, code, message string) *pb.RequirementDiagnostic {
+	return &pb.RequirementDiagnostic{Key: key, Code: code, Message: message}
+}
+
+func collectorModuleConfig(reqs []*pb.IaCRequirement) (map[string]any, error) {
+	signals := requestedSignals(reqs)
+	backends := requestedBackends(reqs)
+	collectorConfig := buildCollectorConfig(signals, backends)
+
+	envVars := map[string]any{
+		"OTELCOL_CONFIG": collectorConfig,
+	}
+	secretVars := make(map[string]any)
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_OTEL) {
+		envVars["OTEL_EXPORTER_OTLP_ENDPOINT"] = "${vars.otel_exporter_otlp_endpoint}"
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_DATADOG) {
+		envVars["DD_SITE"] = "${vars.datadog_site}"
+		secretVars["DD_API_KEY"] = "${secrets.datadog_api_key}"
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_LOKI) {
+		envVars["LOKI_ENDPOINT"] = "${vars.loki_endpoint}"
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_GRAFANA) {
+		envVars["GRAFANA_OTLP_ENDPOINT"] = "${vars.grafana_otlp_endpoint}"
+		secretVars["GRAFANA_OTLP_HEADERS"] = "${secrets.grafana_otlp_headers}"
+	}
+
+	cfg := map[string]any{
+		"image":           collectorImage,
+		"run_command":     collectorRunCommand,
+		"expose":          "internal",
+		"ports":           collectorPorts(backends),
+		"env_vars":        envVars,
+		"env_vars_secret": secretVars,
+	}
+	return cfg, nil
+}
+
+func requestedSignals(reqs []*pb.IaCRequirement) map[pb.TelemetrySignal]bool {
+	out := make(map[pb.TelemetrySignal]bool)
+	for _, req := range reqs {
+		for _, signal := range req.GetTelemetrySignals() {
+			if signal != pb.TelemetrySignal_TELEMETRY_SIGNAL_UNSPECIFIED {
+				out[signal] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		out[pb.TelemetrySignal_TELEMETRY_SIGNAL_TRACES] = true
+		out[pb.TelemetrySignal_TELEMETRY_SIGNAL_METRICS] = true
+		out[pb.TelemetrySignal_TELEMETRY_SIGNAL_LOGS] = true
+	}
+	return out
+}
+
+func requestedBackends(reqs []*pb.IaCRequirement) map[pb.ObservabilityBackend]bool {
+	out := make(map[pb.ObservabilityBackend]bool)
+	for _, req := range reqs {
+		for _, backend := range req.GetObservabilityBackends() {
+			if backend != pb.ObservabilityBackend_OBSERVABILITY_BACKEND_UNSPECIFIED {
+				out[backend] = true
+			}
+		}
+	}
+	if len(out) == 0 {
+		out[pb.ObservabilityBackend_OBSERVABILITY_BACKEND_OTEL] = true
+	}
+	return out
+}
+
+func collectorPorts(backends map[pb.ObservabilityBackend]bool) []any {
+	ports := []any{
+		map[string]any{"port": 4317, "public": false},
+		map[string]any{"port": 4318, "public": false},
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_PROMETHEUS) {
+		ports = append(ports, map[string]any{"port": 9464, "public": false})
+	}
+	return ports
+}
+
+func buildCollectorConfig(signals map[pb.TelemetrySignal]bool, backends map[pb.ObservabilityBackend]bool) string {
+	var b strings.Builder
+	b.WriteString("receivers:\n")
+	b.WriteString("  otlp:\n")
+	b.WriteString("    protocols:\n")
+	b.WriteString("      grpc:\n")
+	b.WriteString("        endpoint: 0.0.0.0:4317\n")
+	b.WriteString("      http:\n")
+	b.WriteString("        endpoint: 0.0.0.0:4318\n")
+	b.WriteString("processors:\n")
+	b.WriteString("  batch: {}\n")
+	b.WriteString("exporters:\n")
+	writeExporters(&b, backends)
+	b.WriteString("service:\n")
+	b.WriteString("  pipelines:\n")
+	if signals[pb.TelemetrySignal_TELEMETRY_SIGNAL_TRACES] {
+		writePipeline(&b, "traces", exportersForSignal(pb.TelemetrySignal_TELEMETRY_SIGNAL_TRACES, backends))
+	}
+	if signals[pb.TelemetrySignal_TELEMETRY_SIGNAL_METRICS] {
+		writePipeline(&b, "metrics", exportersForSignal(pb.TelemetrySignal_TELEMETRY_SIGNAL_METRICS, backends))
+	}
+	if signals[pb.TelemetrySignal_TELEMETRY_SIGNAL_LOGS] {
+		writePipeline(&b, "logs", exportersForSignal(pb.TelemetrySignal_TELEMETRY_SIGNAL_LOGS, backends))
+	}
+	return b.String()
+}
+
+func writeExporters(b *strings.Builder, backends map[pb.ObservabilityBackend]bool) {
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_OTEL) {
+		b.WriteString("  otlp:\n")
+		b.WriteString("    endpoint: ${env:OTEL_EXPORTER_OTLP_ENDPOINT}\n")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_DATADOG) {
+		b.WriteString("  datadog:\n")
+		b.WriteString("    api:\n")
+		b.WriteString("      key: ${env:DD_API_KEY}\n")
+		b.WriteString("      site: ${env:DD_SITE}\n")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_PROMETHEUS) {
+		b.WriteString("  prometheus:\n")
+		b.WriteString("    endpoint: 0.0.0.0:9464\n")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_LOKI) {
+		b.WriteString("  loki:\n")
+		b.WriteString("    endpoint: ${env:LOKI_ENDPOINT}\n")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_GRAFANA) {
+		b.WriteString("  otlp/grafana_otlp:\n")
+		b.WriteString("    endpoint: ${env:GRAFANA_OTLP_ENDPOINT}\n")
+		b.WriteString("    headers:\n")
+		b.WriteString("      authorization: ${env:GRAFANA_OTLP_HEADERS}\n")
+	}
+}
+
+func writePipeline(b *strings.Builder, name string, exporters []string) {
+	if len(exporters) == 0 {
+		return
+	}
+	b.WriteString("    ")
+	b.WriteString(name)
+	b.WriteString(":\n")
+	b.WriteString("      receivers: [otlp]\n")
+	b.WriteString("      processors: [batch]\n")
+	b.WriteString("      exporters: [")
+	b.WriteString(strings.Join(exporters, ", "))
+	b.WriteString("]\n")
+}
+
+func exportersForSignal(signal pb.TelemetrySignal, backends map[pb.ObservabilityBackend]bool) []string {
+	exporters := make([]string, 0, len(backends))
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_OTEL) {
+		exporters = append(exporters, "otlp")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_DATADOG) {
+		exporters = append(exporters, "datadog")
+	}
+	if signal == pb.TelemetrySignal_TELEMETRY_SIGNAL_METRICS &&
+		hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_PROMETHEUS) {
+		exporters = append(exporters, "prometheus")
+	}
+	if signal == pb.TelemetrySignal_TELEMETRY_SIGNAL_LOGS &&
+		hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_LOKI) {
+		exporters = append(exporters, "loki")
+	}
+	if hasBackend(backends, pb.ObservabilityBackend_OBSERVABILITY_BACKEND_GRAFANA) {
+		exporters = append(exporters, "otlp/grafana_otlp")
+	}
+	sort.Strings(exporters)
+	return exporters
+}
+
+func hasBackend(backends map[pb.ObservabilityBackend]bool, backend pb.ObservabilityBackend) bool {
+	return backends[backend]
+}

--- a/internal/iacserver_mapper_test.go
+++ b/internal/iacserver_mapper_test.go
@@ -1,0 +1,216 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	pb "github.com/GoCodeAlone/workflow/plugin/external/proto"
+	sdk "github.com/GoCodeAlone/workflow/plugin/external/sdk"
+)
+
+func TestDORequirementMapper_MapsObservabilityToAppPlatformCollector(t *testing.T) {
+	conn := newMapperTestConn(t)
+	client := pb.NewIaCProviderRequirementMapperClient(conn)
+
+	resp, err := client.MapRequirements(context.Background(), &pb.MapRequirementsRequest{
+		Provider:    "digitalocean",
+		Runtime:     pb.RequirementRuntime_REQUIREMENT_RUNTIME_DIGITALOCEAN_APP_PLATFORM,
+		Environment: "prod",
+		Requirements: []*pb.IaCRequirement{{
+			Key:  "observability.telemetry",
+			Kind: pb.RequirementKind_REQUIREMENT_KIND_OBSERVABILITY,
+			Runtimes: []pb.RequirementRuntime{
+				pb.RequirementRuntime_REQUIREMENT_RUNTIME_DIGITALOCEAN_APP_PLATFORM,
+			},
+			TelemetrySignals: []pb.TelemetrySignal{
+				pb.TelemetrySignal_TELEMETRY_SIGNAL_TRACES,
+				pb.TelemetrySignal_TELEMETRY_SIGNAL_METRICS,
+				pb.TelemetrySignal_TELEMETRY_SIGNAL_LOGS,
+			},
+			ObservabilityBackends: []pb.ObservabilityBackend{
+				pb.ObservabilityBackend_OBSERVABILITY_BACKEND_OTEL,
+				pb.ObservabilityBackend_OBSERVABILITY_BACKEND_DATADOG,
+				pb.ObservabilityBackend_OBSERVABILITY_BACKEND_PROMETHEUS,
+				pb.ObservabilityBackend_OBSERVABILITY_BACKEND_LOKI,
+				pb.ObservabilityBackend_OBSERVABILITY_BACKEND_GRAFANA,
+			},
+			DeploymentModes: []pb.DeploymentMode{
+				pb.DeploymentMode_DEPLOYMENT_MODE_SIDECAR,
+				pb.DeploymentMode_DEPLOYMENT_MODE_SIBLING_SERVICE,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("MapRequirements: %v", err)
+	}
+	if got := resp.GetAcceptedKeys(); len(got) != 1 || got[0] != "observability.telemetry" {
+		t.Fatalf("accepted_keys = %v, want [observability.telemetry]", got)
+	}
+	if len(resp.GetRejected()) != 0 {
+		t.Fatalf("rejected = %+v, want none", resp.GetRejected())
+	}
+	if len(resp.GetModules()) != 1 {
+		t.Fatalf("modules len = %d, want 1", len(resp.GetModules()))
+	}
+	mod := resp.GetModules()[0]
+	if mod.GetName() != "observability-collector" {
+		t.Errorf("module name = %q, want observability-collector", mod.GetName())
+	}
+	if mod.GetType() != "infra.container_service" {
+		t.Errorf("module type = %q, want infra.container_service", mod.GetType())
+	}
+	if got := mod.GetSatisfies(); len(got) != 1 || got[0] != "observability.telemetry" {
+		t.Errorf("module satisfies = %v, want [observability.telemetry]", got)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(mod.GetConfigJson(), &cfg); err != nil {
+		t.Fatalf("config_json: %v", err)
+	}
+	if cfg["image"] != "otel/opentelemetry-collector-contrib:latest" {
+		t.Errorf("image = %v", cfg["image"])
+	}
+	if cfg["run_command"] != "otelcol-contrib --config=env:OTELCOL_CONFIG" {
+		t.Errorf("run_command = %v", cfg["run_command"])
+	}
+	if cfg["expose"] != "internal" {
+		t.Errorf("expose = %v, want internal", cfg["expose"])
+	}
+	envVars, ok := cfg["env_vars"].(map[string]any)
+	if !ok {
+		t.Fatalf("env_vars missing or wrong type: %#v", cfg["env_vars"])
+	}
+	collectorConfig, _ := envVars["OTELCOL_CONFIG"].(string)
+	for _, want := range []string{
+		"otlp:",
+		"datadog:",
+		"prometheus:",
+		"loki:",
+		"grafana_otlp:",
+		"traces:",
+		"metrics:",
+		"logs:",
+	} {
+		if !containsAny(collectorConfig, want) {
+			t.Fatalf("collector config missing %q:\n%s", want, collectorConfig)
+		}
+	}
+	secretVars, ok := cfg["env_vars_secret"].(map[string]any)
+	if !ok {
+		t.Fatalf("env_vars_secret missing or wrong type: %#v", cfg["env_vars_secret"])
+	}
+	if secretVars["DD_API_KEY"] != "${secrets.datadog_api_key}" {
+		t.Errorf("DD_API_KEY = %v", secretVars["DD_API_KEY"])
+	}
+	if secretVars["GRAFANA_OTLP_HEADERS"] != "${secrets.grafana_otlp_headers}" {
+		t.Errorf("GRAFANA_OTLP_HEADERS = %v", secretVars["GRAFANA_OTLP_HEADERS"])
+	}
+}
+
+func TestDORequirementMapper_RejectsUnsupportedRuntime(t *testing.T) {
+	conn := newMapperTestConn(t)
+	client := pb.NewIaCProviderRequirementMapperClient(conn)
+
+	resp, err := client.MapRequirements(context.Background(), &pb.MapRequirementsRequest{
+		Provider: "digitalocean",
+		Runtime:  pb.RequirementRuntime_REQUIREMENT_RUNTIME_KUBERNETES,
+		Requirements: []*pb.IaCRequirement{{
+			Key:  "observability.telemetry",
+			Kind: pb.RequirementKind_REQUIREMENT_KIND_OBSERVABILITY,
+			DeploymentModes: []pb.DeploymentMode{
+				pb.DeploymentMode_DEPLOYMENT_MODE_DAEMONSET,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("MapRequirements: %v", err)
+	}
+	if len(resp.GetModules()) != 0 {
+		t.Fatalf("modules = %+v, want none", resp.GetModules())
+	}
+	if len(resp.GetAcceptedKeys()) != 0 {
+		t.Fatalf("accepted_keys = %v, want none", resp.GetAcceptedKeys())
+	}
+	if got := resp.GetRejected(); len(got) != 1 || got[0].GetCode() != "unsupported_runtime" {
+		t.Fatalf("rejected = %+v, want unsupported_runtime", got)
+	}
+}
+
+func TestDORequirementMapper_UnregisteredProviderName(t *testing.T) {
+	conn := newMapperTestConn(t)
+	client := pb.NewIaCProviderRequirementMapperClient(conn)
+
+	_, err := client.MapRequirements(context.Background(), &pb.MapRequirementsRequest{
+		Provider: "not-digitalocean",
+		Requirements: []*pb.IaCRequirement{{
+			Key:  "observability.telemetry",
+			Kind: pb.RequirementKind_REQUIREMENT_KIND_OBSERVABILITY,
+		}},
+	})
+	if err == nil {
+		t.Fatal("MapRequirements: expected provider mismatch error")
+	}
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("MapRequirements code = %v, want InvalidArgument; err=%v", status.Code(err), err)
+	}
+}
+
+func TestPluginManifestAdvertisesRequirementMapper(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(testRepoRoot(t), "plugin.json"))
+	if err != nil {
+		t.Fatalf("read plugin.json: %v", err)
+	}
+	var manifest struct {
+		MinEngineVersion string   `json:"minEngineVersion"`
+		IaCServices      []string `json:"iacServices"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse plugin.json: %v", err)
+	}
+	if manifest.MinEngineVersion != "0.64.3" {
+		t.Fatalf("minEngineVersion = %q, want 0.64.3", manifest.MinEngineVersion)
+	}
+	const mapperService = "workflow.plugin.external.iac.IaCProviderRequirementMapper"
+	for _, svc := range manifest.IaCServices {
+		if svc == mapperService {
+			return
+		}
+	}
+	t.Fatalf("iacServices missing %s: %v", mapperService, manifest.IaCServices)
+}
+
+func newMapperTestConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+
+	listener := bufconn.Listen(iacServerTestBufSize)
+	t.Cleanup(func() { _ = listener.Close() })
+
+	server := grpc.NewServer()
+	if err := sdk.RegisterAllIaCProviderServices(server, newDOIaCServer(NewDOProvider())); err != nil {
+		t.Fatalf("RegisterAllIaCProviderServices: %v", err)
+	}
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(server.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}

--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "external",
   "tier": "community",
-  "minEngineVersion": "0.64.0",
+  "minEngineVersion": "0.64.3",
   "iacServices": [
     "workflow.plugin.external.iac.IaCProviderRequired",
     "workflow.plugin.external.iac.IaCProviderEnumerator",
@@ -16,6 +16,7 @@
     "workflow.plugin.external.iac.IaCProviderValidator",
     "workflow.plugin.external.iac.IaCProviderDriftConfigDetector",
     "workflow.plugin.external.iac.IaCProviderLogCapture",
+    "workflow.plugin.external.iac.IaCProviderRequirementMapper",
     "workflow.plugin.external.iac.IaCProviderFinalizer",
     "workflow.plugin.external.iac.IaCStateBackend"
   ],


### PR DESCRIPTION
## Summary
- implement the optional `IaCProviderRequirementMapper` service for DigitalOcean
- derive generic observability requirements into an App Platform OTel Collector `infra.container_service`
- support OTel-first backend mapping with Datadog, Prometheus, Loki, and Grafana exporter config placeholders
- advertise the mapper in `plugin.json` and bump the minimum workflow engine to `0.64.3`

## Notes
- DigitalOcean App Platform does not provide native sidecars. The mapper emits a safe internal collector module and sets `satisfies` to the accepted requirement keys, so users can override it with explicit YAML using the same keys when they need a same-app sidecar-style component.
- Provider-specific config stays in `config_json`; no `Struct` or `Any` paths are introduced.

## Verification
- `GOWORK=off go test ./internal -run 'TestDORequirementMapper|TestPluginManifestAdvertisesRequirementMapper'`
- `GOWORK=off go test ./...`
- `GOWORK=off go test ./plugin/external/sdk ./iac/derive ./iac/requirements` in `workflow`
- `GOWORK=off go run ./cmd/wfctl plugin validate-contract ../workflow-plugin-digitalocean` in `workflow`
- `git diff --check`
