### PR TITLE
chore: bump release wfctl version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: git config --global url."https://x-access-token:${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - uses: GoCodeAlone/setup-wfctl@v1
         with:
-          version: v0.64.0
+          version: v0.64.3
       - name: Validate plugin contract for publish (pre-build)
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
       - uses: goreleaser/goreleaser-action@v7


### PR DESCRIPTION
## Summary
- update release workflow setup-wfctl version from `v0.64.0` to `v0.64.3`
- keeps release-time contract validation aligned with the plugin's new `minEngineVersion`

## Verification
- `GOWORK=off go run ./cmd/wfctl plugin validate-contract --for-publish --tag v2.1.3 ../workflow-plugin-digitalocean` in `workflow`
- `git diff --check`
