### PR TITLE
fix: expose database status output

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ Key output fields include:
 | `pending_deployment_id`, `pending_deployment_phase` | Current pending deployment slot when present. |
 | `active_deployment_image_refs` | Active services/workers mapped by component name to canonical image refs. |
 
+## Database outputs
+
+`infra.database` reads expose lifecycle status through `wfctl infra
+refresh-outputs` and `wfctl infra outputs`. Hosts can use the `status` output
+(`online` for healthy managed databases) without calling DigitalOcean database
+APIs directly.
+
 ## DNS stale-record removal
 
 `infra.dns` is not authoritative for every record in a zone. Use `absent_records` to delete specific stale records while leaving unmanaged records intact.

--- a/internal/drivers/database.go
+++ b/internal/drivers/database.go
@@ -622,6 +622,7 @@ func dbOutput(db *godo.Database) *interfaces.ResourceOutput {
 		"num_nodes": float64(db.NumNodes),
 		"region":    db.RegionSlug,
 		"size":      db.SizeSlug,
+		"status":    db.Status,
 		"tags":      tags,
 		"version":   db.VersionSlug,
 	}

--- a/internal/drivers/database_test.go
+++ b/internal/drivers/database_test.go
@@ -97,6 +97,9 @@ func TestDatabaseDriver_Create(t *testing.T) {
 	if out.Status != "online" {
 		t.Errorf("Status = %q, want %q", out.Status, "online")
 	}
+	if got := out.Outputs["status"]; got != "online" {
+		t.Errorf("Outputs[status] = %v, want online", got)
+	}
 	if host, _ := out.Outputs["host"].(string); host == "" {
 		t.Error("expected host in outputs")
 	}


### PR DESCRIPTION
## Summary
- export managed database lifecycle status in Outputs["status"] so hosts can consume it through wfctl infra outputs
- add a regression assertion covering the provider output contract
- document the database status output for host consumers

## Verification
- GOWORK=off go test ./... -count=1
- git diff --check

## Staging context
workflow-compute staging smoke currently consumes wfctl infra outputs --module wfcompute-stg-db; without this provider output it cannot verify database readiness without reintroducing direct DigitalOcean API calls.