### PR TITLE
Fix App Platform secret env drift detection

### DIFF
--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -514,7 +514,7 @@ func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.Resourc
 	// algorithm and compares strings. FieldChange Old/New are the
 	// HASHES, never the values themselves, so the changelog Path
 	// communicates "drift detected" without revealing what changed.
-	if desiredEnvs, ok := desired.Config["env_vars"].(map[string]any); ok {
+	if desiredEnvs, ok := desiredEnvVarsForHash(desired.Config); ok {
 		if curHash, hasKey := current.Outputs["env_vars_hash"].(string); hasKey {
 			desiredHash := envVarsHashFromConfigMap(desiredEnvs)
 			if desiredHash != curHash {
@@ -1508,10 +1508,37 @@ func componentHash(kind string, envs []*godo.AppVariableDefinition) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
+// desiredEnvVarsForHash merges the App Platform service env maps exactly as
+// envVarsFromConfig emits them. Current-side hashes are computed from
+// AppSpec.Services[0].Envs, which contains both general and secret variables;
+// desired-side hashes must include env_vars_secret too or secret-only rotations
+// are invisible/noisy depending on state age.
+func desiredEnvVarsForHash(cfg map[string]any) (map[string]any, bool) {
+	raw, rawOK := cfg["env_vars"].(map[string]any)
+	var secrets map[string]any
+	secretsRaw, secretsOK := cfg["env_vars_secret"]
+	if secretsOK {
+		secrets, _ = secretsRaw.(map[string]any)
+	} else {
+		secrets, secretsOK = cfg["secret_env_vars"].(map[string]any)
+	}
+	if !rawOK && !secretsOK {
+		return nil, false
+	}
+	merged := make(map[string]any, len(raw)+len(secrets))
+	for k, v := range raw {
+		merged[k] = v
+	}
+	for k, v := range secrets {
+		merged[k] = v
+	}
+	return merged, true
+}
+
 // envVarsHashFromConfigMap is the desired-side counterpart for envVarsHash:
-// hashes a map[string]any (the shape infra.yaml YAML decodes to) using the
-// same canonical-sorted-JSON algorithm. Values are coerced to string via
-// fmt.Sprintf to match envVarsFromConfig's coercion.
+// hashes a map[string]any (the merged env var shape infra.yaml YAML decodes to)
+// using the same canonical-sorted-JSON algorithm. Values are coerced to string
+// via fmt.Sprintf to match envVarsFromConfig's coercion.
 func envVarsHashFromConfigMap(m map[string]any) string {
 	if len(m) == 0 {
 		return ""
@@ -1536,7 +1563,7 @@ func componentHashFromConfig(m map[string]any) string {
 	kind, _ := m["kind"].(string)
 	// Match godo's UPPER_SNAKE convention: pre_deploy → PRE_DEPLOY etc.
 	kind = strings.ToUpper(kind)
-	envs, _ := m["env_vars"].(map[string]any)
+	envs, _ := desiredEnvVarsForHash(m)
 	h := sha256.New()
 	fmt.Fprintf(h, "kind=%s\x00", kind)
 	io.WriteString(h, envVarsHashFromConfigMap(envs))

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -519,7 +519,7 @@ func (d *AppPlatformDriver) Diff(ctx context.Context, desired interfaces.Resourc
 			desiredHash := envVarsHashFromConfigMap(desiredEnvs)
 			if desiredHash != curHash {
 				changes = append(changes, interfaces.FieldChange{
-					Path: "env_vars", Old: "[hash:" + curHash[:8] + "...]", New: "[hash:" + desiredHash[:8] + "...]",
+					Path: "env_vars", Old: hashPreview(curHash), New: hashPreview(desiredHash),
 				})
 			}
 		}
@@ -1506,6 +1506,16 @@ func componentHash(kind string, envs []*godo.AppVariableDefinition) string {
 	fmt.Fprintf(h, "kind=%s\x00", kind)
 	io.WriteString(h, envVarsHash(envs))
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func hashPreview(hash string) string {
+	if hash == "" {
+		return "[hash:<empty>]"
+	}
+	if len(hash) < 8 {
+		return "[hash:" + hash + "]"
+	}
+	return "[hash:" + hash[:8] + "...]"
 }
 
 // desiredEnvVarsForHash merges the App Platform service env maps exactly as

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -2566,6 +2566,40 @@ func TestAppPlatformDriver_Diff_DetectsSecretEnvVarsDrift(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_Diff_DetectsSecretEnvVarsDriftFromEmptyHash(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":         "registry.digitalocean.com/myrepo/myapp:v1",
+			"region":        "nyc",
+			"env_vars_hash": "",
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars_secret": map[string]any{
+				"AUTH_BOOTSTRAP_CODE": "BMW-STG-new-bootstrap-code",
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatalf("expected NeedsUpdate=true when env_vars_secret is added from empty current hash")
+	}
+	if len(result.Changes) != 1 {
+		t.Fatalf("changes = %+v, want one env_vars change", result.Changes)
+	}
+	if got := result.Changes[0].Old; got != "[hash:<empty>]" {
+		t.Fatalf("old hash preview = %#v, want empty hash marker", got)
+	}
+}
+
 func TestAppPlatformDriver_Diff_NoSpuriousSecretEnvVarsDrift(t *testing.T) {
 	app := testApp()
 	app.Spec = &godo.AppSpec{

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -2535,6 +2535,81 @@ func TestAppPlatformDriver_Diff_DetectsEnvVarsDrift(t *testing.T) {
 	}
 }
 
+func TestAppPlatformDriver_Diff_DetectsSecretEnvVarsDrift(t *testing.T) {
+	mock := &mockAppClient{}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+
+	current := &interfaces.ResourceOutput{
+		Outputs: map[string]any{
+			"image":         "registry.digitalocean.com/myrepo/myapp:v1",
+			"region":        "nyc",
+			"env_vars_hash": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+		},
+	}
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars_secret": map[string]any{
+				"AUTH_BOOTSTRAP_CODE": "BMW-STG-new-bootstrap-code",
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if !result.NeedsUpdate {
+		t.Fatalf("expected NeedsUpdate=true when env_vars_secret hash mismatched")
+	}
+	if result.NeedsReplace {
+		t.Errorf("env_vars_secret change must NOT force replace (in-place Update suffices)")
+	}
+}
+
+func TestAppPlatformDriver_Diff_NoSpuriousSecretEnvVarsDrift(t *testing.T) {
+	app := testApp()
+	app.Spec = &godo.AppSpec{
+		Name:   "my-app",
+		Region: "nyc",
+		Services: []*godo.AppServiceSpec{{
+			Name: "web",
+			Image: &godo.ImageSourceSpec{
+				Registry:   "registry.digitalocean.com",
+				Repository: "myrepo/myapp",
+				Tag:        "v1",
+			},
+			Envs: []*godo.AppVariableDefinition{{
+				Key:   "AUTH_BOOTSTRAP_CODE",
+				Value: "BMW-STG-current-bootstrap-code",
+				Type:  godo.AppVariableType_Secret,
+				Scope: godo.AppVariableScope_RunAndBuildTime,
+			}},
+		}},
+	}
+	mock := &mockAppClient{app: app}
+	d := drivers.NewAppPlatformDriverWithClient(mock, "nyc")
+	current, err := d.Read(context.Background(), interfaces.ResourceRef{ProviderID: app.ID, Name: "my-app"})
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	result, err := d.Diff(context.Background(), interfaces.ResourceSpec{
+		Config: map[string]any{
+			"image":  "registry.digitalocean.com/myrepo/myapp:v1",
+			"region": "nyc",
+			"env_vars_secret": map[string]any{
+				"AUTH_BOOTSTRAP_CODE": "BMW-STG-current-bootstrap-code",
+			},
+		},
+	}, current)
+	if err != nil {
+		t.Fatalf("Diff: %v", err)
+	}
+	if result.NeedsUpdate {
+		t.Fatalf("expected NeedsUpdate=false for matching env_vars_secret, changes=%+v", result.Changes)
+	}
+}
+
 // TestAppPlatformDriver_Diff_DetectsJobEnvVarsDrift covers the migrate-job
 // case specifically — pre_deploy jobs carry their own env_vars that can
 // independently go stale.


### PR DESCRIPTION
## Summary
- include env_vars_secret in App Platform desired env hashes
- keep secret drift detection hash-only without storing plaintext values
- add regression coverage for secret-only rotations and no-op matching secrets

## Tests
- GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_Diff_(DetectsSecretEnvVarsDrift|NoSpuriousSecretEnvVarsDrift|DetectsEnvVarsDrift|DetectsJobEnvVarsDrift|NoSpurious_EnvVarsChange_OnEmptyState)' -count=1
- GOWORK=off go test ./... -count=1