### PR TITLE
feat: expose App Platform deployment outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ wfctl infra plan   --env staging
 wfctl infra apply  --env staging
 ```
 
+## App Platform outputs
+
+`infra.container_service` reads expose App Platform ingress and deployment
+snapshot fields through `wfctl infra refresh-outputs` and `wfctl infra
+outputs`. Hosts should use these provider-owned outputs for staging URL and
+readiness decisions instead of calling DigitalOcean App Platform APIs directly.
+
+Key output fields include:
+
+| Output | Description |
+|--------|-------------|
+| `live_url` | App Platform live URL. |
+| `default_ingress` | Default App Platform ingress URL. |
+| `active_deployment_id`, `active_deployment_phase` | Current active deployment slot when present. |
+| `in_progress_deployment_id`, `in_progress_deployment_phase` | Current in-progress deployment slot when present. |
+| `pending_deployment_id`, `pending_deployment_phase` | Current pending deployment slot when present. |
+| `active_deployment_image_refs` | Active services/workers mapped by component name to canonical image refs. |
+
 ## DNS stale-record removal
 
 `infra.dns` is not authoritative for every record in a zone. Use `absent_records` to delete specific stale records while leaving unmanaged records intact.

--- a/cmd/plugin/plugin.json
+++ b/cmd/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-plugin-digitalocean",
   "version": "0.0.0",
-  "description": "DigitalOcean IaC provider: App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
+  "description": "DigitalOcean IaC provider: App Platform with deployment snapshot outputs, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",

--- a/docs/DEPLOYMENT_STRATEGIES.md
+++ b/docs/DEPLOYMENT_STRATEGIES.md
@@ -81,6 +81,12 @@ canary traffic splitting.
 
 ## Operator notes
 
+- `wfctl infra refresh-outputs` followed by `wfctl infra outputs` returns the
+  provider-owned App Platform deployment snapshot for `infra.container_service`,
+  including `live_url`, `default_ingress`, active/in-progress/pending deployment
+  IDs and phases, and active service/worker image refs. Deployment hosts should
+  use those outputs for readiness and environment URL publication instead of
+  direct App Platform API calls.
 - The in-rollout availability probe meaningfully fires on the blue
   post-`SwitchTraffic` re-deploy. On the green/canary clone, no custom
   domains are attached, so the probe is a no-op there.

--- a/internal/drivers/app_platform.go
+++ b/internal/drivers/app_platform.go
@@ -1244,7 +1244,8 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 		Type:       "infra.container_service",
 		ProviderID: app.ID,
 		Outputs: map[string]any{
-			"live_url": app.LiveURL,
+			"live_url":        app.LiveURL,
+			"default_ingress": app.DefaultIngress,
 			// `expose` is derived from the first service component:
 			// HTTPPort==0 with InternalPorts populated → "internal";
 			// otherwise "public". Stored on Outputs so Diff can detect
@@ -1288,10 +1289,72 @@ func appOutput(app *godo.App) *interfaces.ResourceOutput {
 		},
 		Status: "running",
 	}
+	addDeploymentSlotOutputs(out.Outputs, "active", app.ActiveDeployment)
+	addDeploymentSlotOutputs(out.Outputs, "in_progress", app.InProgressDeployment)
+	addDeploymentSlotOutputs(out.Outputs, "pending", app.PendingDeployment)
+	if app.ActiveDeployment != nil {
+		if refs := activeDeploymentImageRefs(app.Spec); len(refs) > 0 {
+			out.Outputs["active_deployment_image_refs"] = refs
+		}
+	}
 	if app.ActiveDeployment == nil {
 		out.Status = "pending"
 	}
 	return out
+}
+
+func addDeploymentSlotOutputs(outputs map[string]any, slot string, dep *godo.Deployment) {
+	if dep == nil {
+		return
+	}
+	if dep.ID != "" {
+		outputs[slot+"_deployment_id"] = dep.ID
+	}
+	if dep.Phase != "" {
+		outputs[slot+"_deployment_phase"] = string(dep.Phase)
+	}
+}
+
+func activeDeploymentImageRefs(spec *godo.AppSpec) map[string]any {
+	if spec == nil {
+		return nil
+	}
+	refs := map[string]any{}
+	services := componentImageRefs(spec.Services, func(svc *godo.AppServiceSpec) (string, *godo.ImageSourceSpec) {
+		if svc == nil {
+			return "", nil
+		}
+		return svc.Name, svc.Image
+	})
+	if len(services) > 0 {
+		refs["services"] = services
+	}
+	workers := componentImageRefs(spec.Workers, func(worker *godo.AppWorkerSpec) (string, *godo.ImageSourceSpec) {
+		if worker == nil {
+			return "", nil
+		}
+		return worker.Name, worker.Image
+	})
+	if len(workers) > 0 {
+		refs["workers"] = workers
+	}
+	return refs
+}
+
+func componentImageRefs[T any](components []T, imageOf func(T) (string, *godo.ImageSourceSpec)) map[string]any {
+	refs := map[string]any{}
+	for _, component := range components {
+		name, image := imageOf(component)
+		if name == "" {
+			continue
+		}
+		ref := formatImageSpec(image)
+		if ref == "" {
+			continue
+		}
+		refs[name] = ref
+	}
+	return refs
 }
 
 // desiredRoutesCanonicalFromConfig converts cfg["routes"] into the same

--- a/internal/drivers/app_platform_test.go
+++ b/internal/drivers/app_platform_test.go
@@ -2801,3 +2801,125 @@ func TestAppPlatformDriver_appOutput_DoesNotLeakPlaintextSecrets(t *testing.T) {
 		t.Error("jobs_hash should be populated")
 	}
 }
+
+func TestAppPlatformDriver_appOutput_IncludesDeploymentSnapshotOutputs(t *testing.T) {
+	app := &godo.App{
+		ID:             "app-uuid",
+		LiveURL:        "https://live.example.com",
+		DefaultIngress: "https://default.example.com",
+		Spec: &godo.AppSpec{
+			Name:   "snapshot-app",
+			Region: "nyc",
+			Services: []*godo.AppServiceSpec{
+				{
+					Name: "web",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+						Repository:   "web",
+						Tag:          "sha-web",
+					},
+				},
+				{
+					Name: "admin",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_Ghcr,
+						Registry:     "acme",
+						Repository:   "admin",
+						Tag:          "sha-admin",
+					},
+				},
+			},
+			Workers: []*godo.AppWorkerSpec{
+				{
+					Name: "worker",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_DockerHub,
+						Registry:     "acme",
+						Repository:   "worker",
+						Tag:          "sha-worker",
+					},
+				},
+			},
+		},
+		ActiveDeployment:     &godo.Deployment{ID: "dep-active", Phase: godo.DeploymentPhase_Active},
+		InProgressDeployment: &godo.Deployment{ID: "dep-progress", Phase: godo.DeploymentPhase_Deploying},
+		PendingDeployment:    &godo.Deployment{ID: "dep-pending", Phase: godo.DeploymentPhase_PendingBuild},
+	}
+
+	outputs := drivers.AppOutputForTest(app)
+	requireOutputString(t, outputs, "live_url", "https://live.example.com")
+	requireOutputString(t, outputs, "default_ingress", "https://default.example.com")
+	requireOutputString(t, outputs, "active_deployment_id", "dep-active")
+	requireOutputString(t, outputs, "active_deployment_phase", string(godo.DeploymentPhase_Active))
+	requireOutputString(t, outputs, "in_progress_deployment_id", "dep-progress")
+	requireOutputString(t, outputs, "in_progress_deployment_phase", string(godo.DeploymentPhase_Deploying))
+	requireOutputString(t, outputs, "pending_deployment_id", "dep-pending")
+	requireOutputString(t, outputs, "pending_deployment_phase", string(godo.DeploymentPhase_PendingBuild))
+
+	imageRefs, ok := outputs["active_deployment_image_refs"].(map[string]any)
+	if !ok {
+		t.Fatalf("active_deployment_image_refs = %T, want map[string]any", outputs["active_deployment_image_refs"])
+	}
+	services, ok := imageRefs["services"].(map[string]any)
+	if !ok {
+		t.Fatalf("active_deployment_image_refs.services = %T, want map[string]any", imageRefs["services"])
+	}
+	workers, ok := imageRefs["workers"].(map[string]any)
+	if !ok {
+		t.Fatalf("active_deployment_image_refs.workers = %T, want map[string]any", imageRefs["workers"])
+	}
+	if got := services["web"]; got != "registry.digitalocean.com/web/web:sha-web" {
+		t.Fatalf("services[web] = %v", got)
+	}
+	if got := services["admin"]; got != "ghcr.io/acme/admin:sha-admin" {
+		t.Fatalf("services[admin] = %v", got)
+	}
+	if got := workers["worker"]; got != "docker.io/acme/worker:sha-worker" {
+		t.Fatalf("workers[worker] = %v", got)
+	}
+}
+
+func TestAppPlatformDriver_appOutput_OmitsNilDeploymentSlots(t *testing.T) {
+	app := &godo.App{
+		ID: "app-uuid",
+		Spec: &godo.AppSpec{
+			Name:   "pending-app",
+			Region: "nyc",
+			Services: []*godo.AppServiceSpec{
+				{
+					Name: "web",
+					Image: &godo.ImageSourceSpec{
+						RegistryType: godo.ImageSourceSpecRegistryType_DOCR,
+						Repository:   "web",
+						Tag:          "sha-web",
+					},
+				},
+			},
+		},
+	}
+	outputs := drivers.AppOutputForTest(app)
+	for _, key := range []string{
+		"active_deployment_id",
+		"active_deployment_phase",
+		"in_progress_deployment_id",
+		"in_progress_deployment_phase",
+		"pending_deployment_id",
+		"pending_deployment_phase",
+		"active_deployment_image_refs",
+	} {
+		if _, ok := outputs[key]; ok {
+			t.Fatalf("output %q should be omitted when deployment slot is nil", key)
+		}
+	}
+}
+
+func requireOutputString(t *testing.T, outputs map[string]any, key, want string) {
+	t.Helper()
+	got, ok := outputs[key].(string)
+	if !ok {
+		t.Fatalf("%s = %T, want string", key, outputs[key])
+	}
+	if got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "workflow-plugin-digitalocean",
   "version": "0.0.0",
-  "description": "DigitalOcean IaC provider: App Platform, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
+  "description": "DigitalOcean IaC provider: App Platform with deployment snapshot outputs, App Platform domains, DOKS, databases, Redis cache, load balancers, VPC, firewall, DNS, Spaces, DOCR, certificates, Droplets, Block Storage volumes, IAM (declared), and API gateway",
   "author": "GoCodeAlone",
   "license": "MIT",
   "type": "external",


### PR DESCRIPTION
## Summary
- exposes provider-owned App Platform deployment snapshot outputs from infra.container_service reads
- adds active/in-progress/pending deployment id and phase fields, default ingress, and active service/worker image refs
- documents wfctl infra refresh-outputs / outputs as the host-facing ingress and readiness source

## Verification
- red test first: GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_appOutput_(IncludesDeploymentSnapshotOutputs|OmitsNilDeploymentSlots)' -count=1 failed on missing default_ingress
- GOWORK=off go test ./internal/drivers -run 'TestAppPlatformDriver_appOutput_(IncludesDeploymentSnapshotOutputs|OmitsNilDeploymentSlots|DoesNotLeakPlaintextSecrets)' -count=1
- cmp -s plugin.json cmd/plugin/plugin.json && echo manifests-match
- git diff --check
- wfctl plugin validate --file plugin.json --strict-contracts
- GOWORK=off go test ./... -count=1