### PR TITLE
fix: avoid App Platform replace for region aliases

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -488,7 +488,7 @@ func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.Resourc
 	var needsReplace bool
 	if region := strFromConfig(desired.Config, "region", ""); region != "" {
 		curRegion, _ := current.Outputs["region"].(string)
-		if curRegion != "" && curRegion != region {
+		if curRegion != "" && normalizeAppPlatformRegionForDiff(curRegion) != normalizeAppPlatformRegionForDiff(region) {
 			changes = append(changes, interfaces.FieldChange{
 				Path: "region", Old: curRegion, New: region, ForceNew: true,
 			})

--- a/internal/drivers/app_platform_region.go
+++ b/internal/drivers/app_platform_region.go
@@ -31,6 +31,23 @@ var validAppPlatformRegions = map[string]struct{}{
 	"tlv": {}, // Tel Aviv
 }
 
+var appPlatformRegionGroupsByZone = map[string]string{
+	"ams2": "ams",
+	"ams3": "ams",
+	"blr1": "blr",
+	"fra1": "fra",
+	"lon1": "lon",
+	"nyc1": "nyc",
+	"nyc2": "nyc",
+	"nyc3": "nyc",
+	"sfo1": "sfo",
+	"sfo2": "sfo",
+	"sfo3": "sfo",
+	"sgp1": "sgp",
+	"syd1": "syd",
+	"tor1": "tor",
+}
+
 // validateAppPlatformRegion checks `region` against the set of valid App
 // Platform regional slugs. Empty input is permitted (caller falls back to
 // the driver default). Whitespace is trimmed; comparison is case-insensitive.
@@ -61,4 +78,18 @@ func sortedAppPlatformRegions() []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func normalizeAppPlatformRegionForDiff(region string) string {
+	region = strings.ToLower(strings.TrimSpace(region))
+	if region == "" {
+		return ""
+	}
+	if _, ok := validAppPlatformRegions[region]; ok {
+		return region
+	}
+	if group, ok := appPlatformRegionGroupsByZone[region]; ok {
+		return group
+	}
+	return region
 }

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -755,6 +755,35 @@ func TestAppPlatformDriver_Diff_RegionEmptyCurrentSkipped(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_Diff_RegionZoneStateSameGroupDoesNotReplace(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc3",
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsReplace {
+		t.Fatalf("same-region stale state must not force replace; got %+v", result.Changes)
+	}
+	for _, c := range result.Changes {
+		if c.Path == "region" {
+			t.Fatalf("same-region stale state must not emit region change; got %+v", c)
+		}
+	}
+}
+
 // TestAppPlatformDriver_Diff_DetectsExposeChange covers quality-review Finding
 // 1: changing `expose` (a security-relevant toggle) on an existing service
 // must produce a Plan action — Diff cannot silently no-op the way the


### PR DESCRIPTION
## Summary
- normalize App Platform region groups when comparing desired config to persisted state
- prevent stale zone-style state like nyc3 from forcing replacement when desired App Platform region is nyc
- keep true cross-region changes as ForceNew replacements

## Tests
- GOWORK=off go test ./...

Copilot review is intentionally skipped per current review outage.