### PR TITLE
fix: correct GitLab secret target scope

### DIFF
--- a/cmd/plugin/plugin.json
+++ b/cmd/plugin/plugin.json
@@ -248,10 +248,9 @@
         "provider": "gitlab",
         "scopes": [
           "project",
-          "group",
-          "env"
+          "group"
         ],
-        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
       },
       {
         "provider": "vault",

--- a/plugin.json
+++ b/plugin.json
@@ -248,10 +248,9 @@
         "provider": "gitlab",
         "scopes": [
           "project",
-          "group",
-          "env"
+          "group"
         ],
-        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
       },
       {
         "provider": "vault",


### PR DESCRIPTION
## Summary
- remove stale gitlab env scope from secret_targets
- document GitLab environment narrowing as environment_scope on project/group variables

## Validation
- jq empty plugin.json cmd/plugin/plugin.json
- /tmp/wfctl-env-contract plugin validate -file plugin.json
- /tmp/wfctl-env-contract plugin validate-contract .
- GOWORK=off go test ./...