### PR TITLE
feat(provider): EnumerateAll for infra.dns

### DIFF
--- a/internal/provider.go
+++ b/internal/provider.go
@@ -686,9 +686,66 @@ func (p *DOProvider) EnumerateAll(ctx context.Context, resourceType string) ([]*
 	switch resourceType {
 	case "infra.spaces_key":
 		return p.enumerateAllSpacesKeys(ctx)
+	case "infra.dns":
+		return p.enumerateAllDNS(ctx)
 	default:
 		return nil, fmt.Errorf("digitalocean: EnumerateAll: resource type %q not supported", resourceType)
 	}
+}
+
+// enumerateAllDNS paginates GET /v2/domains via godo's Domains.List using
+// ListOptions{Page,PerPage:200}; loop terminates when godo signals the last
+// page (Links == nil || Links.IsLastPage()). Each *ResourceOutput carries the
+// zone name + ttl + zone_file so the import-all path can feed them into
+// IaCProvider.Import without re-reading each zone individually.
+//
+// ProviderID is set to the zone name because DO's v2/domains API uses the
+// domain name as the addressable identifier (Domains.Get takes the name, not
+// a separate ID) — matches DomainDriver.Read/Delete dispatch elsewhere in
+// this plugin and keeps the EnumerateAll contract consistent for callers.
+//
+// zone_id mirrors ProviderID for cross-provider parity: CF surfaces a distinct
+// hex zone ID + zone name, so other providers' EnumerateAll outputs include
+// both keys. For DO they are identical but the shape is preserved so the
+// downstream import-all wrapper does not have to special-case providers.
+func (p *DOProvider) enumerateAllDNS(ctx context.Context) ([]*interfaces.ResourceOutput, error) {
+	var all []*interfaces.ResourceOutput
+	opt := &godo.ListOptions{Page: 1, PerPage: 200}
+	for {
+		domains, resp, err := p.client.Domains.List(ctx, opt)
+		if err != nil {
+			return nil, fmt.Errorf("digitalocean: EnumerateAll infra.dns: list page=%d: %w", opt.Page, err)
+		}
+		for _, d := range domains {
+			outputs := map[string]any{
+				"zone":      d.Name,
+				"zone_id":   d.Name, // DO uses the domain name as its cloud identifier
+				"ttl":       d.TTL,
+				"zone_file": d.ZoneFile,
+			}
+			all = append(all, &interfaces.ResourceOutput{
+				Name:       d.Name,
+				Type:       "infra.dns",
+				ProviderID: d.Name,
+				Outputs:    outputs,
+				Status:     "active",
+			})
+		}
+		if resp == nil || resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			// Propagate rather than break-with-partial-result. Silent break
+			// past a malformed pagination response would cause import-all to
+			// miss zones past the failed boundary, leaving operators with an
+			// incomplete state import. Sister paginator enumerateAllSpacesKeys
+			// takes this same return-on-error stance.
+			return nil, fmt.Errorf("digitalocean: EnumerateAll infra.dns: parse current page: %w", err)
+		}
+		opt.Page = page + 1
+	}
+	return all, nil
 }
 
 // enumerateAllSpacesKeys paginates GET /v2/spaces/keys via godo's SpacesKeys.List

--- a/internal/provider_enumerator_live_test.go
+++ b/internal/provider_enumerator_live_test.go
@@ -1,0 +1,58 @@
+//go:build live_dns
+
+// Live integration test for EnumerateAll("infra.dns"). Gated by the
+// `live_dns` build tag AND the INFRA_DNS_ENUMERATE_LIVE=1 env var so it does
+// not run in CI by default. Required env:
+//
+//   - INFRA_DNS_ENUMERATE_LIVE=1
+//   - DIGITALOCEAN_TOKEN=<api token with read access to /v2/domains>
+//
+// Run locally:
+//
+//	INFRA_DNS_ENUMERATE_LIVE=1 DIGITALOCEAN_TOKEN=$TOKEN \
+//	  GOWORK=off go test -tags live_dns \
+//	    -run TestDOProvider_EnumerateAll_DNS_live ./internal/...
+
+package internal
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestDOProvider_EnumerateAll_DNS_live(t *testing.T) {
+	if os.Getenv("INFRA_DNS_ENUMERATE_LIVE") != "1" {
+		t.Skip("set INFRA_DNS_ENUMERATE_LIVE=1 + DIGITALOCEAN_TOKEN to run")
+	}
+	token := os.Getenv("DIGITALOCEAN_TOKEN")
+	if token == "" {
+		t.Skip("DIGITALOCEAN_TOKEN not set; cannot run live test")
+	}
+
+	ctx := context.Background()
+	p := NewDOProvider()
+	if err := p.Initialize(ctx, map[string]any{"token": token}); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	outs, err := p.EnumerateAll(ctx, "infra.dns")
+	if err != nil {
+		t.Fatalf("live EnumerateAll(infra.dns): %v", err)
+	}
+	if len(outs) == 0 {
+		t.Skip("account has zero zones; cannot validate live contract")
+	}
+	for _, o := range outs {
+		if o.ProviderID == "" {
+			t.Errorf("empty ProviderID for %+v", o.Outputs)
+		}
+		if o.Type != "infra.dns" {
+			t.Errorf("wrong Type %q", o.Type)
+		}
+		if got, _ := o.Outputs["zone"].(string); got == "" {
+			t.Errorf("Outputs.zone empty for %+v", o)
+		}
+	}
+	t.Logf("enumerated %d zones from live DO account", len(outs))
+}

--- a/internal/provider_enumerator_test.go
+++ b/internal/provider_enumerator_test.go
@@ -245,3 +245,120 @@ func TestDOProvider_EnumerateByTag_EmptyTag(t *testing.T) {
 		t.Errorf("error %q should mention the tag argument", err.Error())
 	}
 }
+
+// TestDOProvider_EnumerateAll_DNS_paginates pins the EnumerateAll contract for
+// resource type "infra.dns": every zone in the DO account is returned with the
+// metadata downstream callers (wfctl infra import-all, plus DNS audit/policy
+// commands) need to feed back into IaCProvider.Import without re-reading each
+// zone individually.
+//
+// Mirrors the paginated httptest pattern used by TestProvider_EnumerateAll_SpacesKeys
+// (provider_test.go:722) — page 1 returns 2 domains with a next-page link;
+// page 2 returns 1 domain. Asserts:
+//
+//   - DOProvider implements interfaces.EnumeratorAll for "infra.dns".
+//   - Pagination is handled inside the provider, not punted to the caller —
+//     the test asserts 3 outputs across 2 fake pages.
+//   - Each *ResourceOutput has Type="infra.dns", ProviderID=zone-name (DO uses
+//     the domain name as its cloud ID per the v2/domains API contract), and
+//     Outputs.{zone, zone_id, ttl, zone_file} populated so the import-all path
+//     can feed them into IaCProvider.Import without a second round-trip.
+func TestDOProvider_EnumerateAll_DNS_paginates(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.Path == "/v2/domains" {
+			w.Header().Set("Content-Type", "application/json")
+			page := r.URL.Query().Get("page")
+			if page == "" || page == "1" {
+				_, _ = fmt.Fprintf(w, `{"domains":[`+
+					`{"name":"alpha.test","ttl":1800,"zone_file":"$ORIGIN alpha.test.\n"},`+
+					`{"name":"beta.test","ttl":3600,"zone_file":"$ORIGIN beta.test.\n"}`+
+					`],"links":{"pages":{"next":%q,"last":%q}}}`,
+					srv.URL+"/v2/domains?page=2", srv.URL+"/v2/domains?page=2")
+				return
+			}
+			_, _ = fmt.Fprintf(w, `{"domains":[`+
+				`{"name":"gamma.test","ttl":1800,"zone_file":"$ORIGIN gamma.test.\n"}`+
+				`],"links":{}}`)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		http.Error(w, "unexpected path", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := newDOProviderForDNSEnumeratorTest(t, srv)
+	enumerator, ok := interfaces.IaCProvider(p).(interfaces.EnumeratorAll)
+	if !ok {
+		t.Fatalf("Provider must implement EnumeratorAll")
+	}
+
+	outs, err := enumerator.EnumerateAll(context.Background(), "infra.dns")
+	if err != nil {
+		t.Fatalf("EnumerateAll(infra.dns): %v", err)
+	}
+	if len(outs) != 3 {
+		t.Fatalf("expected 3 zones (paginated), got %d: %+v", len(outs), outs)
+	}
+
+	// Sort by ProviderID for stable comparison; pagination order is documented
+	// but the test should not depend on the order godo emits pages in.
+	sort.Slice(outs, func(i, j int) bool { return outs[i].ProviderID < outs[j].ProviderID })
+
+	wantNames := []string{"alpha.test", "beta.test", "gamma.test"}
+	for i, want := range wantNames {
+		o := outs[i]
+		if o.Type != "infra.dns" {
+			t.Errorf("outs[%d].Type = %q, want %q", i, o.Type, "infra.dns")
+		}
+		if o.ProviderID != want {
+			t.Errorf("outs[%d].ProviderID = %q, want %q", i, o.ProviderID, want)
+		}
+		if got, _ := o.Outputs["zone"].(string); got != want {
+			t.Errorf("outs[%d].Outputs.zone = %v, want %q", i, o.Outputs["zone"], want)
+		}
+		// DO uses the domain name as its cloud identifier — zone_id mirrors
+		// the ProviderID so downstream Import can call back via the same
+		// addressable name without parsing ProviderID separately.
+		if got, _ := o.Outputs["zone_id"].(string); got != want {
+			t.Errorf("outs[%d].Outputs.zone_id = %v, want %q", i, o.Outputs["zone_id"], want)
+		}
+		// ttl must be the int from the godo Domain struct, not a string —
+		// downstream Import code paths assert on int directly.
+		if _, ok := o.Outputs["ttl"].(int); !ok {
+			t.Errorf("outs[%d].Outputs.ttl = %T, want int", i, o.Outputs["ttl"])
+		}
+		if got, _ := o.Outputs["zone_file"].(string); got == "" {
+			t.Errorf("outs[%d].Outputs.zone_file is empty; want non-empty", i)
+		}
+	}
+}
+
+// TestDOProvider_EnumerateAll_DNS_NilClient pins the defensive guard: if a
+// caller invokes EnumerateAll("infra.dns") on an uninitialised provider, the
+// method returns a clear error rather than panicking on nil-pointer deref.
+// Mirrors the sister guard in TestDOProvider_EnumerateByTag_NilClient.
+func TestDOProvider_EnumerateAll_DNS_NilClient(t *testing.T) {
+	p := NewDOProvider()
+	_, err := p.EnumerateAll(context.Background(), "infra.dns")
+	if err == nil {
+		t.Fatal("expected error from EnumerateAll on uninitialised provider; got nil")
+	}
+	if !strings.Contains(err.Error(), "not initialized") {
+		t.Errorf("error %q should mention not initialized", err.Error())
+	}
+}
+
+// newDOProviderForDNSEnumeratorTest mirrors newDOProviderForTest
+// (provider_test.go) for tests that drive their own httptest handler. Kept
+// local to this file so the enumerator suite stays self-contained.
+func newDOProviderForDNSEnumeratorTest(t *testing.T, srv *httptest.Server) *DOProvider {
+	t.Helper()
+	client := godo.NewClient(srv.Client())
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse httptest URL %q: %v", srv.URL, err)
+	}
+	client.BaseURL = base
+	return &DOProvider{client: client, region: "nyc3"}
+}


### PR DESCRIPTION
## Summary

Implements `IaCProviderEnumerator.EnumerateAll(ctx, "infra.dns")` on `*DOProvider` via godo `Domains.List`, paginated transparently (PerPage=200, terminate on `Links.IsLastPage()`). Returns one `*interfaces.ResourceOutput` per zone with:

- `Name` + `ProviderID` = zone name (DO uses the domain name as its cloud identifier)
- `Type = "infra.dns"`
- `Outputs = {zone, zone_id, ttl, zone_file}` — `zone_id` mirrors `ProviderID` for cross-provider parity (CF/NC/Hover surface distinct IDs)
- `Status = "active"` (matches the sister enumerator's stance — DO has no zone-lifecycle field in the v2/domains response)

Unblocks the `wfctl infra import-all --provider digitalocean --type infra.dns` path coming in PR 6 of the cross-repo cascade.

## Changes

- `internal/provider.go` — add `case "infra.dns"` to `EnumerateAll` switch + new `enumerateAllDNS` helper mirroring the existing `enumerateAllSpacesKeys` pagination shape (lines 703-756).
- `internal/provider_enumerator_test.go` — paginated httptest test (page 1 returns 2 zones with `next` link; page 2 returns 1; asserts 3 outputs total + populated `Outputs.{zone, zone_id, ttl, zone_file}`) + nil-client guard.
- `internal/provider_enumerator_live_test.go` (new) — env-gated live test (`//go:build live_dns` + `INFRA_DNS_ENUMERATE_LIVE=1` + `DIGITALOCEAN_TOKEN`).

`var _ interfaces.EnumeratorAll = (*DOProvider)(nil)` assertion already present at `internal/provider.go:51`; capability `IaCProviderEnumerator` already declared in `cmd/plugin/plugin.json:12`.

## Part of cross-repo cascade

Plan: `docs/plans/2026-05-26-dns-provider-contract.md` (workflow-plugin-infra). PR 1 of 9 — DO/CF/NC/Hover EnumerateAll → workflow-registry pin bump → wfctl `infra import-all` → wfctl `dns-policy *` → workflow-plugin-infra libdns strip → workflow-scenarios DNS orchestration.

## Test plan

- [x] `GOWORK=off go test ./internal/...` — all green (unit + paginator tests pass)
- [x] Capability `IaCProviderEnumerator` advertised via `cmd/plugin/plugin.json`
- [ ] Live test (env-gated; reviewer can run with `INFRA_DNS_ENUMERATE_LIVE=1 DIGITALOCEAN_TOKEN=$TOKEN GOWORK=off go test -tags live_dns -run TestDOProvider_EnumerateAll_DNS_live ./internal/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)