### PR TITLE
feat(plugin): advertise required_secrets[] (DIGITALOCEAN_TOKEN)

### DIFF
--- a/cmd/plugin/plugin.json
+++ b/cmd/plugin/plugin.json
@@ -7,6 +7,14 @@
   "type": "external",
   "tier": "community",
   "minEngineVersion": "0.64.3",
+  "required_secrets": [
+    {
+      "name": "DIGITALOCEAN_TOKEN",
+      "sensitive": true,
+      "description": "DigitalOcean API token with read/write scope (DNS + infra via godo).",
+      "prompt": "DigitalOcean API token"
+    }
+  ],
   "iacServices": [
     "workflow.plugin.external.iac.IaCProviderRequired",
     "workflow.plugin.external.iac.IaCProviderEnumerator",

--- a/plugin.json
+++ b/plugin.json
@@ -7,6 +7,14 @@
   "type": "external",
   "tier": "community",
   "minEngineVersion": "0.64.3",
+  "required_secrets": [
+    {
+      "name": "DIGITALOCEAN_TOKEN",
+      "sensitive": true,
+      "description": "DigitalOcean API token with read/write scope (DNS + infra via godo).",
+      "prompt": "DigitalOcean API token"
+    }
+  ],
   "iacServices": [
     "workflow.plugin.external.iac.IaCProviderRequired",
     "workflow.plugin.external.iac.IaCProviderEnumerator",


### PR DESCRIPTION
DO was the only DNS provider plugin NOT declaring `required_secrets[]` (cloudflare/namecheap/hover all do), so `wfctl secrets setup --plugin digitalocean` was a no-op. Adds `DIGITALOCEAN_TOKEN` so secret provisioning is uniform across providers. Spaces keys stay optional (state-backend only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)